### PR TITLE
P4-2260 reworking the way the resources are provided.  Moving the property loading to the actual config.  No need to load them in the components.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/GeoamyPricesProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/GeoamyPricesProvider.kt
@@ -5,4 +5,6 @@ import java.io.InputStream
 /**
  * Responsible for providing the Geoamey prices Excel spreadsheet via an [InputStream].
  */
-fun interface GeoamyPricesProvider : Provider<InputStream>
+fun interface GeoamyPricesProvider {
+    fun get(): InputStream
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/Provider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/Provider.kt
@@ -1,5 +1,0 @@
-package uk.gov.justice.digital.hmpps.pecs.jpc.config
-
-fun interface Provider<T> {
-    fun get(resourceName: String) : T
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/ReportingProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/ReportingProvider.kt
@@ -1,3 +1,5 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.config
 
-fun interface ReportingProvider : Provider<String>
+fun interface ReportingProvider {
+    fun get(resourceName: String) : String
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/S3ProviderConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/S3ProviderConfiguration.kt
@@ -65,32 +65,35 @@ class S3ProviderConfiguration {
 
     @Bean
     @ConditionalOnProperty(name = ["resources.provider"], havingValue = "s3")
-    fun locationsResourceProvider(@Qualifier("jpcAmazonS3") client: AmazonS3, @Value("\${JPC_BUCKET_NAME}") bucketName: String): Schedule34LocationsProvider {
-        logger.info("Using AWS S3 provider for Schedule 34 locations.")
+    fun locationsResourceProvider(@Qualifier("jpcAmazonS3") client: AmazonS3, @Value("\${JPC_BUCKET_NAME}") bucketName: String,
+                                  @Value("\${import-files.locations}") locationsFile: String): Schedule34LocationsProvider {
+        logger.info("Using AWS S3 provider for Schedule 34 locations file: $locationsFile")
 
         return Schedule34LocationsProvider {
             logger.info("Getting locations using bucket $bucketName")
-            client.getObject(GetObjectRequest(bucketName, it)).objectContent
+            client.getObject(GetObjectRequest(bucketName, locationsFile)).objectContent
         }
     }
 
     @Bean
     @ConditionalOnProperty(name = ["resources.provider"], havingValue = "s3")
-    fun sercoPricesResourceProvider(@Qualifier("jpcAmazonS3") client: AmazonS3, @Value("\${JPC_BUCKET_NAME}") bucketName: String): SercoPricesProvider {
-        logger.info("Using AWS S3 provider for Serco prices.")
+    fun sercoPricesResourceProvider(@Qualifier("jpcAmazonS3") client: AmazonS3, @Value("\${JPC_BUCKET_NAME}") bucketName: String,
+                                    @Value("\${import-files.serco-prices}") sercoPricesFile: String): SercoPricesProvider {
+        logger.info("Using AWS S3 provider for Serco prices file: $sercoPricesFile")
         return SercoPricesProvider {
             logger.info("getting serco")
-            client.getObject(GetObjectRequest(bucketName, it)).objectContent
+            client.getObject(GetObjectRequest(bucketName, sercoPricesFile)).objectContent
         }
     }
 
     @Bean
     @ConditionalOnProperty(name = ["resources.provider"], havingValue = "s3")
-    fun geoameyPricesResourceProvider(@Qualifier("jpcAmazonS3") client: AmazonS3, @Value("\${JPC_BUCKET_NAME}") bucketName: String): GeoamyPricesProvider {
-        logger.info("Using AWS S3 provider for Geoamey prices.")
+    fun geoameyPricesResourceProvider(@Qualifier("jpcAmazonS3") client: AmazonS3, @Value("\${JPC_BUCKET_NAME}") bucketName: String,
+                                      @Value("\${import-files.geo-prices}") geoPricesFile: String): GeoamyPricesProvider {
+        logger.info("Using AWS S3 provider for Geoamey prices file: $geoPricesFile")
         return GeoamyPricesProvider {
             logger.info("getting geo")
-            client.getObject(GetObjectRequest(bucketName, it)).objectContent
+            client.getObject(GetObjectRequest(bucketName, geoPricesFile)).objectContent
         }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/Schedule34LocationsProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/Schedule34LocationsProvider.kt
@@ -5,4 +5,6 @@ import java.io.InputStream
 /**
  * Responsible for providing the Schedule 34 locations Excel spreadsheet via an [InputStream].
  */
-fun interface Schedule34LocationsProvider : Provider<InputStream>
+fun interface Schedule34LocationsProvider {
+    fun get(): InputStream
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/SercoPricesProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/SercoPricesProvider.kt
@@ -5,4 +5,6 @@ import java.io.InputStream
 /**
  * Responsible for providing the Serco prices Excel spreadsheet via an [InputStream].
  */
-fun interface SercoPricesProvider : Provider<InputStream>
+fun interface SercoPricesProvider{
+    fun get(): InputStream
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ImportController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ImportController.kt
@@ -16,12 +16,6 @@ import javax.servlet.http.HttpServletResponse
 @RestController
 class ImportController(private val importService: ImportService) {
 
-    @PostMapping("/locations/import")
-    fun locations(): String = importService.importLocations().second.name
-
-    @PostMapping("/prices/import")
-    fun prices(): String = importService.importPrices().second.name
-
     @GetMapping("/generate-prices-spreadsheet/{supplier}")
     @Throws(IOException::class)
     fun generateSpreadsheet(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/importer/LocationsImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/importer/LocationsImporter.kt
@@ -2,19 +2,14 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.location.importer
 
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.Schedule34LocationsProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
 
 @Component
-class LocationsImporter(private val locationRepo: LocationRepository,
-                        private val schedule34LocationsProvider: Schedule34LocationsProvider) {
+class LocationsImporter(private val locationRepo: LocationRepository, private val schedule34LocationsProvider: Schedule34LocationsProvider) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
-
-    @Value("\${import-files.locations}")
-    private lateinit var locationsFile: String
 
     fun import(spreadsheet: LocationsSpreadsheet) {
         val count = locationRepo.count()
@@ -31,9 +26,7 @@ class LocationsImporter(private val locationRepo: LocationRepository,
      fun import() {
         locationRepo.deleteAll()
 
-        logger.info("Using locations file: $locationsFile")
-
-        schedule34LocationsProvider.get(locationsFile).use { locations ->
+        schedule34LocationsProvider.get().use { locations ->
             LocationsSpreadsheet(XSSFWorkbook(locations), locationRepo).use {
                 import(it)
             }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/pricing/importer/PriceImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/pricing/importer/PriceImporter.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.pricing.importer
 
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.GeoamyPricesProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.SercoPricesProvider
@@ -17,15 +16,22 @@ class PriceImporter(private val priceRepo: PriceRepository,
                     private val geoameyPrices: GeoamyPricesProvider,
                     private val locationRepository: LocationRepository) {
 
-    @Value("\${import-files.geo-prices}")
-    private lateinit var geoPricesFile: String
-
-    @Value("\${import-files.serco-prices}")
-    private lateinit var sercoPricesFile: String
-
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    internal fun import(spreadsheet: PricesSpreadsheet) {
+    fun import(supplier: Supplier) {
+        logger.info("Importing prices for $supplier")
+
+        priceRepo.deleteAll()
+
+        when(supplier) {
+            Supplier.SERCO -> sercoPrices.get().use { import(it, Supplier.SERCO) }
+            Supplier.GEOAMEY -> geoameyPrices.get().use { import(it, Supplier.GEOAMEY) }
+        }
+    }
+
+    private fun import(prices: InputStream, supplier: Supplier) = PricesSpreadsheet(XSSFWorkbook(prices), supplier, locationRepository, priceRepo).use { import(it) }
+
+    private fun import(spreadsheet: PricesSpreadsheet) {
         val count = priceRepo.count()
 
         spreadsheet.forEachRow { priceRepo.save(it) }
@@ -35,21 +41,5 @@ class PriceImporter(private val priceRepo: PriceRepository,
         val inserted = priceRepo.count() - count
 
         logger.info("${spreadsheet.supplier} PRICES INSERTED: $inserted. TOTAL ERRORS: ${spreadsheet.errors.size}")
-    }
-
-    private fun import(prices: InputStream, supplier: Supplier) {
-        PricesSpreadsheet(XSSFWorkbook(prices), supplier, locationRepository, priceRepo).use {
-            import(it)
-        }
-    }
-
-    fun import() {
-        priceRepo.deleteAll()
-
-        logger.info("Using Serco file: $sercoPricesFile")
-        sercoPrices.get(sercoPricesFile).use { import(it, Supplier.SERCO) }
-
-        logger.info("Using Geoamey file: $sercoPricesFile")
-        geoameyPrices.get(geoPricesFile).use { import(it, Supplier.GEOAMEY) }
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
@@ -54,7 +54,7 @@ class ImportService(
 
     fun importLocations() = importUnlessLocked(locationsImporter::import)
 
-    fun importPrices() = importUnlessLocked(priceImporter::import)
+    fun importPrices(supplier: Supplier) = importUnlessLocked { priceImporter.import(supplier) }
 
     fun spreadsheet(
             supplierName: String,
@@ -63,7 +63,7 @@ class ImportService(
             reportsTo: LocalDate): File? {
 
         return if (importLocations().second == ImportStatus.IN_PROGRESS) null
-        else if (importPrices().second == ImportStatus.IN_PROGRESS) null
+        else if (importPrices(Supplier.valueOf(supplierName.toUpperCase())).second == ImportStatus.IN_PROGRESS) null
         else {
             val supplier = Supplier.valueOf(supplierName.toUpperCase())
             val (reports, status) = importUnlessLocked { reportingImporter.import(movesFrom, reportsTo) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/TestConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/TestConfig.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc
 
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.core.io.ResourceLoader
@@ -23,18 +24,18 @@ class TestConfig {
     fun clock(): Clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
 
     @Bean
-    fun locationsResourceProvider(): Schedule34LocationsProvider {
-        return Schedule34LocationsProvider { resourceLoader.getResource(it).inputStream }
+    fun locationsResourceProvider(@Value("\${import-files.locations}") locationsFile: String): Schedule34LocationsProvider {
+        return Schedule34LocationsProvider { resourceLoader.getResource(locationsFile).inputStream }
     }
 
     @Bean
-    fun sercoPricesResourceProvider(): SercoPricesProvider {
-        return SercoPricesProvider { resourceLoader.getResource(it).inputStream }
+    fun sercoPricesResourceProvider(@Value("\${import-files.serco-prices}") sercoPricesFile: String): SercoPricesProvider {
+        return SercoPricesProvider { resourceLoader.getResource(sercoPricesFile).inputStream }
     }
 
     @Bean
-    fun geoameyPricesResourceProvider(): GeoamyPricesProvider {
-        return GeoamyPricesProvider { resourceLoader.getResource(it).inputStream }
+    fun geoameyPricesResourceProvider(@Value("\${import-files.geo-prices}") geoPricesFile: String): GeoamyPricesProvider {
+        return GeoamyPricesProvider { resourceLoader.getResource(geoPricesFile).inputStream }
     }
 
     @Bean

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ImportControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ImportControllerTest.kt
@@ -5,22 +5,14 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.test.web.client.TestRestTemplate
-import org.springframework.boot.test.web.client.postForEntity
-import org.springframework.context.annotation.Bean
-import org.springframework.core.io.ResourceLoader
+import org.springframework.core.io.InputStreamResource
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
-import uk.gov.justice.digital.hmpps.pecs.jpc.config.GeoamyPricesProvider
-import uk.gov.justice.digital.hmpps.pecs.jpc.config.Schedule34LocationsProvider
-import uk.gov.justice.digital.hmpps.pecs.jpc.config.SercoPricesProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.pricing.PriceRepository
-import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportStatus
-import java.time.Clock
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -35,18 +27,13 @@ class ImportControllerTest(@Autowired val restTemplate: TestRestTemplate) {
     lateinit var priceRepository: PriceRepository
 
     @Test
-    fun `can import locations followed by prices`() {
+    fun `can generate spreadsheet for serco`() {
         assertThat(locationRepository.count()).isEqualTo(0)
-        val locationsResponse = restTemplate.postForEntity<String>("/locations/import")
-        assertThat(locationsResponse.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(locationsResponse.body).isEqualTo(ImportStatus.DONE.name)
-        assertThat(locationRepository.count()).isEqualTo(2)
-
         assertThat(priceRepository.count()).isEqualTo(0)
-        val pricesResponse = restTemplate.postForEntity<String>("/prices/import")
-        assertThat(pricesResponse.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(pricesResponse.body).isEqualTo(ImportStatus.DONE.name)
-        assertThat(priceRepository.count()).isEqualTo(2)
-    }
+        val response = restTemplate.getForEntity("/generate-prices-spreadsheet/SERCO?moves_from=2020-10-01&moves_to=2020-10-01&reports_to=2020-10-01", InputStreamResource::class.java)
 
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(locationRepository.count()).isEqualTo(2)
+        assertThat(priceRepository.count()).isEqualTo(1)
+    }
 }


### PR DESCRIPTION
This changes takes out the property loading from the location and pricing importers into the config itself.  No need to do it this way anymore.

Also change the generate supplier spreadsheet to only load the prices for the given supplier.