### PR TITLE
P4-2170 changes to tighten and improve the validation around the locations import process.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationRepository.kt
@@ -6,4 +6,6 @@ import java.util.*
 interface LocationRepository : CrudRepository<Location, UUID> {
 
     fun findBySiteName(siteName: String) : Location?
+
+    fun findByNomisAgencyId(id: String) : Location?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/importer/LocationsImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/importer/LocationsImporter.kt
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.Schedule34LocationsProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
-import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportStatus
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.Importer
 
 @Component
@@ -38,7 +37,7 @@ class LocationsImporter(private val locationRepo: LocationRepository,
         locationRepo.deleteAll()
 
         schedule34LocationsProvider.get(locationsFile).use { locations ->
-            LocationsSpreadsheet(XSSFWorkbook(locations)).use {
+            LocationsSpreadsheet(XSSFWorkbook(locations), locationRepo).use {
                 import(it)
             }
         }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/importer/LocationsSpreadsheet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/importer/LocationsSpreadsheet.kt
@@ -4,6 +4,7 @@ import org.apache.poi.ss.usermodel.Cell
 import org.apache.poi.ss.usermodel.Row
 import org.apache.poi.ss.usermodel.Workbook
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.Location
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
 import java.io.Closeable
 
@@ -11,12 +12,18 @@ private const val TYPE = 1
 private const val SITE = 2
 private const val AGENCY = 3
 private const val COLUMN_HEADINGS = 1
-private const val ROW_OFFSET = 2
+private const val ROW_OFFSET = 1
 
 /**
  * Simple wrapper class to encapsulate the logic around access to data in the locations spreadsheet. When finished with the spreadsheet should be closed.
  */
-class LocationsSpreadsheet(private val spreadsheet: Workbook) : Closeable {
+class LocationsSpreadsheet(private val spreadsheet: Workbook, private val locationRepository: LocationRepository) : Closeable {
+
+    init {
+        Tab.values().toList().filter { spreadsheet.getSheet(it.label) == null }.joinToString { it.label }.let {
+            if (it.isNotBlank()) throw IllegalStateException("The following tabs are missing from the locations spreadsheet: $it")
+        }
+    }
 
     enum class Tab(val label: String) {
         COURT("Courts"),
@@ -36,11 +43,21 @@ class LocationsSpreadsheet(private val spreadsheet: Workbook) : Closeable {
     fun getRowsFrom(tab: Tab): List<Row> = spreadsheet.getSheet(tab.label).drop(COLUMN_HEADINGS).filterNot { it.getCell(1)?.stringCellValue.isNullOrBlank() }
 
     fun mapToLocation(cells: List<Cell>): Location {
+        val locationType = LocationType.map(cells[TYPE].stringCellValue.toUpperCase().trim())
+                ?: throw IllegalArgumentException("Unsupported location type: " + cells[TYPE].stringCellValue)
+
+        val agency = cells[AGENCY].stringCellValue.toUpperCase().trim().takeUnless { it == "" }
+                ?: throw IllegalArgumentException("Agency id cannot be blank")
+
+        val site = cells[SITE].stringCellValue.toUpperCase().trim().takeUnless { it == "" }
+                ?: throw IllegalArgumentException("Site name cannot be blank")
+
+        locationRepository.findByNomisAgencyId(agency).let { if (it != null) throw IllegalArgumentException("Agency id '$agency' already exists") }
+
         return Location(
-                locationType = LocationType.map(cells[TYPE].stringCellValue.toUpperCase().trim())
-                        ?: throw IllegalArgumentException("Unsupported location type: " + cells[TYPE].stringCellValue),
-                nomisAgencyId = cells[AGENCY].stringCellValue.trim(),
-                siteName = cells[SITE].stringCellValue.toUpperCase().trim())
+                locationType = locationType,
+                nomisAgencyId = agency,
+                siteName = site)
     }
 
     fun mapToLocation(row: Row): Location = mapToLocation(row.toList())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/pricing/importer/PriceImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/pricing/importer/PriceImporter.kt
@@ -7,16 +7,10 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.GeoamyPricesProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.SercoPricesProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
-import uk.gov.justice.digital.hmpps.pecs.jpc.pricing.Price
 import uk.gov.justice.digital.hmpps.pecs.jpc.pricing.PriceRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.pricing.Supplier
-import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportStatus
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.Importer
 import java.io.InputStream
-import java.time.Clock
-import java.time.Duration
-import java.time.LocalDateTime
-import java.util.concurrent.atomic.AtomicBoolean
 
 @Component
 class PriceImporter(private val priceRepo: PriceRepository,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/pricing/importer/PricesSpreadsheet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/pricing/importer/PricesSpreadsheet.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.pricing.Supplier
 import java.io.Closeable
 
 private const val COLUMN_HEADINGS = 1
-private const val ROW_OFFSET = 2
+private const val ROW_OFFSET = 1
 
 /**
  * Simple wrapper class to encapsulate the logic around access to data in the supplier prices spreadsheet. When finished with the spreadsheet should be closed.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ImportControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ImportControllerTest.kt
@@ -17,6 +17,8 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.GeoamyPricesProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.Schedule34LocationsProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.SercoPricesProvider
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.pricing.PriceRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportStatus
 import java.time.Clock
 
@@ -26,14 +28,24 @@ import java.time.Clock
 @ContextConfiguration(classes = [TestConfig::class])
 class ImportControllerTest(@Autowired val restTemplate: TestRestTemplate) {
 
+    @Autowired
+    lateinit var locationRepository: LocationRepository
+
+    @Autowired
+    lateinit var priceRepository: PriceRepository
+
     @Test
     fun `can import locations followed by prices`() {
+        assertThat(locationRepository.count()).isEqualTo(0)
         val locationsResponse = restTemplate.postForEntity<String>("/locations/import")
         assertThat(locationsResponse.statusCode).isEqualTo(HttpStatus.OK)
         assertThat(locationsResponse.body).isEqualTo(ImportStatus.DONE.name)
+        assertThat(locationRepository.count()).isEqualTo(2)
 
+        assertThat(priceRepository.count()).isEqualTo(0)
         val pricesResponse = restTemplate.postForEntity<String>("/prices/import")
         assertThat(pricesResponse.statusCode).isEqualTo(HttpStatus.OK)
         assertThat(pricesResponse.body).isEqualTo(ImportStatus.DONE.name)
+        assertThat(priceRepository.count()).isEqualTo(2)
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/importer/LocationImporterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/importer/LocationImporterTest.kt
@@ -40,13 +40,13 @@ class LocationImporterTest(
             }
         }
 
-        locationsSpreadsheet = LocationsSpreadsheet(workbook)
+        locationsSpreadsheet = LocationsSpreadsheet(workbook, repo)
     }
 
     @Test
     @Disabled
     fun `Assert workbook with only headers imports without errors`() {
-        val errors = locationsImporter.import(LocationsSpreadsheet(workbook))
+        val errors = locationsImporter.import(LocationsSpreadsheet(workbook, repo))
 
 //        assertThat(errors).isEmpty()
     }
@@ -62,7 +62,7 @@ class LocationImporterTest(
         row.createCell(2).setCellValue("") // site name
         row.createCell(3).setCellValue("NOM100")
 
-        val errors = locationsImporter.import(LocationsSpreadsheet(workbook))
+        val errors = locationsImporter.import(LocationsSpreadsheet(workbook, repo))
 
 //        assertThat(errors).isNotEmpty
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/importer/LocationsSpreadsheetTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/importer/LocationsSpreadsheetTest.kt
@@ -1,45 +1,116 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.location.importer
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
 import org.apache.poi.ss.usermodel.Cell
+import org.apache.poi.ss.usermodel.Row
+import org.apache.poi.ss.usermodel.Sheet
 import org.apache.poi.ss.usermodel.Workbook
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.AfterEach
+import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.Location
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
 
 internal class LocationsSpreadsheetTest {
 
-    // TODO - consider adding minimal test spreadsheets to the test resources
+    private val sheet: Sheet = mock()
+    private val workbook: Workbook = mock { on { it.getSheet( com.nhaarman.mockitokotlin2.any()) } doReturn sheet }
+    private val location: Location = mock()
+    private val locationRepository: LocationRepository = mock()
+    private val spreadsheet: LocationsSpreadsheet = LocationsSpreadsheet(workbook, locationRepository)
 
-    private val ignored: Cell = mock { on { it.stringCellValue } doReturn "ignored" }
-    private val unsupportedLocationType: Cell = mock { on { it.stringCellValue } doReturn "bad location" }
-    private val supportedLocationType: Cell = mock { on { it.stringCellValue } doReturn LocationType.CC.label }
-    private val site: Cell = mock { on { it.stringCellValue } doReturn "site" }
-    private val agency: Cell = mock { on { it.stringCellValue } doReturn "agency" }
-    private val workbook: Workbook = mock()
-    private val spreadsheet: LocationsSpreadsheet = LocationsSpreadsheet(workbook)
+    @Nested
+    inner class Instantiation {
+        @Test
+        internal fun `fails instantiation if court and immigration tabs are missing the locations spreadsheet`() {
+            LocationsSpreadsheet.Tab.values().forEach {
+                if (it == LocationsSpreadsheet.Tab.COURT || it == LocationsSpreadsheet.Tab.IMMIGRATION)
+                    whenever(workbook.getSheet(it.label)).thenReturn(null)
+                else
+                    whenever(workbook.getSheet(it.label)).thenReturn(sheet)
+            }
+
+            assertThatThrownBy { LocationsSpreadsheet(workbook, locationRepository) }
+                    .isInstanceOf(IllegalStateException::class.java)
+                    .hasMessage("The following tabs are missing from the locations spreadsheet: Courts, Immigration")
+        }
+
+        @Test
+        internal fun `succeeds instantiation when all tabs are present in the locations spreadsheet`() {
+            LocationsSpreadsheet.Tab.values().forEach { whenever(workbook.getSheet(it.label)).thenReturn(sheet) }
+
+            assertThatCode { LocationsSpreadsheet(workbook, locationRepository) }.doesNotThrowAnyException()
+        }
+    }
 
     @Nested
     inner class MappingRowToLocation {
+
+        private val ignored: Cell = mock { on { it.stringCellValue } doReturn "ignored" }
+        private val unsupportedLocationType: Cell = mock { on { it.stringCellValue } doReturn "bad location" }
+        private val supportedLocationType: Cell = mock { on { it.stringCellValue } doReturn LocationType.CC.label }
+        private val site: Cell = mock { on { it.stringCellValue } doReturn "site" }
+        private val agency: Cell = mock { on { it.stringCellValue } doReturn "AGENCY_ID" }
+        private val blankCell: Cell = mock { on { it.stringCellValue } doReturn "" }
+
         @Test
         internal fun `throws error for unsupported location type`() {
             assertThatThrownBy { spreadsheet.mapToLocation(listOf(ignored, unsupportedLocationType, site, agency)) }
                     .isInstanceOf(IllegalArgumentException::class.java)
-                    .withFailMessage("Unsupported location type: ", unsupportedLocationType.stringCellValue)
+                    .hasMessage("Unsupported location type: bad location")
         }
 
         @Test
         internal fun `court location type is mapped correctly`() {
+            whenever(locationRepository.findByNomisAgencyId(any())).thenReturn(null)
+
             assertThat(spreadsheet.mapToLocation(listOf(ignored, supportedLocationType, site, agency)).locationType).isEqualTo(LocationType.CC)
+        }
+
+        @Test
+        internal fun `throws error if agency id is blank`() {
+            assertThatThrownBy { spreadsheet.mapToLocation(listOf(ignored, supportedLocationType, site, blankCell)) }
+                    .isInstanceOf(IllegalArgumentException::class.java)
+                    .hasMessage("Agency id cannot be blank")
+        }
+
+        @Test
+        internal fun `throws error if site name is blank`() {
+            assertThatThrownBy { spreadsheet.mapToLocation(listOf(ignored, supportedLocationType, blankCell, agency)) }
+                    .isInstanceOf(IllegalArgumentException::class.java)
+                    .hasMessage("Site name cannot be blank")
+        }
+
+        @Test
+        internal fun `throws error if duplicate agency id`() {
+            whenever(locationRepository.findByNomisAgencyId("AGENCY_ID")).thenReturn(location)
+
+            assertThatThrownBy { spreadsheet.mapToLocation(listOf(ignored, supportedLocationType, site, agency)) }
+                    .isInstanceOf(IllegalArgumentException::class.java)
+                    .hasMessage("Agency id 'AGENCY_ID' already exists")
         }
     }
 
-    @AfterEach
-    fun after() {
-        spreadsheet.close()
+    @Nested
+    inner class RecordingErrors {
+        @Test
+        fun `no errors by default`() {
+            assertThat(spreadsheet.errors).isEmpty()
+        }
+
+        @Test
+        fun `errors are recorded correctly`() {
+            val row: Row = mock { on { it.rowNum } doReturn 1 }
+
+            val exception = RuntimeException("something went wrong")
+
+            spreadsheet.addError(LocationsSpreadsheet.Tab.COURT, row, exception)
+
+            assertThat(spreadsheet.errors).containsOnly(LocationsSpreadsheetError(LocationsSpreadsheet.Tab.COURT , row.rowNum + 1, exception))
+        }
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/pricing/importer/PricesSpreadsheetTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/pricing/importer/PricesSpreadsheetTest.kt
@@ -40,7 +40,7 @@ internal class PricesSpreadsheetTest {
 
             spreadsheet.addError(row, exception)
 
-            assertThat(spreadsheet.errors).containsOnly(PricesSpreadsheetError(Supplier.GEOAMEY, 2, exception))
+            assertThat(spreadsheet.errors).containsOnly(PricesSpreadsheetError(Supplier.GEOAMEY, row.rowNum + 1, exception))
         }
     }
 


### PR DESCRIPTION
These changes tighten up the location validation steps when importing the locations spreadsheet.

Persistence level exceptions have been reduced as we are now checking prior to save the locations entity in the DB.

The locations import will also fail (fast) if any of the expected location spreadsheet tabs are missing.