### PR TITLE
P4-2434 adding ability to run an import on application start.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/JpcApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/JpcApplication.kt
@@ -1,11 +1,20 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc
 
+import org.springframework.beans.factory.getBean
+import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import uk.gov.justice.digital.hmpps.pecs.jpc.import.LocationAndPriceImporter
 
 @SpringBootApplication
 class JpcApplication
 
 fun main(args: Array<String>) {
-	runApplication<JpcApplication>(*args)
+    runApplication<JpcApplication>(*args).let { context ->
+
+        // This is a temporary solution to run an import of locations and prices then terminate bypassing the need to go to an endpoint.
+        args.firstOrNull { it == "--run-import" }?.let {
+            (context.getBean(LocationAndPriceImporter::class) as LocationAndPriceImporter).let { SpringApplication.exit(context, it) }
+        }
+    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/JpcApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/JpcApplication.kt
@@ -13,7 +13,7 @@ fun main(args: Array<String>) {
     runApplication<JpcApplication>(*args).let { context ->
 
         // This is a temporary solution to run an import of locations and prices then terminate bypassing the need to go to an endpoint.
-        args.firstOrNull { it == "--run-import" }?.let {
+        args.firstOrNull { it == "--import-locations-and-prices" }?.let {
             (context.getBean(LocationAndPriceImporter::class) as LocationAndPriceImporter).let { SpringApplication.exit(context, it) }
         }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/import/LocationAndPriceImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/import/LocationAndPriceImporter.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.import
+
+import org.slf4j.LoggerFactory
+import org.springframework.boot.ExitCodeGenerator
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.PriceRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportService
+
+/**
+ * This should be considered a temporary component in that as soon as we no longer need to import spreadsheets this can be removed.
+ */
+@Component
+internal class LocationAndPriceImporter(private val priceRepository: PriceRepository,
+                                        private val locationRepository: LocationRepository,
+                                        private val importService: ImportService) : ExitCodeGenerator {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    private val success = 0;
+
+    private val failure = 1;
+
+    /**
+     * Calling this kicks off an import and returns '0' if successful or '1' if any exception is thrown (and caught).
+     */
+    override fun getExitCode(): Int {
+        return Result.runCatching { importLocationsAndPrices() }.onFailure { logger.error(it.stackTraceToString()) }.getOrDefault(failure)
+    }
+
+    private fun importLocationsAndPrices(): Int {
+        priceRepository.deleteAll()
+        locationRepository.deleteAll()
+
+        importService.importLocations()
+        importService.importPrices(Supplier.GEOAMEY)
+        importService.importPrices(Supplier.SERCO)
+
+        return success
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/import/LocationAndPriceImporterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/import/LocationAndPriceImporterTest.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.import
+
+import com.nhaarman.mockitokotlin2.doThrow
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.PriceRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportService
+
+internal class LocationAndPriceImporterTest {
+
+    private val priceRepository: PriceRepository = mock()
+    private val locationRepository: LocationRepository = mock()
+    private val importService: ImportService = mock()
+    private val importer: LocationAndPriceImporter = LocationAndPriceImporter(priceRepository, locationRepository, importService)
+
+    @Test
+    internal fun `returns successful exit code when import succeeds`() {
+        assertThat(importer.exitCode).isEqualTo(0)
+        verify(priceRepository).deleteAll()
+        verify(locationRepository).deleteAll()
+        verify(importService).importLocations()
+        verify(importService).importPrices(Supplier.GEOAMEY)
+        verify(importService).importPrices(Supplier.SERCO)
+    }
+
+    @Test
+    internal fun `returns failure exit code when import fails`() {
+        whenever(importService.importLocations()).doThrow(RuntimeException())
+
+        assertThat(importer.exitCode).isEqualTo(1)
+    }
+}


### PR DESCRIPTION
The driver for this change is so we can run an import of locations and prices via direct call to jar file and negate the need to go via a rest call.  This should enable us to then call via a cron job for example.