### PR TITLE
p4-2186 add columns to standard moves sheet

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/calculator/MovePrice.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/calculator/MovePrice.kt
@@ -1,9 +1,12 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.calculator
 
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
 import uk.gov.justice.digital.hmpps.pecs.jpc.reporting.JourneyWithEvents
 import uk.gov.justice.digital.hmpps.pecs.jpc.reporting.MovePersonJourneysEvents
 
 data class MovePrice(
+        val fromLocationType: LocationType?,
+        val toLocationType: LocationType?,
         val movePersonJourneysEvents: MovePersonJourneysEvents,
         val journeyPrices: List<JourneyPrice>
 ){
@@ -17,4 +20,6 @@ data class MovePrice(
     }
 }
 
-data class JourneyPrice(val journeyWithEvents: JourneyWithEvents, val priceInPence: Int?)
+data class JourneyPrice(
+        val journeyWithEvents: JourneyWithEvents,
+        val priceInPence: Int?)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/calculator/PriceCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/calculator/PriceCalculator.kt
@@ -43,7 +43,11 @@ class PriceCalculator(val nomisAgencyId2Location: Map<String, Location>,
                 Supplier.SERCO -> sercoJourney2price[priceKey(it.journeysWithEvents[0].journey)]
                 Supplier.GEOAMEY -> geoJourney2price[priceKey(it.journeysWithEvents[0].journey)]
             }
-            MovePrice(it, listOf(JourneyPrice(it.journeysWithEvents[0], journeyPrice?.priceInPence)))
+
+            val fromLocationType = nomisAgencyId2Location.get(it.move.fromLocation)?.locationType
+            val toLocationType = nomisAgencyId2Location.get(it.move.toLocation)?.locationType
+
+            MovePrice(fromLocationType, toLocationType, it, listOf(JourneyPrice(it.journeysWithEvents[0], journeyPrice?.priceInPence)))
         }
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/output/PriceSheet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/output/PriceSheet.kt
@@ -24,6 +24,31 @@ abstract class PriceSheet(val sheet: Sheet, private val header: Header) {
         // TODO need to add version as well.
     }
 
+    fun addStandardRow(row: Row, price: MovePrice) {
+
+        with(StandardValues.fromMovePrice(price)) {
+            row.addCell(0, ref)
+            row.addCell(1, pickUp)
+            row.addCell(2, pickUpLocationType)
+            row.addCell(3, dropOff)
+            row.addCell(4, dropOffLocationType)
+            row.addCell(5, pickUpDate)
+            row.addCell(6, pickUpTime)
+            row.addCell(7, dropOffDate)
+            row.addCell(8, dropOffTime)
+            row.addCell(9, vehicleReg)
+            row.addCell(10, prisonNumber)
+
+            totalInPence?.let {
+                row.createCell(11).setCellValue(it.toDouble())
+            } ?: row.createCell(11).setCellValue("NOT PRESENT")
+        }
+
+
+    }
+
+    fun Row.addCell(col: Int, value: String?) = createCell(col).setCellValue(value)
+
     fun add(prices: Sequence<MovePrice>) {
         prices.forEach { addPrice(it) }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/output/RowValue.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/output/RowValue.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.output
+
+import uk.gov.justice.digital.hmpps.pecs.jpc.calculator.MovePrice
+import uk.gov.justice.digital.hmpps.pecs.jpc.reporting.Event
+import uk.gov.justice.digital.hmpps.pecs.jpc.reporting.EventType
+import java.time.format.DateTimeFormatter
+
+data class StandardValues(
+        val ref: String,
+        val pickUp: String,
+        val pickUpLocationType: String?,
+        val dropOff: String?,
+        val dropOffLocationType: String?,
+        val pickUpDate: String?,
+        val pickUpTime: String?,
+        val dropOffDate: String?,
+        val dropOffTime: String?,
+        val vehicleReg: String?,
+        val prisonNumber: String?,
+        val totalInPence: Int?
+){
+
+    companion object {
+        val dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+        val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+
+        fun fromMovePrice(price: MovePrice): StandardValues {
+            val pickUpDate = Event.getLatestByType(price.movePersonJourneysEvents.events, EventType.MOVE_START)?.occurredAt
+            val dropOffDate = Event.getLatestByType(price.movePersonJourneysEvents.events, EventType.MOVE_COMPLETE)?.occurredAt
+
+            return with(price.movePersonJourneysEvents.move) {
+                StandardValues(
+                        reference,
+                        fromLocation,
+                        price.fromLocationType?.name,
+                        toLocation,
+                        price.toLocationType?.name,
+                        pickUpDate?.format(dateFormatter),
+                        pickUpDate?.format(timeFormatter),
+                        dropOffDate?.format(dateFormatter),
+                        dropOffDate?.format(timeFormatter),
+                        price.movePersonJourneysEvents.journeysWithEvents.withIndex().joinToString(separator = ", ") {
+                            "Journey ${(it.index+1).toString()}: " + it.value.journey.vehicleRegistration},
+                        price.movePersonJourneysEvents.person?.prisonNumber,
+                        price.totalInPence()
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/output/StandardMovesSheet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/output/StandardMovesSheet.kt
@@ -9,27 +9,6 @@ import java.time.format.DateTimeFormatter
 
 class StandardMovesSheet(workbook: Workbook, header: Header) : PriceSheet(workbook.getSheet("Standard")!!, header) {
 
-    val dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
-    val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+    override fun add(row: Row, price: MovePrice) = addStandardRow(row, price)
 
-    override fun add(row: Row, price: MovePrice) {
-
-        val pickUpDate = Event.getLatestByType(price.movePersonJourneysEvents.events, EventType.MOVE_START)?.occurredAt
-        val dropOffDate = Event.getLatestByType(price.movePersonJourneysEvents.events, EventType.MOVE_COMPLETE)?.occurredAt
-
-        with(price.movePersonJourneysEvents.move) {
-            row.createCell(0).setCellValue(reference)
-            row.createCell(1).setCellValue(fromLocation)
-            row.createCell(3).setCellValue(toLocation)
-            row.createCell(5).setCellValue(pickUpDate?.format(dateFormatter))
-            row.createCell(6).setCellValue(pickUpDate?.format(timeFormatter))
-            row.createCell(7).setCellValue(dropOffDate?.format(dateFormatter))
-            row.createCell(8).setCellValue(dropOffDate?.format(timeFormatter))
-
-        }
-
-        price.totalInPence()?.let {
-            row.createCell(11).setCellValue(it.toDouble())
-        } ?: row.createCell(11).setCellValue("NOT PRESENT")
-    }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/calculator/StandardMovesPriceCalculatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/calculator/StandardMovesPriceCalculatorTest.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.pricing.PriceRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.pricing.Supplier
 import org.assertj.core.api.Assertions.assertThat
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
 import uk.gov.justice.digital.hmpps.pecs.jpc.reporting.*
 import java.time.LocalDate
 
@@ -16,8 +17,8 @@ import java.time.LocalDate
 internal class StandardMovesPriceCalculatorTest{
 
     private val locationRepository: LocationRepository = mock { on {findAll()} doReturn listOf(
-            locationFactory(nomisAgencyId = "WYI", siteName = "from"),
-            locationFactory(nomisAgencyId = "GNI", siteName = "to")
+            locationFactory(locationType = LocationType.CC, nomisAgencyId = "WYI", siteName = "from"),
+            locationFactory(locationType = LocationType.AP, nomisAgencyId = "GNI", siteName = "to")
             )
         }
 
@@ -69,6 +70,10 @@ internal class StandardMovesPriceCalculatorTest{
 
         // M1 price should be 101p
         assertThat(prices[0].totalInPence()).isEqualTo(101)
+
+        // M1 from and to location type should be set
+        assertThat(prices[0].fromLocationType).isEqualTo(LocationType.CC)
+        assertThat(prices[0].toLocationType).isEqualTo(LocationType.AP)
 
         // M2 price should not be set
         assertThat(prices[1].totalInPence()).isNull()


### PR DESCRIPTION
Not pretty, but functional

Create RowValue.kt to hold the display value for each cell
Add fromLocationType and toLocationType to MovePrice.kt
Create an addStandardRow fun on PriceSheet.kt which StandardMovesSheet uses