### PR TITLE
P4-2452 cleaning up some compilation warnings and increasing number of pods.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,6 @@ dependencies {
 	implementation("com.beust:klaxon:5.4")
 	implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
 	implementation("com.amazonaws:aws-java-sdk-s3:1.11.901")
-	implementation("org.ocpsoft.prettytime:prettytime-nlp:4.0.6.Final")
 	implementation("nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:2.5.1")
 	implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 	implementation("org.springframework.session:spring-session-jdbc")

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,7 +1,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 2
 
 image:
   repository: quay.io/hmpps/calculate-journey-variable-payments

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,7 +1,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 2
 
 image:
   repository: quay.io/hmpps/calculate-journey-variable-payments

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,7 +1,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 2
 
 image:
   repository: quay.io/hmpps/calculate-journey-variable-payments

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/FilterConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/FilterConfiguration.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.config
 
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -11,10 +12,13 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.filter.ChooseSupplierFilter
 
 @Configuration
 class FilterRegistrationConfig {
+
+    @Autowired lateinit var timeSource: TimeSource
+
     @Bean
     fun chooseFilter(): FilterRegistrationBean<ChooseSupplierFilter> {
         val registrationBean: FilterRegistrationBean<ChooseSupplierFilter> = FilterRegistrationBean<ChooseSupplierFilter>()
-        registrationBean.filter = ChooseSupplierFilter()
+        registrationBean.filter = ChooseSupplierFilter(timeSource)
         registrationBean.addUrlPatterns(DASHBOARD_URL, SELECT_MONTH_URL, JOURNEYS_URL, MOVES_BY_TYPE_URL)
         return registrationBean
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/SecurityConfiguration.kt
@@ -65,7 +65,7 @@ class SecurityConfiguration : WebSecurityConfigurerAdapter() {
     }
 
     private fun accessDeniedHandler(): AccessDeniedHandler {
-        return AccessDeniedHandler { request, response, accessDeniedException ->
+        return AccessDeniedHandler { request, _, accessDeniedException ->
             val auth: Authentication? = SecurityContextHolder.getContext().authentication
 
             if (auth != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/constraint/MonthYearConstraintValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/constraint/MonthYearConstraintValidator.kt
@@ -1,13 +1,12 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.constraint
 
-import org.ocpsoft.prettytime.nlp.PrettyTimeParser
+import uk.gov.justice.digital.hmpps.pecs.jpc.util.MonthYearParser
 import javax.validation.ConstraintValidator
 import javax.validation.ConstraintValidatorContext
-
 
 class MonthYearValidator : ConstraintValidator<ValidMonthYear?, String?> {
     override fun initialize(arg0: ValidMonthYear?) {}
     override fun isValid(dateAsString: String?, context: ConstraintValidatorContext): Boolean {
-        return Result.runCatching { PrettyTimeParser().parse(dateAsString).size == 1 }.getOrElse { false }
+        return dateAsString != null && MonthYearParser.isValid(dateAsString)
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/constraint/ValidMonthYear.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/constraint/ValidMonthYear.kt
@@ -1,14 +1,11 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.constraint
 
-import java.lang.annotation.Documented
-import java.lang.annotation.Retention
-import java.lang.annotation.RetentionPolicy
 import javax.validation.Constraint
 import kotlin.reflect.KClass
 
 
-@Documented
+@MustBeDocumented
 @Constraint(validatedBy = [MonthYearValidator::class])
 @Target(AnnotationTarget.FIELD, AnnotationTarget.ANNOTATION_CLASS)
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(AnnotationRetention.RUNTIME)
 annotation class ValidMonthYear(val message: String = "Invalid date", val groups: Array<KClass<*>> = [], val payload: Array<KClass<out Any>> = [])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
@@ -102,7 +102,7 @@ class HtmlController(@Autowired val moveService: MoveService) {
         return "dashboard"
     }
 
-    @RequestMapping(SELECT_MONTH_URL, method = [RequestMethod.GET])
+    @GetMapping(SELECT_MONTH_URL)
     fun selectMonth(@ModelAttribute(name = SUPPLIER_ATTRIBUTE) supplier: Supplier, model: ModelMap): Any {
         model.addAttribute("form", JumpToMonthForm(date = ""))
         return "select-month"
@@ -110,7 +110,7 @@ class HtmlController(@Autowired val moveService: MoveService) {
 
     data class JumpToMonthForm(@ValidMonthYear val date: String)
 
-    @RequestMapping(value = ["/select-month"], method = [RequestMethod.POST])
+    @PostMapping(SELECT_MONTH_URL)
     fun jumpToMonth(
             @Valid @ModelAttribute("form") form: JumpToMonthForm,
             result: BindingResult, model: ModelMap,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.controller
 
-import org.ocpsoft.prettytime.nlp.PrettyTimeParser
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.stereotype.Controller
@@ -17,6 +16,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.move.MoveType
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.MoveService
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.endOfMonth
+import uk.gov.justice.digital.hmpps.pecs.jpc.util.MonthYearParser
 import java.time.LocalDate
 import java.time.ZoneId
 import java.util.*
@@ -111,16 +111,13 @@ class HtmlController(@Autowired val moveService: MoveService) {
     data class JumpToMonthForm(@ValidMonthYear val date: String)
 
     @PostMapping(SELECT_MONTH_URL)
-    fun jumpToMonth(
-            @Valid @ModelAttribute("form") form: JumpToMonthForm,
-            result: BindingResult, model: ModelMap,
-    ): Any {
+    fun jumpToMonth(@Valid @ModelAttribute("form") form: JumpToMonthForm, result: BindingResult, model: ModelMap, ): Any {
         if (result.hasErrors()) {
             return "select-month"
         }
-        val date = PrettyTimeParser().parse(form.date)[0]
-        val localDate = convertToLocalDate(date)
-        model.addAttribute(DATE_ATTRIBUTE, localDate)
+
+        model.addAttribute(DATE_ATTRIBUTE, MonthYearParser.atStartOf(form.date))
+
         return RedirectView(DASHBOARD_URL)
     }
 
@@ -128,12 +125,6 @@ class HtmlController(@Autowired val moveService: MoveService) {
         return Date.from(dateToConvert.atStartOfDay()
                 .atZone(ZoneId.systemDefault())
                 .toInstant())
-    }
-
-    fun convertToLocalDate(dateToConvert: Date): LocalDate {
-        return dateToConvert.toInstant()
-                .atZone(ZoneId.systemDefault())
-                .toLocalDate()
     }
 
     companion object{

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/filter/ChooseSupplierFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/filter/ChooseSupplierFilter.kt
@@ -1,14 +1,18 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.filter
 
-import org.springframework.core.annotation.Order
-import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import java.io.IOException
-import java.time.LocalDate
-import javax.servlet.*
+import javax.servlet.Filter
+import javax.servlet.FilterChain
+import javax.servlet.FilterConfig
+import javax.servlet.ServletException
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
-class ChooseSupplierFilter : Filter {
+class ChooseSupplierFilter(private val timeSource: TimeSource) : Filter {
+
     @Throws(ServletException::class)
     override fun init(filterConfig: FilterConfig?) {
     }
@@ -21,8 +25,8 @@ class ChooseSupplierFilter : Filter {
         val supplier = session.getAttribute("supplier")
 
         if (supplier == null) {
-            session.setAttribute("date", LocalDate.now().withDayOfMonth(1))
-            res.sendRedirect("/choose-supplier");
+            session.setAttribute("date", timeSource.date().withDayOfMonth(1))
+            res.sendRedirect("/choose-supplier")
         } else {
             chain.doFilter(request, response)
         }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/ReportDateParser.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/ReportDateParser.kt
@@ -19,5 +19,5 @@ val dateConverter = object: Converter {
                 null
             }
 
-    override fun toJson(o: Any) = """"$o""""
+    override fun toJson(value: Any) = """"$value""""
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/ReportDateTimeParser.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/ReportDateTimeParser.kt
@@ -20,5 +20,5 @@ val dateTimeConverter = object: Converter {
                 throw KlaxonException("Couldn't parse date: ${jv.string}")
             }
 
-    override fun toJson(o: Any) = """"$o""""
+    override fun toJson(value: Any) = """"$value""""
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/util/MonthYearParser.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/util/MonthYearParser.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.util
+
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+
+/**
+ * Simple month and year parser supporting the following formats:
+ *
+ * M/yyyy e.g. 9/2020,
+ * MMM yyyy e.g Jan 2020
+ * MMMM yyyy e.g. October 2020.
+ *
+ * Characters can also be in mixed case. Whitespace characters at the beginning or end are also allowed.
+ */
+object MonthYearParser {
+
+    fun isValid(monthYear: String): Boolean {
+        return atStartOf(monthYear) != null
+    }
+
+    /**
+     * @return [LocalDate] at the beginning of the month for the given month and year if parsable, otherwise null.
+     */
+    fun atStartOf(monthYear: String): LocalDate? {
+        return Result.runCatching {
+            YearMonth.parse(monthYear.trim(), DateTimeFormatter.ofPattern("M/yyyy")).atDay(1)
+        }.getOrElse {
+            Result.runCatching {
+                YearMonth.parse(monthYear.trim(), DateTimeFormatterBuilder().parseCaseInsensitive().appendPattern("MMM yyyy").toFormatter()).atDay(1)
+            }.getOrElse {
+                Result.runCatching {
+                    YearMonth.parse(monthYear.trim(), DateTimeFormatterBuilder().parseCaseInsensitive().appendPattern("MMMM yyyy").toFormatter()).atDay(1)
+                }.getOrNull()
+            }
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/ChooseSupplierFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/ChooseSupplierFilterTest.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
+import uk.gov.justice.digital.hmpps.pecs.jpc.filter.ChooseSupplierFilter
+import java.time.LocalDateTime
+import javax.servlet.FilterChain
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import javax.servlet.http.HttpSession
+
+internal class ChooseSupplierFilterTest {
+
+    private val session: HttpSession = mock()
+
+    private val request: HttpServletRequest = mock()
+
+    private val response: HttpServletResponse = mock()
+
+    private val filterChain: FilterChain = mock()
+
+    private val timeSource: TimeSource = TimeSource { LocalDateTime.of(2020, 11, 18, 0, 0) }
+
+    private val filter: ChooseSupplierFilter = ChooseSupplierFilter(timeSource)
+
+    @Test
+    internal fun `filter redirects to choose supplier when no supplier selected`() {
+        whenever(request.session).thenReturn(session)
+        whenever(session.getAttribute("supplier")).thenReturn(null)
+
+        filter.doFilter(request, response, filterChain)
+
+        verify(session).getAttribute("supplier")
+        verify(session).setAttribute("date", timeSource.date().withDayOfMonth(1))
+        verify(response).sendRedirect("/choose-supplier")
+    }
+
+    @Test
+    internal fun `filter does not redirect when supplier already selected`() {
+        whenever(request.session).thenReturn(session)
+        whenever(session.getAttribute("supplier")).thenReturn("serco")
+
+        filter.doFilter(request, response, filterChain)
+
+        verify(session).getAttribute("supplier")
+        verify(session, never()).setAttribute(any(), any())
+        verify(response, never()).sendRedirect(any())
+        verify(filterChain).doFilter(request, response)
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveQueryRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveQueryRepositoryTest.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.move
 
-import junit.framework.Assert.assertFalse
-import junit.framework.Assert.assertTrue
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/util/MonthYearParserTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/util/MonthYearParserTest.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+internal class MonthYearParserTest {
+
+    @Test
+    internal fun `parse using format month digit and yyyy`() {
+        assertThat(MonthYearParser.atStartOf("6/2020")).isEqualTo(LocalDate.of(2020, 6, 1))
+        assertThat(MonthYearParser.atStartOf("06/2020")).isEqualTo(LocalDate.of(2020, 6, 1))
+        assertThat(MonthYearParser.atStartOf("10/2021")).isEqualTo(LocalDate.of(2021, 10, 1))
+        assertThat(MonthYearParser.atStartOf(" 10/2021")).isEqualTo(LocalDate.of(2021, 10, 1))
+        assertThat(MonthYearParser.atStartOf("10/2021 ")).isEqualTo(LocalDate.of(2021, 10, 1))
+        assertThat(MonthYearParser.atStartOf(" 10/2021 ")).isEqualTo(LocalDate.of(2021, 10, 1))
+        assertThat(MonthYearParser.atStartOf("13/2022")).isNull()
+    }
+
+    @Test
+    internal fun `parse using format - first 3 letter month and YYYY`() {
+        assertThat(MonthYearParser.atStartOf("jan 2019")).isEqualTo(LocalDate.of(2019, 1, 1))
+        assertThat(MonthYearParser.atStartOf(" jan 2019 ")).isEqualTo(LocalDate.of(2019, 1, 1))
+        assertThat(MonthYearParser.atStartOf("fEb 2020")).isEqualTo(LocalDate.of(2020, 2, 1))
+        assertThat(MonthYearParser.atStartOf("jAn 2021")).isEqualTo(LocalDate.of(2021, 1, 1))
+        assertThat(MonthYearParser.atStartOf("jAnu 2021")).isNull()
+    }
+
+    @Test
+    internal fun `parse using format - whole month in letters and yyyy`() {
+        assertThat(MonthYearParser.atStartOf("october 2019")).isEqualTo(LocalDate.of(2019, 10, 1))
+        assertThat(MonthYearParser.atStartOf(" october 2019 ")).isEqualTo(LocalDate.of(2019, 10, 1))
+        assertThat(MonthYearParser.atStartOf("oCtober 2020")).isEqualTo(LocalDate.of(2020, 10, 1))
+        assertThat(MonthYearParser.atStartOf("November 2021")).isEqualTo(LocalDate.of(2021, 11, 1))
+    }
+
+    @Test
+    internal fun `is valid`() {
+        assertThat(MonthYearParser.isValid("9/2020")).isTrue
+        assertThat(MonthYearParser.isValid("q/2020")).isFalse
+        assertThat(MonthYearParser.isValid("Oct 2019")).isTrue
+        assertThat(MonthYearParser.isValid("0ct 2019")).isFalse
+        assertThat(MonthYearParser.isValid("October 2019")).isTrue
+        assertThat(MonthYearParser.isValid("0ctober 2019")).isFalse
+    }
+}


### PR DESCRIPTION
Relatively low impact changes.  This removed some compilation warnings and also increases the number of pods from 1 to 2.  The report generation is still very memory intensive so don't want to go any higher.

This branch also include a fix for the jump to month page.