### PR TITLE
P4-2434 removal of import supplier reports endpoint as to be run via commandline.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ If you prefer to run the app from the command line, you can do so from the root 
 export $(cat .env | xargs)  # If you want to set or update the current shell environment
 ./gradlew bootRun '
 ```
+### Running imports from the commandline
+
+Importing locations and prices:
+
+```bash
+export $(cat .env | xargs)  # If you want to set or update the current shell environment
+
+java -jar app.jar --spring.main.web-application-type=none --import-locations-and-prices
+```
+
+Importing supplier reports for given dates:
+
+```bash
+export $(cat .env | xargs)  # If you want to set or update the current shell environment
+
+java -jar app.jar --spring.main.web-application-type=none --import-supplier-reports=2020-10-01,2020-10-02
+```
+
 
 ### Common gradle tasks 
 To list project dependencies, run:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/SecurityConfiguration.kt
@@ -1,13 +1,13 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.config
 
-import org.springframework.context.annotation.Profile
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 import org.springframework.security.config.web.servlet.invoke
 
-// TODO for now this is tied to run for localstack profile only!!
 @EnableWebSecurity
+@ConditionalOnWebApplication
 class SecurityConfiguration : WebSecurityConfigurerAdapter() {
 
     @Throws(Exception::class)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/OutputSpreadsheetController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/OutputSpreadsheetController.kt
@@ -24,18 +24,6 @@ class OutputSpreadsheetController(private val importService: ImportService,
                                   private val timeSource: TimeSource,
                                   private val spreadsheetProtection: SpreadsheetProtection) {
 
-    @GetMapping("/import-reports/{supplier}")
-    fun importReports(
-            @PathVariable supplier: String,
-            @RequestParam(name = "reports_from", required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) reportsFrom: LocalDate,
-            @RequestParam(name = "reports_to", required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) reportsTo: LocalDate,
-            response: HttpServletResponse?): String {
-
-        importService.importReports(supplier, reportsFrom, reportsTo)
-
-        return "Done import reports for $supplier"
-    }
-
     @GetMapping("/generate-prices-spreadsheet/{supplier}")
     @Throws(IOException::class)
     fun generateSpreadsheet(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/OutputSpreadsheetControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/OutputSpreadsheetControllerTest.kt
@@ -30,8 +30,6 @@ import java.time.LocalDateTime
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
 @ContextConfiguration(classes = [TestConfig::class])
-// bypassing security for now.
-@EnableAutoConfiguration(exclude = [ SecurityAutoConfiguration::class, ManagementWebSecurityAutoConfiguration::class ])
 class OutputSpreadsheetControllerTest(@Autowired val restTemplate: TestRestTemplate) {
 
     @MockBean
@@ -49,7 +47,7 @@ class OutputSpreadsheetControllerTest(@Autowired val restTemplate: TestRestTempl
 
         val response = restTemplate.getForEntity("/generate-prices-spreadsheet/SERCO?moves_from=2020-10-01", InputStreamResource::class.java)
 
-//        verify(spreadsheetProtection).protectAndGet(any())
+        verify(spreadsheetProtection).protectAndGet(any())
         assertThat(response.headers.contentDisposition.filename).isEqualTo("Journey_Variable_Payment_Output_SERCO_2020-10-13_15_25.xlsx")
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
     }


### PR DESCRIPTION
This changes means you you can only import supplier reports from the command line going forwards, for example:

`java -jar app.jar --spring.main.web-application-type=none --import-supplier-reports=2020-10-01,2020-10-02`

