### PR TITLE
P4-2452 flushing data after each repository call in effort to reduce memory footprint.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/LocationAndPriceImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/LocationAndPriceImporter.kt
@@ -28,11 +28,19 @@ internal class LocationAndPriceImporter(private val priceRepository: PriceReposi
     fun import() : ExitCodeGenerator {
         return Result.runCatching {
             priceRepository.deleteAll()
+            priceRepository.flush()
+
             locationRepository.deleteAll()
+            locationRepository.flush()
 
             importService.importLocations()
+            locationRepository.flush()
+
             importService.importPrices(Supplier.GEOAMEY)
+            priceRepository.flush()
+
             importService.importPrices(Supplier.SERCO)
+            priceRepository.flush()
 
             return success
         }.onFailure { logger.error(it.stackTraceToString()) }.getOrDefault(failure)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationRepository.kt
@@ -1,9 +1,9 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.location
 
-import org.springframework.data.repository.CrudRepository
-import java.util.*
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
 
-interface LocationRepository : CrudRepository<Location, UUID> {
+interface LocationRepository : JpaRepository<Location, UUID> {
 
     fun findByNomisAgencyId(id: String) : Location?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceRepository.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.price
 
-import org.springframework.data.repository.CrudRepository
-import java.util.*
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
 
-interface PriceRepository : CrudRepository<Price, UUID> {
+interface PriceRepository : JpaRepository<Price, UUID> {
     fun deleteBySupplier(supplier: Supplier): Long
 }


### PR DESCRIPTION
Not able to prove this locally.  Need to deploy to see if this resolves an out of memory issue when importing locations and prices spreadsheets.  Will revert if it doesn't.