### PR TITLE
P4-2452 splitting out the imports further in effort to stop out of memory errors.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/JpcApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/JpcApplication.kt
@@ -5,7 +5,10 @@ import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.LocationAndPriceImporter
+import uk.gov.justice.digital.hmpps.pecs.jpc.importer.ManualLocationImporter
+import uk.gov.justice.digital.hmpps.pecs.jpc.importer.ManualPriceImporter
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.ReportsImporter
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import java.time.LocalDate
 
 @SpringBootApplication
@@ -14,8 +17,16 @@ class JpcApplication
 fun main(args: Array<String>) {
     runApplication<JpcApplication>(*args).let { context ->
         // This is a temporary solution to run an import of locations and prices then terminate bypassing the need to go to an endpoint.
-        context.environment.getProperty("import-locations-and-prices")?.let {
-            (context.getBean(LocationAndPriceImporter::class) as LocationAndPriceImporter).let { SpringApplication.exit(context, it.import()) }
+        context.environment.getProperty("import-locations")?.let {
+            (context.getBean(ManualLocationImporter::class) as ManualLocationImporter).let { SpringApplication.exit(context, it.import()) }
+        }
+
+        context.environment.getProperty("import-serco-prices")?.let {
+            (context.getBean(ManualPriceImporter::class) as ManualPriceImporter).let { SpringApplication.exit(context, it.import(Supplier.SERCO)) }
+        }
+
+        context.environment.getProperty("import-geoamey-prices")?.let {
+            (context.getBean(ManualPriceImporter::class) as ManualPriceImporter).let { SpringApplication.exit(context, it.import(Supplier.GEOAMEY)) }
         }
 
         // This is a temporary solution to run an import of both supplier reports then terminate bypassing the need to go to an endpoint.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/ManualLocationImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/ManualLocationImporter.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.importer
+
+import org.slf4j.LoggerFactory
+import org.springframework.boot.ExitCodeGenerator
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.PriceRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportService
+
+/**
+ * This should be considered a temporary component in that as soon as we no longer need to import spreadsheets this can be removed.
+ */
+@Component
+internal class ManualLocationImporter(private val priceRepository: PriceRepository,
+                                      private val locationRepository: LocationRepository,
+                                      private val importService: ImportService) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    private val success = ExitCodeGenerator { 0 }
+
+    private val failure = ExitCodeGenerator { 1 }
+
+    /**
+     * Calling this kicks off an import and returns '0' if successful or '1' if any exception is thrown (and caught).
+     */
+    fun import() : ExitCodeGenerator {
+        return Result.runCatching {
+            priceRepository.deleteAll()
+            priceRepository.flush()
+
+            locationRepository.deleteAll()
+            locationRepository.flush()
+
+            importService.importLocations()
+            locationRepository.flush()
+
+            return success
+        }.onFailure { logger.error(it.stackTraceToString()) }.getOrDefault(failure)
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/ManualPriceImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/ManualPriceImporter.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.importer
+
+import org.slf4j.LoggerFactory
+import org.springframework.boot.ExitCodeGenerator
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.PriceRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportService
+
+/**
+ * This should be considered a temporary component in that as soon as we no longer need to import spreadsheets this can be removed.
+ */
+@Component
+internal class ManualPriceImporter(private val priceRepository: PriceRepository,
+                                   private val importService: ImportService) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    private val success = ExitCodeGenerator { 0 }
+
+    private val failure = ExitCodeGenerator { 1 }
+
+    /**
+     * Calling this kicks off an import and returns '0' if successful or '1' if any exception is thrown (and caught).
+     */
+    fun import(supplier: Supplier) : ExitCodeGenerator {
+        return Result.runCatching {
+            priceRepository.deleteBySupplier(supplier)
+            priceRepository.flush()
+
+            importService.importPrices(supplier)
+            priceRepository.flush()
+
+            return success
+        }.onFailure { logger.error(it.stackTraceToString()) }.getOrDefault(failure)
+    }
+}


### PR DESCRIPTION
As it stands keeping the import of locations and prices in one call is causing out of memory errors when running on the container.  This splits out each import into a separate call to try and avoid this.