### PR TITLE
P4-2494: Add price

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
@@ -19,6 +19,8 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.service.endOfMonth
 import uk.gov.justice.digital.hmpps.pecs.jpc.util.MonthYearParser
 import java.time.LocalDate
 import javax.validation.Valid
+import javax.validation.constraints.DecimalMin
+import javax.validation.constraints.Min
 
 
 data class MonthsWidget(val currentMonth: LocalDate, val nextMonth: LocalDate, val previousMonth: LocalDate)
@@ -120,6 +122,23 @@ class HtmlController(@Autowired val moveService: MoveService) {
         return RedirectView(DASHBOARD_URL)
     }
 
+    data class PriceForm(@DecimalMin("0.0") val price: Double)
+
+    @GetMapping("$ADD_PRICE_URL/{moveId}")
+    fun addPrice(@PathVariable moveId: String, model: ModelMap): Any {
+        model.addAttribute("form", PriceForm(price = 0.0))
+        return "add-price"
+    }
+
+    @PostMapping("$ADD_PRICE_URL/{moveId}")
+    fun savePrice(@PathVariable moveId: String, @Valid @ModelAttribute("form") form: PriceForm?, result: BindingResult, model: ModelMap): Any {
+        if (result.hasErrors()) {
+            return "add-price"
+        }
+
+        return RedirectView(DASHBOARD_URL)
+    }
+
     companion object {
         const val DATE_ATTRIBUTE = "date"
         const val SUPPLIER_ATTRIBUTE = "supplier"
@@ -132,5 +151,6 @@ class HtmlController(@Autowired val moveService: MoveService) {
         const val MOVES_BY_TYPE_URL = "/moves-by-type"
         const val MOVES_URL = "/moves"
         const val JOURNEYS_URL = "/journeys"
+        const val ADD_PRICE_URL = "/add-price"
     }
 }

--- a/src/main/resources/templates/add-price.html
+++ b/src/main/resources/templates/add-price.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+
+<head>
+    <title>Calculate Journey Variable Payments - GOV.UK</title>
+</head>
+
+<body>
+
+<div class="govuk-width-container" layout:fragment="content">
+    <a href="/dashboard" class="govuk-back-link">Back</a>
+
+    <div class="mv4">
+        <h1 class="govuk-heading-xl mv2" th:inline="text">Add price</h1>
+        <p class="govuk-heading-s govuk-body govuk-!-font-weight-regular">Please add the price agreed with the supplier for this journey.</p>
+    </div>
+
+<!--    <form th:action="@{/add-price}" th:object="${form}" method="post">-->
+    <form th:action="@{/add-price/1}" th:object="${form}" method="post">
+
+        <div class="govuk-form-group" th:classappend="${#fields.hasErrors('price')} ? 'govuk-form-group--error'">
+            <ol class="list pl0">
+                <li class="mv1">
+                    <p class="govuk-label govuk-body govuk-!-font-weight-bold">Journey</p>
+                    <p th:inline="text" class="govuk-body">Location A to Loaction B</p>
+                </li>
+                <li class="mv1">
+                    <label class="govuk-label govuk-body govuk-!-font-weight-bold"
+                           for="event-name">
+                        Add price
+                    </label>
+                    <div id="event-name-hint" class="govuk-hint">
+                        Example £100.00
+                    </div>
+                    <p th:if="${#fields.hasErrors('price')}" class="govuk-error-message">
+                        <span class="govuk-visually-hidden">Error:</span> Enter a valid price in the correct
+                        format
+                    </p>
+                    <div class="govuk-input__wrapper">
+                        <div class="govuk-input__prefix" aria-hidden="true">£</div>
+                        <input class="govuk-input govuk-input--width-5" id="event-name" name="price" type="text"
+                               aria-describedby="event-name-hint" th:field="*{price}"
+                               th:classappend="${#fields.hasErrors('price')} ? 'govuk-input--error'">
+                    </div>
+                </li>
+            </ol>
+        </div>
+        <div class="govuk-warning-text mv3">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text">
+                <span class="govuk-warning-text__assistive">Warning</span>
+                <span th:inline="text">Please note the added price will be effective for all instances of this journey undertaken by in [[${supplier}]] the current contractual year.</span>
+            </strong>
+        </div>
+        <div class="flex items-center">
+            <button class="govuk-button mv3 mr3" data-module="govuk-button">
+                Confirm and save
+            </button>
+            <a href="/dashboard" class="govuk-link">Cancel</a>
+        </div>
+    </form>
+</div>
+</body>
+
+</html>

--- a/src/main/resources/templates/select-month.html
+++ b/src/main/resources/templates/select-month.html
@@ -22,8 +22,8 @@
                 <span class="db govuk-!-font-weight-bold">Enter month and year you want to view.</span>
                 For example 10/2019 or October 2019
             </div>
-            <p th:if="${#fields.hasErrors('date')}" th:errors="*{date}" class="govuk-error-message">
-                <span class="govuk-visually-hidden">Error:</span> Enter a National Insurance number in the correct
+            <p th:if="${#fields.hasErrors('date')}" class="govuk-error-message">
+                <span class="govuk-visually-hidden">Error:</span> Enter a valid month in the correct
                 format
             </p>
             <input class="govuk-input govuk-input--width-20" id="event-name" name="date" type="text"


### PR DESCRIPTION
Add price

![image](https://user-images.githubusercontent.com/1130499/100433572-39747480-30d6-11eb-9491-af1ebdb617df.png)

TODO:

- [ ] Add the "add price" link to the Journey summary page.
- [ ] Save the price for a move.
- [ ] Retrieve the move and display the location.