### PR TITLE
P4-2214 tuning mainly around price import but also some refactoring.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ WORKDIR /app
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/calculate-journey-variable*.jar /app/app.jar
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/applicationinsights-agent*.jar /app/agent.jar
 COPY --from=builder --chown=appuser:appgroup /app/AI-Agent.xml /app
-COPY --from=builder --chown=appuser:appgroup /app/src/main/resources/spreadsheets/JCP_template.xlsx /app/resources/spreadsheets/JCP_template.xlsx
 
 USER 2000
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,10 +17,10 @@ dependencies {
 	implementation("com.github.kittinunf.result:result:3.1.0")
 	implementation("com.github.kittinunf.result:result-coroutines:3.1.0")
 	implementation("com.beust:klaxon:5.4")
-	implementation("com.amazonaws:aws-java-sdk-s3:1.11.876")
+	implementation("com.amazonaws:aws-java-sdk-s3:1.11.880")
 
 	testImplementation("org.mockito:mockito-inline:3.5.13")
 
 	runtimeOnly("com.h2database:h2")
-	runtimeOnly("org.postgresql:postgresql:42.2.16")
+	runtimeOnly("org.postgresql:postgresql:42.2.17")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/ImporterConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/ImporterConfiguration.kt
@@ -1,12 +1,10 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.config
 
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.ResourceLoader
-import java.io.File
 import java.time.Clock
 
 @Configuration
@@ -19,6 +17,7 @@ class ImporterConfiguration {
     fun clock() = Clock.systemDefaultZone()
 
     @Bean
-    @Qualifier(value ="spreadsheet-template")
-    fun file(@Value("\${export-files.template}") location: String) : File = resourceLoader.getResource(location).file
+    fun jcpTemplateProvider(@Value("\${export-files.template}") templateFileLocation: String): JCPTemplateProvider {
+        return JCPTemplateProvider { resourceLoader.getResource(templateFileLocation).inputStream }
+    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/JCPTemplateProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/JCPTemplateProvider.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.config
+
+import java.io.InputStream
+
+/**
+ * Responsible for providing the JCP template Excel spreadsheet via an [InputStream].
+ */
+fun interface JCPTemplateProvider {
+    /**
+     * The caller is responsible for closing the [InputStream].
+     */
+    fun get(): InputStream
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/output/PricesSpreadsheetGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/output/PricesSpreadsheetGenerator.kt
@@ -8,16 +8,18 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.pecs.jpc.calculator.PriceCalculator
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.GeoamyPricesProvider
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.JCPTemplateProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.SercoPricesProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.pricing.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.reporting.FilterParams
 import java.io.File
 import java.io.FileOutputStream
+import java.io.InputStream
 import java.time.Clock
 import java.time.LocalDate
 
 @Component
-class PricesSpreadsheetGenerator(@Autowired @Qualifier(value = "spreadsheet-template") private val template: File,
+class PricesSpreadsheetGenerator(@Autowired private val template: JCPTemplateProvider,
                                  @Autowired private val clock: Clock,
                                  @Autowired private val sercoPricesProvider: SercoPricesProvider,
                                  @Autowired private val geoamyPricesProvider: GeoamyPricesProvider) {
@@ -27,7 +29,7 @@ class PricesSpreadsheetGenerator(@Autowired @Qualifier(value = "spreadsheet-temp
     internal fun generate(filter: FilterParams, calculator: PriceCalculator): File {
         val dateGenerated = LocalDate.now(clock)
 
-        XSSFWorkbook(template.inputStream()).use { workbook ->
+        XSSFWorkbook(template.get()).use { workbook ->
             val header = PriceSheet.Header(dateGenerated, filter.dateRange(), filter.supplier)
 
             StandardMovesSheet(workbook, header)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/pricing/Price.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/pricing/Price.kt
@@ -1,15 +1,20 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.pricing
 
 import java.time.LocalDateTime
-import java.util.*
-import javax.persistence.*
-import javax.validation.constraints.NotNull
-import javax.validation.constraints.Size
+import java.util.UUID
+import javax.persistence.Column
+import javax.persistence.Enumerated
+import javax.persistence.EnumType
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Index
+import javax.persistence.Table
 import javax.validation.constraints.Min
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
 
 @Entity
-@Table(name = "PRICES")
+@Table(name = "PRICES", indexes = [Index(name = "supplier_from_to_index", columnList = "supplier, fromLocationName, toLocationName", unique = true)])
 data class Price(
         @Id
         @Column(name = "price_id", nullable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/pricing/importer/PriceImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/pricing/importer/PriceImporter.kt
@@ -19,6 +19,8 @@ class PriceImporter(private val priceRepo: PriceRepository,
     private val logger = LoggerFactory.getLogger(javaClass)
 
     fun import(supplier: Supplier) {
+        val start = System.currentTimeMillis()
+
         logger.info("Importing prices for $supplier")
 
         priceRepo.deleteAll()
@@ -27,9 +29,11 @@ class PriceImporter(private val priceRepo: PriceRepository,
             Supplier.SERCO -> sercoPrices.get().use { import(it, Supplier.SERCO) }
             Supplier.GEOAMEY -> geoameyPrices.get().use { import(it, Supplier.GEOAMEY) }
         }
+
+        logger.info("Supplier $supplier prices import finished in '${(System.currentTimeMillis() - start) / 1000}' seconds.")
     }
 
-    private fun import(prices: InputStream, supplier: Supplier) = PricesSpreadsheet(XSSFWorkbook(prices), supplier, locationRepository, priceRepo).use { import(it) }
+    private fun import(prices: InputStream, supplier: Supplier) = PricesSpreadsheet(XSSFWorkbook(prices), supplier, locationRepository.findAll().toList()).use { import(it) }
 
     private fun import(spreadsheet: PricesSpreadsheet) {
         val count = priceRepo.count()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/output/PricesSpreadsheetGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/output/PricesSpreadsheetGeneratorTest.kt
@@ -3,24 +3,23 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.output
 import com.nhaarman.mockitokotlin2.*
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
 import uk.gov.justice.digital.hmpps.pecs.jpc.calculator.PriceCalculator
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.GeoamyPricesProvider
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.JCPTemplateProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.SercoPricesProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.pricing.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.reporting.FilterParams
-import java.io.File
 import java.time.Clock
 import java.time.LocalDate
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @ContextConfiguration(classes = [TestConfig::class])
-internal class PricesSpreadsheetGeneratorTest(@Autowired @Qualifier(value = "spreadsheet-template") private val template: File,
+internal class PricesSpreadsheetGeneratorTest(@Autowired private val template: JCPTemplateProvider,
                                               @Autowired private val clock: Clock,
                                               @Autowired private val sercoPricesProvider: SercoPricesProvider,
                                               @Autowired private val geoamyPricesProvider: GeoamyPricesProvider) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/output/RedirectionMovesSheetTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/output/RedirectionMovesSheetTest.kt
@@ -4,24 +4,23 @@ import org.apache.poi.ss.usermodel.Workbook
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
 import uk.gov.justice.digital.hmpps.pecs.jpc.calculator.JourneyPrice
 import uk.gov.justice.digital.hmpps.pecs.jpc.calculator.MovePrice
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.JCPTemplateProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.pricing.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.reporting.*
-import java.io.File
 import java.time.LocalDate
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @ContextConfiguration(classes = [TestConfig::class])
-internal class RedirectionMovesSheetTest(@Autowired @Qualifier(value = "spreadsheet-template") template: File) {
+internal class RedirectionMovesSheetTest(@Autowired private val template: JCPTemplateProvider) {
 
-    private val workbook: Workbook = XSSFWorkbook(template)
+    private val workbook: Workbook = XSSFWorkbook(template.get())
 
     @Test
     internal fun `test redirection prices`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/output/StandardMovesSheetTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/output/StandardMovesSheetTest.kt
@@ -6,26 +6,23 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
 import uk.gov.justice.digital.hmpps.pecs.jpc.calculator.JourneyPrice
 import uk.gov.justice.digital.hmpps.pecs.jpc.calculator.MovePrice
-import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.JCPTemplateProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.pricing.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.reporting.*
-import java.io.File
-import java.lang.RuntimeException
 import java.time.LocalDate
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @ContextConfiguration(classes = [TestConfig::class])
-internal class StandardMovesSheetTest(@Autowired @Qualifier(value = "spreadsheet-template") template: File) {
+internal class StandardMovesSheetTest(@Autowired private val template: JCPTemplateProvider) {
 
-    private val workbook: Workbook = XSSFWorkbook(template)
+    private val workbook: Workbook = XSSFWorkbook(template.get())
 
     private val date: LocalDate = LocalDate.now()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/pricing/importer/PriceImportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/pricing/importer/PriceImportTest.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.config.GeoamyPricesProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.SercoPricesProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.Location
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
 import uk.gov.justice.digital.hmpps.pecs.jpc.pricing.PriceRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.pricing.Supplier
 import java.io.ByteArrayInputStream
@@ -21,10 +22,6 @@ internal class PriceImportTest {
 
     private val locationRepo: LocationRepository = mock()
 
-    private val fromLocation: Location = mock { on { id } doReturn UUID.randomUUID() }
-
-    private val toLocation: Location = mock { on { id } doReturn UUID.randomUUID() }
-
     private val sercoPricesProvider: SercoPricesProvider = mock()
 
     private val geoamyPricesProvider: GeoamyPricesProvider = mock()
@@ -34,11 +31,13 @@ internal class PriceImportTest {
     @Test
     internal fun `verify import interactions for serco`() {
         whenever(sercoPricesProvider.get()).thenReturn(priceSheetWithRow(1.0, "SERCO FROM", "SERCO TO", 100.00))
-        whenever(locationRepo.findBySiteName("SERCO FROM")).thenReturn(fromLocation)
-        whenever(locationRepo.findBySiteName("SERCO TO")).thenReturn(toLocation)
+        val fromLocation = Location(LocationType.PR, "ID1", "SERCO FROM")
+        val toLocation = Location(LocationType.CC, "ID2", "SERCO TO")
+        whenever(locationRepo.findAll()).thenReturn(listOf(fromLocation, toLocation))
 
         import.import(Supplier.SERCO)
 
+        verify(locationRepo).findAll()
         verify(sercoPricesProvider).get()
         verify(priceRepo).deleteAll()
         verify(priceRepo, times(2)).count()
@@ -48,11 +47,13 @@ internal class PriceImportTest {
     @Test
     internal fun `verify import interactions for geoamey`() {
         whenever(geoamyPricesProvider.get()).thenReturn(priceSheetWithRow(2.0, "GEO FROM", "GEO TO", 101.00))
-        whenever(locationRepo.findBySiteName("GEO FROM")).thenReturn(fromLocation)
-        whenever(locationRepo.findBySiteName("GEO TO")).thenReturn(toLocation)
+        val fromLocation = Location(LocationType.PR, "ID1", "GEO FROM")
+        val toLocation = Location(LocationType.CC, "ID2", "GEO TO")
+        whenever(locationRepo.findAll()).thenReturn(listOf(fromLocation, toLocation))
 
         import.import(Supplier.GEOAMEY)
 
+        verify(locationRepo).findAll()
         verify(geoamyPricesProvider).get()
         verify(priceRepo).deleteAll()
         verify(priceRepo, times(2)).count()


### PR DESCRIPTION
This PR was originally primarily to improve some of the overall performance when importing prices.  In doing so this did highlight a few things that needed attention.  In particular the way the JCP template spreadsheet was being supplied (as a File) using the Spring ResourceLoader meant it could not be detected with in the deployed JAR.  To load files from the JAR itself you need to load them as an input streams.  This should now be resolved so there is no need to copy to a separate file location in the Docker file.