### PR TITLE
P4-2434 changes to support running the import of supplier reports from the commandline.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/JpcApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/JpcApplication.kt
@@ -5,16 +5,26 @@ import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import uk.gov.justice.digital.hmpps.pecs.jpc.import.LocationAndPriceImporter
+import uk.gov.justice.digital.hmpps.pecs.jpc.import.SupplierReportsImporter
+import java.time.LocalDate
 
 @SpringBootApplication
 class JpcApplication
 
 fun main(args: Array<String>) {
     runApplication<JpcApplication>(*args).let { context ->
-
         // This is a temporary solution to run an import of locations and prices then terminate bypassing the need to go to an endpoint.
-        args.firstOrNull { it == "--import-locations-and-prices" }?.let {
-            (context.getBean(LocationAndPriceImporter::class) as LocationAndPriceImporter).let { SpringApplication.exit(context, it) }
+        context.environment.getProperty("import-locations-and-prices")?.let {
+            (context.getBean(LocationAndPriceImporter::class) as LocationAndPriceImporter).let { SpringApplication.exit(context, it.import()) }
+        }
+
+        // This is a temporary solution to run an import of both supplier reports then terminate bypassing the need to go to an endpoint.
+        context.environment.getProperty("import-supplier-reports")?.let {dates ->
+            val from = LocalDate.parse(dates.split(",")[0].trim())
+            val to = LocalDate.parse(dates.split(",")[1].trim())
+
+            (context.getBean(SupplierReportsImporter::class) as SupplierReportsImporter).let { reportImporter ->
+                SpringApplication.exit(context, reportImporter.import(from, to)) }
         }
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/import/SupplierReportsImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/import/SupplierReportsImporter.kt
@@ -3,18 +3,15 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.import
 import org.slf4j.LoggerFactory
 import org.springframework.boot.ExitCodeGenerator
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
-import uk.gov.justice.digital.hmpps.pecs.jpc.price.PriceRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportService
+import java.time.LocalDate
 
 /**
  * This should be considered a temporary component in that as soon as we no longer need to import spreadsheets this can be removed.
  */
 @Component
-internal class LocationAndPriceImporter(private val priceRepository: PriceRepository,
-                                        private val locationRepository: LocationRepository,
-                                        private val importService: ImportService) {
+internal class SupplierReportsImporter(private val importService: ImportService) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -25,14 +22,10 @@ internal class LocationAndPriceImporter(private val priceRepository: PriceReposi
     /**
      * Calling this kicks off an import and returns '0' if successful or '1' if any exception is thrown (and caught).
      */
-    fun import() : ExitCodeGenerator {
+    fun import(from: LocalDate, to: LocalDate): ExitCodeGenerator {
         return Result.runCatching {
-            priceRepository.deleteAll()
-            locationRepository.deleteAll()
-
-            importService.importLocations()
-            importService.importPrices(Supplier.GEOAMEY)
-            importService.importPrices(Supplier.SERCO)
+            importService.importReports(Supplier.GEOAMEY, from, to)
+            importService.importReports(Supplier.SERCO, from, to)
 
             return success
         }.onFailure { logger.error(it.stackTraceToString()) }.getOrDefault(failure)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
@@ -56,11 +56,12 @@ class ImportService(
 
     fun importPrices(supplier: Supplier) = importUnlessLocked { priceImporter.import(supplier) }
 
-    fun importReports(supplierName: String, reportsFrom: LocalDate, reportsTo: LocalDate) {
+    // TODO remove this...
+    fun importReports(supplierName: String, reportsFrom: LocalDate, reportsTo: LocalDate) = importReports(Supplier.valueOfCaseInsensitive(supplierName), reportsFrom, reportsTo)
 
-        logger.info("Importing reports for supplier '$supplierName', moves from '$reportsFrom', moves to '$reportsTo'.")
+    fun importReports(supplier: Supplier, reportsFrom: LocalDate, reportsTo: LocalDate) {
+        logger.info("Importing reports for supplier '$supplier', moves from '$reportsFrom', moves to '$reportsTo'.")
 
-        val supplier = Supplier.valueOfCaseInsensitive(supplierName)
         val (reports, status) = importUnlessLocked { reportImporter.import(supplier, reportsFrom, reportsTo) }
 
         reports?.let{

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/import/LocationAndPriceImporterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/import/LocationAndPriceImporterTest.kt
@@ -40,7 +40,7 @@ internal class LocationAndPriceImporterTest(@Autowired val priceRepository: Pric
     internal fun `returns successful exit code when import succeeds`() {
         assertThat(priceRepository.count()).isEqualTo(0)
         assertThat(locationRepository.count()).isEqualTo(0)
-        assertThat(importer.exitCode).isEqualTo(0)
+        assertThat(importer.import().exitCode).isEqualTo(0)
 
         verify(priceRepositorySpy).deleteAll()
         verify(locationRepositorySpy).deleteAll()
@@ -56,6 +56,6 @@ internal class LocationAndPriceImporterTest(@Autowired val priceRepository: Pric
     internal fun `returns failure exit code when import fails`() {
         whenever(importServiceSpy.importLocations()).doThrow(RuntimeException())
 
-        assertThat(importer.exitCode).isEqualTo(1)
+        assertThat(importer.import().exitCode).isEqualTo(1)
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/import/SupplierReportsImporterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/import/SupplierReportsImporterTest.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.import
+
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doThrow
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportService
+import java.time.LocalDate
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@ContextConfiguration(classes = [TestConfig::class])
+internal class SupplierReportsImporterTest(@Autowired val importService: ImportService) {
+
+    private val from: LocalDate = LocalDate.now()
+
+    private val to: LocalDate = from.plusDays(1)
+
+    private val importServiceSpy: ImportService = mock {
+        on { importReports(Supplier.GEOAMEY, from, to) } doAnswer { importService.importReports(Supplier.GEOAMEY, from, to) }
+        on { importReports(Supplier.SERCO, from, to) } doAnswer { importService.importReports(Supplier.SERCO, from, to) }
+    }
+
+    private val importer: SupplierReportsImporter = SupplierReportsImporter(importServiceSpy)
+
+    @Test
+    internal fun `returns successful exit code when import succeeds`() {
+        assertThat(importer.import(from, to).exitCode).isEqualTo(0)
+
+        verify(importServiceSpy).importReports(Supplier.GEOAMEY, from, to)
+        verify(importServiceSpy).importReports(Supplier.SERCO, from, to)
+    }
+
+    @Test
+    internal fun `returns failure exit code when import fails`() {
+        whenever(importServiceSpy.importReports(Supplier.GEOAMEY, from, to)).doThrow(RuntimeException())
+
+        assertThat(importer.import(from, to).exitCode).isEqualTo(1)
+    }
+}


### PR DESCRIPTION
This is part two of moving imports (of reports) to the command line.

The following commandline parameter has now been added, see example below:

`--import-supplier-reports=2020-10-01,2020-10-02`