### PR TITLE
P4-2434 removed endpoints for importing locations and prices.  This can now only be done via the commandline.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ImportController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ImportController.kt
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.spreadsheet.SpreadsheetProtection
-import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportService
 import java.io.FileInputStream
 import java.io.IOException
@@ -24,25 +23,6 @@ import javax.servlet.http.HttpServletResponse
 class ImportController(private val importService: ImportService,
                        private val timeSource: TimeSource,
                        private val spreadsheetProtection: SpreadsheetProtection) {
-
-
-    @GetMapping("/import-locations")
-    fun importLocations(
-            response: HttpServletResponse?): String {
-
-        importService.importLocations()
-        return "Done import locations"
-    }
-
-    @GetMapping("/import-prices/{supplier}")
-    fun importPrices(
-            @PathVariable supplier: String,
-            response: HttpServletResponse?): String {
-
-        importService.importPrices(Supplier.valueOfCaseInsensitive(supplier))
-
-        return "Done import prices for $supplier"
-    }
 
     @GetMapping("/import-reports/{supplier}")
     fun importReports(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/import/price/PriceImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/import/price/PriceImporter.kt
@@ -23,7 +23,7 @@ class PriceImporter(private val priceRepo: PriceRepository,
 
         logger.info("Importing prices for $supplier")
 
-        priceRepo.deleteAll()
+        priceRepo.deleteBySupplier(supplier)
 
         when(supplier) {
             Supplier.SERCO -> sercoPrices.get().use { import(it, Supplier.SERCO) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceRepository.kt
@@ -4,4 +4,5 @@ import org.springframework.data.repository.CrudRepository
 import java.util.*
 
 interface PriceRepository : CrudRepository<Price, UUID> {
+    fun deleteBySupplier(supplier: Supplier): Long
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ImportControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ImportControllerTest.kt
@@ -21,9 +21,7 @@ import org.springframework.test.context.ContextConfiguration
 import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
-import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.spreadsheet.SpreadsheetProtection
-import uk.gov.justice.digital.hmpps.pecs.jpc.price.PriceRepository
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -31,7 +29,7 @@ import java.time.LocalDateTime
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
 @ContextConfiguration(classes = [TestConfig::class])
-// by passing security for now.
+// bypassing security for now.
 @EnableAutoConfiguration(exclude = [ SecurityAutoConfiguration::class, ManagementWebSecurityAutoConfiguration::class ])
 class ImportControllerTest(@Autowired val restTemplate: TestRestTemplate) {
 
@@ -41,36 +39,6 @@ class ImportControllerTest(@Autowired val restTemplate: TestRestTemplate) {
     @SpyBean
     @Autowired
     lateinit var spreadsheetProtection: SpreadsheetProtection
-
-    @Autowired
-    lateinit var locationRepository: LocationRepository
-
-    @Autowired
-    lateinit var priceRepository: PriceRepository
-
-    @Test
-    fun `can import locations`() {
-        whenever(timeSource.dateTime()).thenReturn(LocalDateTime.of(2020, 10, 13, 15, 25))
-
-        assertThat(locationRepository.count()).isEqualTo(0)
-
-        val response = restTemplate.getForEntity("/import-locations", InputStreamResource::class.java)
-
-        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(locationRepository.count()).isEqualTo(2)
-    }
-
-    @Test
-    fun `can import prices`() {
-        whenever(timeSource.dateTime()).thenReturn(LocalDateTime.of(2020, 10, 13, 15, 25))
-
-        assertThat(priceRepository.count()).isEqualTo(0)
-
-        val response = restTemplate.getForEntity("/import-prices/geoamey", InputStreamResource::class.java)
-
-        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-//        assertThat(priceRepository.count()).isEqualTo(2)
-    }
 
     @Test
     fun `can generate spreadsheet for serco`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/import/LocationAndPriceImporterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/import/LocationAndPriceImporterTest.kt
@@ -1,36 +1,60 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.import
 
+import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doThrow
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.PriceRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportService
 
-internal class LocationAndPriceImporterTest {
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@ContextConfiguration(classes = [TestConfig::class])
+internal class LocationAndPriceImporterTest(@Autowired val priceRepository: PriceRepository,
+                                            @Autowired val locationRepository: LocationRepository,
+                                            @Autowired val importService: ImportService) {
 
-    private val priceRepository: PriceRepository = mock()
-    private val locationRepository: LocationRepository = mock()
-    private val importService: ImportService = mock()
-    private val importer: LocationAndPriceImporter = LocationAndPriceImporter(priceRepository, locationRepository, importService)
+    private val priceRepositorySpy: PriceRepository = mock { on { deleteAll() } doAnswer { priceRepository.deleteAll() } }
+
+    private val locationRepositorySpy: LocationRepository = mock { on { deleteAll() } doAnswer { locationRepository.deleteAll() } }
+
+    private val importServiceSpy: ImportService = mock {
+        on { importLocations() } doAnswer { importService.importLocations() }
+        on { importPrices(Supplier.GEOAMEY) } doAnswer { importService.importPrices(Supplier.GEOAMEY) }
+        on { importPrices(Supplier.SERCO) } doAnswer { importService.importPrices(Supplier.SERCO) }
+    }
+
+    private val importer: LocationAndPriceImporter = LocationAndPriceImporter(priceRepositorySpy, locationRepositorySpy, importServiceSpy)
 
     @Test
     internal fun `returns successful exit code when import succeeds`() {
+        assertThat(priceRepository.count()).isEqualTo(0)
+        assertThat(locationRepository.count()).isEqualTo(0)
         assertThat(importer.exitCode).isEqualTo(0)
-        verify(priceRepository).deleteAll()
-        verify(locationRepository).deleteAll()
-        verify(importService).importLocations()
-        verify(importService).importPrices(Supplier.GEOAMEY)
-        verify(importService).importPrices(Supplier.SERCO)
+
+        verify(priceRepositorySpy).deleteAll()
+        verify(locationRepositorySpy).deleteAll()
+        verify(importServiceSpy).importLocations()
+        verify(importServiceSpy).importPrices(Supplier.GEOAMEY)
+        verify(importServiceSpy).importPrices(Supplier.SERCO)
+
+        assertThat(locationRepository.count()).isEqualTo(2)
+        assertThat(priceRepository.count()).isEqualTo(2)
     }
 
     @Test
     internal fun `returns failure exit code when import fails`() {
-        whenever(importService.importLocations()).doThrow(RuntimeException())
+        whenever(importServiceSpy.importLocations()).doThrow(RuntimeException())
 
         assertThat(importer.exitCode).isEqualTo(1)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/importer/PriceImportTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/importer/PriceImportTest.kt
@@ -39,7 +39,7 @@ internal class PriceImportTest {
 
         verify(locationRepo).findAll()
         verify(sercoPricesProvider).get()
-        verify(priceRepo).deleteAll()
+        verify(priceRepo).deleteBySupplier(Supplier.SERCO)
         verify(priceRepo, times(2)).count()
         verify(priceRepo).save(any())
     }
@@ -55,7 +55,7 @@ internal class PriceImportTest {
 
         verify(locationRepo).findAll()
         verify(geoameyPricesProvider).get()
-        verify(priceRepo).deleteAll()
+        verify(priceRepo).deleteBySupplier(Supplier.GEOAMEY)
         verify(priceRepo, times(2)).count()
         verify(priceRepo).save(any())
     }


### PR DESCRIPTION
This changes means locations and prices can only be imported from the commandline going forwards.

@mafonso this change should mean going forwards we will not be restricted to one pod as this can be run via a cron job in a controlled manner.