### PR TITLE
P4 2512 search jpc journey

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/constraint/JourneySearchConstraintValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/constraint/JourneySearchConstraintValidator.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.constraint
+
+import uk.gov.justice.digital.hmpps.pecs.jpc.controller.HtmlController
+import uk.gov.justice.digital.hmpps.pecs.jpc.util.MonthYearParser
+import javax.validation.ConstraintValidator
+import javax.validation.ConstraintValidatorContext
+
+class JourneySearchConstraintValidator : ConstraintValidator<ValidJourneySearch, HtmlController.SearchJourneyForm> {
+    override fun initialize(arg0: ValidJourneySearch) {}
+
+    override fun isValid(form: HtmlController.SearchJourneyForm, context: ConstraintValidatorContext) =
+            !form.from.isNullOrBlank() || !form.to.isNullOrBlank()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/constraint/ValidJourneySearch.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/constraint/ValidJourneySearch.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.constraint
+
+import javax.validation.Constraint
+import kotlin.reflect.KClass
+
+
+@MustBeDocumented
+@Constraint(validatedBy = [JourneySearchConstraintValidator::class])
+@Target(AnnotationTarget.TYPE, AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ValidJourneySearch(val message: String = "Please choose a pick up or drop off location", val groups: Array<KClass<*>> = [], val payload: Array<KClass<out Any>> = [])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/DistinctJourney.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/DistinctJourney.kt
@@ -2,19 +2,14 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.move
 
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
 
-data class UniqueJourney(
+data class DistinctJourney(
         val fromNomisAgencyId: String,
         val fromLocationType: LocationType?,
         val fromSiteName: String?,
         val toNomisAgencyId: String,
         val toLocationType: LocationType?,
-        val toSiteName: String?,
-        val volume: Int,
-        val unitPriceInPence: Int?,
-        val totalPriceInPence: Int?
+        val toSiteName: String?
 ) {
-    fun unitPriceInPounds() = unitPriceInPence?.let{it.toDouble() / 100}
-    fun totalPriceInPounds() = totalPriceInPence?.let{it.toDouble() / 100}
     fun fromSiteName() = fromSiteName ?: fromNomisAgencyId
     fun toSiteName() = toSiteName ?: toNomisAgencyId
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyQueryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyQueryRepository.kt
@@ -1,0 +1,142 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.move
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.RowMapper
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import java.sql.ResultSet
+import java.sql.Timestamp
+import java.time.LocalDate
+
+@Component
+class JourneyQueryRepository(@Autowired val jdbcTemplate: JdbcTemplate) {
+
+    fun distinctJourneysBySiteNames(supplier: Supplier, fromSiteName: String?, toSiteName: String?): List<DistinctJourney>{
+        val selectDistinctJourneysSQL = """
+             select distinct
+                   j.from_nomis_agency_id                                     as journey_from_nomis_agency_id,
+                   jfl.site_name                                              as journey_from_site_name,
+                   jfl.location_type                                          as journey_from_location_type,
+                   j.to_nomis_agency_id                                       as journey_to_nomis_agency_id,
+                   jtl.site_name                                              as journey_to_site_name,
+                   jtl.location_type                                          as journey_to_location_type
+            from  JOURNEYS j
+                     left join LOCATIONS jfl on j.from_nomis_agency_id = jfl.nomis_agency_id
+                     left join LOCATIONS jtl on j.to_nomis_agency_id = jtl.nomis_agency_id
+                     left join PRICES p on jfl.location_id = p.from_location_id and jtl.location_id = p.to_location_id
+            where j.supplier = ?
+        """.trimIndent() +
+                (if(fromSiteName.isNullOrBlank()) "" else  " and jfl.site_name = ? ") +
+                (if(toSiteName.isNullOrBlank()) "" else  " and jtl.site_name = ? ")
+
+
+        val distinctJourneysRowMapper = RowMapper { resultSet: ResultSet, _: Int ->
+            with(resultSet) {
+                DistinctJourney(
+                    fromNomisAgencyId = getString("journey_from_nomis_agency_id"),
+                    fromLocationType = getString("journey_from_location_type")?.let { LocationType.valueOf(it) },
+                    fromSiteName = getString("journey_from_site_name"),
+                    toNomisAgencyId = getString("journey_to_nomis_agency_id"),
+                    toLocationType = getString("journey_to_location_type")?.let { LocationType.valueOf(it) },
+                    toSiteName = getString("journey_to_site_name"),
+                )
+            }
+        }
+        val placeholders = listOf(supplier.name, fromSiteName, toSiteName).filter { !it.isNullOrBlank() }.toTypedArray()
+        return jdbcTemplate.query(selectDistinctJourneysSQL, placeholders, distinctJourneysRowMapper)
+    }
+
+    fun distinctJourneysAndPriceInDateRange(supplier: Supplier, startDate: LocalDate, endDateInclusive: LocalDate, excludePriced: Boolean = true): List<JourneyWithPrices> {
+        val journeyWithPricesRowMapper = RowMapper { resultSet: ResultSet, _: Int ->
+            with(resultSet) {
+                JourneyWithPrices(
+                    fromNomisAgencyId = getString("journey_from_nomis_agency_id"),
+                    fromLocationType = getString("journey_from_location_type")?.let { LocationType.valueOf(it) },
+                    fromSiteName = getString("journey_from_site_name"),
+                    toNomisAgencyId = getString("journey_to_nomis_agency_id"),
+                    toLocationType = getString("journey_to_location_type")?.let { LocationType.valueOf(it) },
+                    toSiteName = getString("journey_to_site_name"),
+                    volume = getInt("volume"),
+                    unitPriceInPence = getInt("unit_price_in_pence"),
+                    totalPriceInPence = getInt("total_price_in_pence")
+                )
+            }
+        }
+
+        val havingOnlyUnpriced = if(excludePriced) "HAVING max(case when p.price_in_pence is null then 1 else 0 end) > 0 " else ""
+        val uniqueJourneysSQL = """
+            select j.from_nomis_agency_id                                     as journey_from_nomis_agency_id,
+                   jfl.site_name                                              as journey_from_site_name,
+                   jfl.location_type                                          as journey_from_location_type,
+                   j.to_nomis_agency_id                                       as journey_to_nomis_agency_id,
+                   jtl.site_name                                              as journey_to_site_name,
+                   jtl.location_type                                          as journey_to_location_type,
+                   p.price_in_pence                                           as unit_price_in_pence,
+                   count (CONCAT(j.from_nomis_agency_id, ' ', j.to_nomis_agency_id)) as volume,
+                   sum(case when j.billable then p.price_in_pence else case when p.price_in_pence is null then null else 0 end end) as total_price_in_pence,
+                   sum(case when jfl.site_name is null then 3 else 0 end + case when jtl.site_name is null then 2 else 0 end + case when p.price_in_pence is null then 1 else 0 end) /
+                   count (CONCAT(j.from_nomis_agency_id, ' ', j.to_nomis_agency_id)) as null_locations_and_prices_sum
+            from MOVES m
+                     inner join JOURNEYS j on j.move_id = m.move_id
+                     left join LOCATIONS jfl on j.from_nomis_agency_id = jfl.nomis_agency_id
+                     left join LOCATIONS jtl on j.to_nomis_agency_id = jtl.nomis_agency_id
+                     left join PRICES p on jfl.location_id = p.from_location_id and jtl.location_id = p.to_location_id
+                     where m.move_type is not null and m.supplier = ? and m.drop_off_or_cancelled >= ? and m.drop_off_or_cancelled < ?
+            GROUP BY j.from_nomis_agency_id, j.to_nomis_agency_id, jfl.site_name, jtl.site_name, jfl.location_type, jtl.location_type, p.price_in_pence
+            $havingOnlyUnpriced
+            ORDER BY null_locations_and_prices_sum desc, volume desc
+        """.trimIndent()
+
+        return jdbcTemplate.query(uniqueJourneysSQL,
+                arrayOf(
+                    supplier.name,
+                    Timestamp.valueOf(startDate.atStartOfDay()),
+                    Timestamp.valueOf(endDateInclusive.plusDays(1).atStartOfDay())
+                ),
+                journeyWithPricesRowMapper)
+    }
+
+
+
+    fun journeysSummaryInDateRange(supplier: Supplier, startDate: LocalDate, endDateInclusive: LocalDate): JourneysSummary {
+        val journeysSummaryRowMapper = RowMapper { resultSet: ResultSet, _: Int ->
+            with(resultSet) {
+                JourneysSummary(
+                    supplier = supplier,
+                    count = getInt("journey_count"),
+                    totalPriceInPence = getInt("total_price_in_pence"),
+                    countWithoutLocations = getInt("count_without_locations"),
+                    countUnpriced = getInt("count_unpriced")
+                )
+            }
+        }
+
+        val journeysSummarySQL = "select count(js.journey) as journey_count,\n" +
+            "       sum(js.price_in_pence) as total_price_in_pence,\n" +
+            "       sum (js.volume_unlocationed) as count_without_locations,\n" +
+            "       sum(js.volume_unpriced) as count_unpriced from(\n" +
+            "            select distinct CONCAT(j.from_nomis_agency_id, ' ', j.to_nomis_agency_id) as journey,\n" +
+            "                            max(case when jfl.location_id is null or jtl.location_id is null then 1 else 0 end) as volume_unlocationed,\n" +
+            "                            sum(case when j.billable then p.price_in_pence else 0 end) as price_in_pence,\n" +
+            "                            max(case when p.price_in_pence is null then 1 else 0 end) as volume_unpriced\n" +
+            "             from MOVES m\n" +
+            "             inner join JOURNEYS j on j.move_id = m.move_id " +
+            "             left join LOCATIONS jfl on j.from_nomis_agency_id = jfl.nomis_agency_id\n" +
+            "             left join LOCATIONS jtl on j.to_nomis_agency_id = jtl.nomis_agency_id\n" +
+            "             left join PRICES p on jfl.location_id = p.from_location_id and jtl.location_id = p.to_location_id\n" +
+            "             where m.move_type is not null and m.supplier = ? and m.drop_off_or_cancelled >= ? and m.drop_off_or_cancelled < ? " +
+            "\n" +
+            "    GROUP BY journey) as js"
+
+        return jdbcTemplate.query(journeysSummarySQL,
+                arrayOf(
+                    supplier.name,
+                    Timestamp.valueOf(startDate.atStartOfDay()),
+                    Timestamp.valueOf(endDateInclusive.plusDays(1).atStartOfDay())
+                ),
+                journeysSummaryRowMapper)[0]
+    }
+}
+

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyWithPrices.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyWithPrices.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.move
+
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
+
+data class JourneyWithPrices(
+        val fromNomisAgencyId: String,
+        val fromLocationType: LocationType?,
+        val fromSiteName: String?,
+        val toNomisAgencyId: String,
+        val toLocationType: LocationType?,
+        val toSiteName: String?,
+        val volume: Int,
+        val unitPriceInPence: Int?,
+        val totalPriceInPence: Int?
+) {
+    fun unitPriceInPounds() = unitPriceInPence?.let{it.toDouble() / 100}
+    fun totalPriceInPounds() = totalPriceInPence?.let{it.toDouble() / 100}
+    fun fromSiteName() = fromSiteName ?: fromNomisAgencyId
+    fun toSiteName() = toSiteName ?: toNomisAgencyId
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyWithPrices.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyWithPrices.kt
@@ -17,4 +17,4 @@ data class JourneyWithPrices(
     fun totalPriceInPounds() = totalPriceInPence?.let{it.toDouble() / 100}
     fun fromSiteName() = fromSiteName ?: fromNomisAgencyId
     fun toSiteName() = toSiteName ?: toNomisAgencyId
-}
+    }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveQueryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveQueryRepository.kt
@@ -29,58 +29,10 @@ class MoveQueryRepository(@Autowired val jdbcTemplate: JdbcTemplate) {
             rowMapper)[0]
     }
 
-    fun uniqueJourneysInDateRange(supplier: Supplier, startDate: LocalDate, endDateInclusive: LocalDate, excludePriced: Boolean = true): List<UniqueJourney> {
-        val uniqueJourneysRowMapper = RowMapper<UniqueJourney> { resultSet: ResultSet, _: Int ->
-            with(resultSet) {
-                UniqueJourney(
-                    fromNomisAgencyId = getString("journey_from_nomis_agency_id"),
-                    fromLocationType = getString("journey_from_location_type")?.let { LocationType.valueOf(it) },
-                    fromSiteName = getString("journey_from_site_name"),
-                    toNomisAgencyId = getString("journey_to_nomis_agency_id"),
-                    toLocationType = getString("journey_to_location_type")?.let { LocationType.valueOf(it) },
-                    toSiteName = getString("journey_to_site_name"),
-                    volume = getInt("volume"),
-                    unitPriceInPence = getInt("unit_price_in_pence"),
-                    totalPriceInPence = getInt("total_price_in_pence")
-                )
-            }
-        }
 
-        val havingOnlyUnpriced = if(excludePriced) "HAVING max(case when p.price_in_pence is null then 1 else 0 end) > 0 " else ""
-        val uniqueJourneysSQL = """
-            select j.from_nomis_agency_id                                     as journey_from_nomis_agency_id,
-                   jfl.site_name                                              as journey_from_site_name,
-                   jfl.location_type                                          as journey_from_location_type,
-                   j.to_nomis_agency_id                                       as journey_to_nomis_agency_id,
-                   jtl.site_name                                              as journey_to_site_name,
-                   jtl.location_type                                          as journey_to_location_type,
-                   p.price_in_pence                                           as unit_price_in_pence,
-                   count (CONCAT(j.from_nomis_agency_id, ' ', j.to_nomis_agency_id)) as volume,
-                   sum(case when j.billable then p.price_in_pence else case when p.price_in_pence is null then null else 0 end end) as total_price_in_pence,
-                   sum(case when jfl.site_name is null then 3 else 0 end + case when jtl.site_name is null then 2 else 0 end + case when p.price_in_pence is null then 1 else 0 end) /
-                   count (CONCAT(j.from_nomis_agency_id, ' ', j.to_nomis_agency_id)) as null_locations_and_prices_sum
-            from MOVES m
-                     inner join JOURNEYS j on j.move_id = m.move_id
-                     left join LOCATIONS jfl on j.from_nomis_agency_id = jfl.nomis_agency_id
-                     left join LOCATIONS jtl on j.to_nomis_agency_id = jtl.nomis_agency_id
-                     left join PRICES p on jfl.location_id = p.from_location_id and jtl.location_id = p.to_location_id
-                     where m.move_type is not null and m.supplier = ? and m.drop_off_or_cancelled >= ? and m.drop_off_or_cancelled < ?
-            GROUP BY j.from_nomis_agency_id, j.to_nomis_agency_id, jfl.site_name, jtl.site_name, jfl.location_type, jtl.location_type, p.price_in_pence
-            $havingOnlyUnpriced
-            ORDER BY null_locations_and_prices_sum desc, volume desc
-        """.trimIndent()
-
-        return jdbcTemplate.query(uniqueJourneysSQL,
-                arrayOf(
-                        supplier.name,
-                        Timestamp.valueOf(startDate.atStartOfDay()),
-                        Timestamp.valueOf(endDateInclusive.plusDays(1).atStartOfDay())
-                ),
-                uniqueJourneysRowMapper)
-    }
 
     fun summariesInDateRange(supplier: Supplier, startDate: LocalDate, endDateInclusive: LocalDate, totalMoves: Int): List<MovesSummary> {
-        val movesSummaryRowMapper = RowMapper<MovesSummary> { resultSet: ResultSet, _: Int ->
+        val movesSummaryRowMapper = RowMapper { resultSet: ResultSet, _: Int ->
             with(resultSet) {
                 val count = getInt("moves_count")
                 MovesSummary(
@@ -226,45 +178,6 @@ class MoveQueryRepository(@Autowired val jdbcTemplate: JdbcTemplate) {
             val mjs = movesAndJourneys.getValue(k)
             mjs[0].move.copy(journeys = mjs.mapNotNull { it.journey }.toMutableSet())
         }
-    }
-
-    fun journeysSummaryInDateRange(supplier: Supplier, startDate: LocalDate, endDateInclusive: LocalDate): JourneysSummary {
-        val journeysSummaryRowMapper = RowMapper<JourneysSummary> { resultSet: ResultSet, _: Int ->
-            with(resultSet) {
-                JourneysSummary(
-                        supplier = supplier,
-                        count = getInt("journey_count"),
-                        totalPriceInPence = getInt("total_price_in_pence"),
-                        countWithoutLocations = getInt("count_without_locations"),
-                        countUnpriced = getInt("count_unpriced")
-                )
-            }
-        }
-
-        val journeysSummarySQL = "select count(js.journey) as journey_count,\n" +
-            "       sum(js.price_in_pence) as total_price_in_pence,\n" +
-            "       sum (js.volume_unlocationed) as count_without_locations,\n" +
-            "       sum(js.volume_unpriced) as count_unpriced from(\n" +
-            "            select distinct CONCAT(j.from_nomis_agency_id, ' ', j.to_nomis_agency_id) as journey,\n" +
-            "                            max(case when jfl.location_id is null or jtl.location_id is null then 1 else 0 end) as volume_unlocationed,\n" +
-            "                            sum(case when j.billable then p.price_in_pence else 0 end) as price_in_pence,\n" +
-            "                            max(case when p.price_in_pence is null then 1 else 0 end) as volume_unpriced\n" +
-            "             from MOVES m\n" +
-            "             inner join JOURNEYS j on j.move_id = m.move_id " +
-            "             left join LOCATIONS jfl on j.from_nomis_agency_id = jfl.nomis_agency_id\n" +
-            "             left join LOCATIONS jtl on j.to_nomis_agency_id = jtl.nomis_agency_id\n" +
-            "             left join PRICES p on jfl.location_id = p.from_location_id and jtl.location_id = p.to_location_id\n" +
-            "             where m.move_type is not null and m.supplier = ? and m.drop_off_or_cancelled >= ? and m.drop_off_or_cancelled < ? " +
-            "\n" +
-            "    GROUP BY journey) as js"
-
-        return jdbcTemplate.query(journeysSummarySQL,
-                arrayOf(
-                    supplier.name,
-                    Timestamp.valueOf(startDate.atStartOfDay()),
-                    Timestamp.valueOf(endDateInclusive.plusDays(1).atStartOfDay())
-                ),
-                journeysSummaryRowMapper)[0]
     }
 
     fun movesInDateRange(supplier: Supplier, startDate: LocalDate, endDateInclusive: LocalDate) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/JourneyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/JourneyService.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.pecs.jpc.move.*
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import java.time.LocalDate
+
+
+@Service
+class JourneyService(private val journeyQueryRepository: JourneyQueryRepository) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun distinctJourneysExcludingPriced(supplier: Supplier, startDate: LocalDate) =
+            journeyQueryRepository.distinctJourneysAndPriceInDateRange(supplier, startDate, endOfMonth(startDate))
+
+    fun distinctJourneysIncludingPriced(supplier: Supplier, startDate: LocalDate) =
+            journeyQueryRepository.distinctJourneysAndPriceInDateRange(supplier, startDate, endOfMonth(startDate), false)
+
+    fun journeysSummary(supplier: Supplier, startDate: LocalDate) =
+            journeyQueryRepository.journeysSummaryInDateRange(supplier, startDate, endOfMonth(startDate))
+
+    fun distinctJourneysBySiteNames(supplier: Supplier, fromSiteName: String?, toSiteName: String?) =
+            journeyQueryRepository.distinctJourneysBySiteNames(supplier, fromSiteName, toSiteName)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MoveService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MoveService.kt
@@ -43,12 +43,6 @@ class MoveService(private val moveQueryRepository: MoveQueryRepository, private 
         return MovesTypeSummary(moveCount, summary ?: MovesSummary(moveType))
     }
 
-    fun uniqueJourneysExcludingPriced(supplier: Supplier, startDate: LocalDate) = moveQueryRepository.uniqueJourneysInDateRange(supplier, startDate, endOfMonth(startDate))
-
-    fun uniqueJourneysIncludingPriced(supplier: Supplier, startDate: LocalDate) = moveQueryRepository.uniqueJourneysInDateRange(supplier, startDate, endOfMonth(startDate), false)
-
-    fun journeysSummary(supplier: Supplier, startDate: LocalDate) = moveQueryRepository.journeysSummaryInDateRange(supplier, startDate, endOfMonth(startDate))
-
     fun moveTypeSummaries(supplier: Supplier, startDate: LocalDate): MoveTypeSummaries {
         val endDate = endOfMonth(startDate)
         val moveCount = moveQueryRepository.moveCountInDateRange(supplier, startDate, endDate)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/JourneysSheet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/JourneysSheet.kt
@@ -2,17 +2,15 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.spreadsheet
 
 import org.apache.poi.ss.usermodel.Workbook
 import uk.gov.justice.digital.hmpps.pecs.jpc.move.Move
-import uk.gov.justice.digital.hmpps.pecs.jpc.move.MovesSummary
-import uk.gov.justice.digital.hmpps.pecs.jpc.move.UniqueJourney
-import uk.gov.justice.digital.hmpps.pecs.jpc.service.MoveTypeSummaries
+import uk.gov.justice.digital.hmpps.pecs.jpc.move.JourneyWithPrices
 
 
 class JourneysSheet(workbook: Workbook, header: Header) : PriceSheet(workbook.getSheet("Journeys")!!, header) {
 
     override fun writeMove(move: Move) {}
 
-    fun writeJourneys(journeys: List<UniqueJourney>) {
-        journeys.forEach {
+    fun writeJourneys(journeyWithPrices: List<JourneyWithPrices>) {
+        journeyWithPrices.forEach {
             val row = createRow()
             row.addCell(0, it.fromSiteName())
             row.addCell(1, it.toSiteName())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/PricesSpreadsheetGenerator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/PricesSpreadsheetGenerator.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.config.JPCTemplateProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.SercoPricesProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.JourneyService
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.MoveService
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.endOfMonth
 
@@ -22,7 +23,8 @@ class PricesSpreadsheetGenerator(@Autowired private val template: JPCTemplatePro
                                  @Autowired private val timeSource: TimeSource,
                                  @Autowired private val sercoPricesProvider: SercoPricesProvider,
                                  @Autowired private val geoameyPricesProvider: GeoameyPricesProvider,
-                                 @Autowired private val moveService: MoveService) {
+                                 @Autowired private val moveService: MoveService,
+                                 @Autowired private val journeyService: JourneyService) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -34,7 +36,7 @@ class PricesSpreadsheetGenerator(@Autowired private val template: JPCTemplatePro
             val header = PriceSheet.Header(dateGenerated, ClosedRangeLocalDate(startDate, endOfMonth(startDate)), supplier)
 
             val moves = moveService.moves(supplier, startDate)
-            val journeys = moveService.uniqueJourneysIncludingPriced(supplier, startDate)
+            val journeys = journeyService.distinctJourneysIncludingPriced(supplier, startDate)
             val summaries = moveService.moveTypeSummaries(supplier, startDate)
 
                 StandardMovesSheet(workbook, header)

--- a/src/main/resources/templates/fragments/journey-summary.html
+++ b/src/main/resources/templates/fragments/journey-summary.html
@@ -2,7 +2,7 @@
     <ul class="list pl0 flex mv0">
         <li class="w-40">
             <div class="pa3">
-                <a th:href="@{/journeyWithPrices}" class="govuk-heading-m govuk-link">Total moves by journey</a>
+                <a th:href="@{/journeys}" class="govuk-heading-m govuk-link">Total moves by journey</a>
             </div>
         </li>
         <li class="flex-auto bl">
@@ -29,7 +29,7 @@
                 <p class="govuk-heading-m mb1" th:inline="text">
                     [[${#numbers.formatDecimal(journeysSummary.count, 0, 'COMMA', 0, 'POINT')}]]</p>
                 <div>
-                    <p class="govuk-body mv0">Total unique journeyWithPrices</p>
+                    <p class="govuk-body mv0">Total unique journeys</p>
                 </div>
             </div>
         </li>

--- a/src/main/resources/templates/fragments/journey-summary.html
+++ b/src/main/resources/templates/fragments/journey-summary.html
@@ -2,7 +2,7 @@
     <ul class="list pl0 flex mv0">
         <li class="w-40">
             <div class="pa3">
-                <a th:href="@{/journeys}" class="govuk-heading-m govuk-link">Total moves by journey</a>
+                <a th:href="@{/journeyWithPrices}" class="govuk-heading-m govuk-link">Total moves by journey</a>
             </div>
         </li>
         <li class="flex-auto bl">
@@ -29,7 +29,7 @@
                 <p class="govuk-heading-m mb1" th:inline="text">
                     [[${#numbers.formatDecimal(journeysSummary.count, 0, 'COMMA', 0, 'POINT')}]]</p>
                 <div>
-                    <p class="govuk-body mv0">Total unique journeys</p>
+                    <p class="govuk-body mv0">Total unique journeyWithPrices</p>
                 </div>
             </div>
         </li>

--- a/src/main/resources/templates/fragments/journey.html
+++ b/src/main/resources/templates/fragments/journey.html
@@ -1,0 +1,8 @@
+<div th:fragment="journey">
+    <div class="ba">
+                <div class="pa3">
+                    <p th:text="${journey}">${journey}</p>
+                </div>
+            </li>
+    </div>
+</div>

--- a/src/main/resources/templates/journeys.html
+++ b/src/main/resources/templates/journeys.html
@@ -92,13 +92,12 @@
                     <td class="govuk-table__cell" scope="row" th:inline="text">[[${journey.toLocationType ?: "Not
                         mapped"}]]
                     </td>
-                    <td class="govuk-table__cell" scope="row"
-                        th:text="${false} : '???'">
+                    <td class="govuk-table__cell" scope="row" th:inline="text">[[${journey.volume}]]
                     </td>
                     <td class="govuk-table__cell" scope="row"
                         th:inline="text">
-                        <span th:if="${journey.hasPrice()}" th:inline="text">£[[${#numbers.formatDecimal(summary.totalPriceInPounds, 1, 'COMMA', 2, 'POINT')}]]</span>
-                        <span th:unless="${journey.hasPrice()}">Add price</span>
+                        <span th:unless="${journey.unitPriceInPence == 0}" th:inline="text">£[[${#numbers.formatDecimal(journey.unitPriceInPounds(), 1, 'COMMA', 2, 'POINT')}]]</span>
+                        <span th:if="${journey.unitPriceInPence == 0}">Add price</span>
                     </td>
                 </tr>
             </thbody>

--- a/src/main/resources/templates/layout/base.html
+++ b/src/main/resources/templates/layout/base.html
@@ -75,7 +75,7 @@
             </div>
         </footer>
 
-        <script src="govuk-frontend-3.9.1.min.js"></script>
+        <script src="/govuk-frontend-3.9.1.min.js"></script>
         <script>
         window.GOVUKFrontend.initAll()
 

--- a/src/main/resources/templates/layout/base.html
+++ b/src/main/resources/templates/layout/base.html
@@ -30,12 +30,9 @@
                             <li class="moj-primary-navigation__item">
                                 <a class="moj-primary-navigation__link" href="/dashboard" aria-current="page">Move summary</a>
                             </li>
-<!--                            <li class="moj-primary-navigation__item">-->
-<!--                                <a class="moj-primary-navigation__link" href="#">Managing pricing</a>-->
-<!--                            </li>-->
-<!--                            <li class="moj-primary-navigation__item">-->
-<!--                                <a class="moj-primary-navigation__link" href="#">Manage locations</a>-->
-<!--                            </li>-->
+                            <li class="moj-primary-navigation__item">
+                                <a class="moj-primary-navigation__link" href="/search-journeys">Manage Journey Price Catalogue</a>
+                            </li>
                         </ul>
                     </nav>
                 </div>

--- a/src/main/resources/templates/layout/empty.html
+++ b/src/main/resources/templates/layout/empty.html
@@ -42,7 +42,7 @@
             </div>
         </footer>
 
-        <script src="govuk-frontend-3.9.1.min.js"></script>
+        <script src="/govuk-frontend-3.9.1.min.js"></script>
         <script>
         window.GOVUKFrontend.initAll()
         </script>

--- a/src/main/resources/templates/move.html
+++ b/src/main/resources/templates/move.html
@@ -128,14 +128,14 @@
 
                 <div>
 
-                    <div th:switch="${#lists.size(move.journeys)}">
+                    <div th:switch="${#lists.size(move.journeyWithPrices)}">
                         <h2 th:case="'1'" class="govuk-heading-m ma0 pb2" th:inline="text">Journey details</h2>
                         <h2 th:case="*" class="govuk-heading-m ma0 pb2" th:inline="text">Journey [[${iter.index + 1}]]
                             of
-                            [[${#lists.size(move.journeys)}]] details</h2>
+                            [[${#lists.size(move.journeyWithPrices)}]] details</h2>
                     </div>
 
-                    <dl class="govuk-summary-list" th:each="journey, iter: ${move.journeys}">
+                    <dl class="govuk-summary-list" th:each="journey, iter: ${move.journeyWithPrices}">
                         <div class="govuk-summary-list__row">
                             <dt class="govuk-summary-list__key">
                                 Pick up location

--- a/src/main/resources/templates/move.html
+++ b/src/main/resources/templates/move.html
@@ -128,14 +128,14 @@
 
                 <div>
 
-                    <div th:switch="${#lists.size(move.journeyWithPrices)}">
+                    <div th:switch="${#lists.size(move.journeys)}">
                         <h2 th:case="'1'" class="govuk-heading-m ma0 pb2" th:inline="text">Journey details</h2>
                         <h2 th:case="*" class="govuk-heading-m ma0 pb2" th:inline="text">Journey [[${iter.index + 1}]]
                             of
-                            [[${#lists.size(move.journeyWithPrices)}]] details</h2>
+                            [[${#lists.size(move.journeys)}]] details</h2>
                     </div>
 
-                    <dl class="govuk-summary-list" th:each="journey, iter: ${move.journeyWithPrices}">
+                    <dl class="govuk-summary-list" th:each="journey, iter: ${move.journeys}">
                         <div class="govuk-summary-list__row">
                             <dt class="govuk-summary-list__key">
                                 Pick up location
@@ -202,7 +202,7 @@
                                 Journey payment
                             </dt>
                             <dd class="govuk-summary-list__value" th:inline="text">
-                                £[[${#numbers.formatDecimal(journey.priceInPence ?: 0, 1, 'COMMA', 2, 'POINT')}]]
+                                £[[${#numbers.formatDecimal(journey.priceInPounds() ?: 0, 1, 'COMMA', 2, 'POINT')}]]
                             </dd>
                         </div>
                     </dl>
@@ -211,7 +211,7 @@
 
             <div class="govuk-grid-column-one-third">
                 <h2 class="govuk-heading-m mb1 bt bw1 b--blue pt2">Move price</h2>
-                <p class="govuk-body">£[[${#numbers.formatDecimal(move.totalInPence() ?: 0, 1, 'COMMA', 2,
+                <p class="govuk-body">£[[${#numbers.formatDecimal(move.totalInPounds() ?: 0, 1, 'COMMA', 2,
                     'POINT')}]]</p>
             </div>
         </div>

--- a/src/main/resources/templates/no-search-journeys-results.html
+++ b/src/main/resources/templates/no-search-journeys-results.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+
+<head>
+    <title>Calculate Journey Variable Payments - GOV.UK</title>
+</head>
+
+<body>
+
+<div class="govuk-width-container" layout:fragment="content" th:inline="text">
+
+    <section class="mt5">
+        <h2 class="govuk-heading-m pt1 bt bw2">0 results found for <span th:text="${form.from}"/> <span th:text="${form.to}"/>
+        </h2>
+    </section>
+
+</div>
+
+</body>
+
+</html>

--- a/src/main/resources/templates/search-journeys-results.html
+++ b/src/main/resources/templates/search-journeys-results.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+
+<head>
+    <title>Calculate Journey Variable Payments - GOV.UK</title>
+</head>
+
+<body>
+
+<div class="govuk-width-container" layout:fragment="content" th:inline="text">
+
+    <section class="mt5">
+        <h2 class="govuk-heading-m pt1 bt bw2">Distinct Journeys</h2>
+        <div th:each="journey: ${journeys}">
+            <div th:replace="fragments/journey.html :: journey"></div>
+        </div>
+    </section>
+
+</div>
+
+</body>
+
+</html>

--- a/src/main/resources/templates/search-journeys.html
+++ b/src/main/resources/templates/search-journeys.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+
+<head>
+    <title>Calculate Journey Variable Payments - GOV.UK</title>
+</head>
+
+<body>
+
+<div class="govuk-width-container" layout:fragment="content">
+
+    <h1 class="govuk-heading-xl mv2 pt2" th:inline="text">Manage Journey Price Catalogue</h1>
+
+    <h2 class="govuk-heading-xl mv2 pt3" th:inline="text">Find Journeys</h2>
+
+
+    <form th:action="@{/search-journeys}" th:object="${form}" method="post">
+        <h1 class="govuk-label-wrapper">Enter pick up or drop off location</h1>
+
+        <div class="govuk-form-group" th:classappend="${#fields.hasErrors('*')} ? 'govuk-form-group--error'">
+            <p th:if="${#fields.hasErrors('*')}" class="govuk-error-message">
+                <span class="govuk-visually-hidden">Error:</span> Please enter either a pick up or drop off location
+            </p>
+
+            <label class="govuk-label govuk-label--m" for="from">Pick up location</label>
+            <input class="govuk-input govuk-input--width-20" id="from" name="from" type="text"
+                   aria-describedby="from-hint" th:field="*{from}"
+                   th:classappend="${#fields.hasErrors('from')} ? 'govuk-input--error'">
+        </div>
+
+        <div class="govuk-form-group">
+            <label class="govuk-label govuk-label--m" for="from">Drop off location</label>
+            <input class="govuk-input govuk-input--width-20" id="to" name="to" type="text"
+                   aria-describedby="to-hint" th:field="*{to}"
+                   th:classappend="${#fields.hasErrors('to')} ? 'govuk-input--error'">
+        </div>
+        <div class="flex items-center">
+            <button class="govuk-button mv3 mr3" data-module="govuk-button">
+                Find Journeys
+            </button>
+            <a href="/dashboard" class="govuk-link">Cancel</a>
+        </div>
+    </form>
+
+</div>
+
+</body>
+
+</html>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/TestConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/TestConfig.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.config.Schedule34LocationsProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.SercoPricesProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.ReportImporter
+import uk.gov.justice.digital.hmpps.pecs.jpc.move.JourneyQueryRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.move.MoveQueryRepository
 import java.time.Clock
 import java.time.Instant
@@ -32,6 +33,11 @@ class TestConfig {
     @Bean
     fun moveQueryRepository(@Qualifier("dataSource") dataSource: DataSource): MoveQueryRepository{
         return MoveQueryRepository(JdbcTemplate(dataSource))
+    }
+
+    @Bean
+    fun journeyQueryRepository(@Qualifier("dataSource") dataSource: DataSource): JourneyQueryRepository{
+        return JourneyQueryRepository(JdbcTemplate(dataSource))
     }
 
     @Bean

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyQueryRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyQueryRepositoryTest.kt
@@ -1,0 +1,135 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.move
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.Location
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Price
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.PriceRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.GNICourtLocation
+import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.WYIPrisonLocation
+import java.util.UUID
+
+@ActiveProfiles("test")
+@DataJpaTest
+@Import(TestConfig::class)
+internal class JourneyQueryRepositoryTest {
+
+    @Autowired
+    lateinit var locationRepository: LocationRepository
+
+    @Autowired
+    lateinit var priceRepository: PriceRepository
+
+    @Autowired
+    lateinit var moveRepository: MoveRepository
+
+    @Autowired
+    lateinit var journeyQueryRepository: JourneyQueryRepository
+
+    @Autowired
+    lateinit var journeyRepository: JourneyRepository
+
+
+    @Autowired
+    lateinit var entityManager: TestEntityManager
+
+    val wyi = WYIPrisonLocation()
+    val gni = GNICourtLocation()
+
+    val standardMove = move( dropOffOrCancelledDateTime = moveDate.atStartOfDay().plusHours(5)) // should appear before the one above
+    val journeyModel1 = journey()
+    val journeyModel2 = journey(journeyId = "J2")
+
+    @BeforeEach
+    fun beforeEach(){
+        locationRepository.save(wyi)
+        locationRepository.save(gni)
+        priceRepository.save(Price(id = UUID.randomUUID(), fromLocation = wyi, toLocation = gni, priceInPence = 999, supplier = Supplier.SERCO))
+
+        moveRepository.save(standardMove)
+        journeyRepository.save(journeyModel1)
+        journeyRepository.save(journeyModel2)
+
+        entityManager.flush()
+    }
+
+
+
+
+    @Test
+    fun `unique journeys and journey summaries`() {
+
+        val locationX  = Location(id = UUID.randomUUID(), locationType = LocationType.CO, nomisAgencyId = "locationX", siteName = "banana")
+        val locationY  = Location(id = UUID.randomUUID(), locationType = LocationType.CO, nomisAgencyId = "locationY", siteName = "apple")
+
+        locationRepository.save(locationX)
+        locationRepository.save(locationY)
+
+        priceRepository.save(Price(id = UUID.randomUUID(), fromLocation = wyi, toLocation = locationX, priceInPence = 201, supplier = Supplier.SERCO))
+
+        val moveWithUnbillableJourney = standardMove.copy(moveId = "M2")
+        val journey3 = journey(moveId = "M2", journeyId = "J3", billable = false, toNomisAgencyId = locationX.nomisAgencyId)
+
+        val moveWithUnmappedLocation = standardMove.copy(moveId = "M3")
+        val journey4 = journey(moveId = "M3", journeyId = "J4", billable = true, fromNomisAgencyId = "unmappedNomisAgencyId")
+
+        val moveWithUpricedLocation = standardMove.copy(moveId = "M4")
+        val journey5 = journey(moveId = "M4", journeyId = "J5", billable = true, fromNomisAgencyId = locationY.nomisAgencyId)
+
+        moveRepository.save(moveWithUnbillableJourney) // not unpriced just because journey is not billable
+        moveRepository.save(moveWithUpricedLocation) // unpriced but has location
+        moveRepository.save(moveWithUnmappedLocation) // unpriced since it has no mapped location
+
+        journeyRepository.save(journey3)
+        journeyRepository.save(journey4)
+        journeyRepository.save(journey5)
+
+        entityManager.flush()
+
+        val summaries = journeyQueryRepository.journeysSummaryInDateRange(Supplier.SERCO, moveDate, moveDate)
+        assertThat(summaries).isEqualTo(JourneysSummary(4, 1998, 1, 2, Supplier.SERCO))
+
+        val unpricedUniqueJourneys = journeyQueryRepository.distinctJourneysAndPriceInDateRange(Supplier.SERCO, moveDate, moveDate)
+        assertThat(unpricedUniqueJourneys.size).isEqualTo(2)
+
+        // Ordered by unmapped from locations first
+        assertThat(unpricedUniqueJourneys[0].fromNomisAgencyId).isEqualTo("unmappedNomisAgencyId")
+    }
+
+    @Test
+    fun `distinct journeys filtered on from location with empty to location`() {
+        val journey2 = journey(moveId = "M1", journeyId = "J2", toNomisAgencyId = "NEW")
+        journeyRepository.save(journey2)
+        entityManager.flush()
+
+        val journeys = journeyQueryRepository.distinctJourneysBySiteNames(Supplier.SERCO, "from", "")
+        assertThat(journeys).containsExactlyInAnyOrder(
+                DistinctJourney(fromNomisAgencyId="WYI", LocationType.PR, fromSiteName="from", toNomisAgencyId="GNI", LocationType.CO, toSiteName="to"),
+                DistinctJourney(fromNomisAgencyId="WYI", LocationType.PR, fromSiteName="from", toNomisAgencyId="NEW", null, toSiteName=null)
+        )
+    }
+
+    @Test
+    fun `distinct journeys filtered on to location with whitespace from location`() {
+        val journey2 = journey(moveId = "M1", journeyId = "J2", fromNomisAgencyId = "NEW", toNomisAgencyId = "GNI")
+        journeyRepository.save(journey2)
+        entityManager.flush()
+
+        val journeys = journeyQueryRepository.distinctJourneysBySiteNames(Supplier.SERCO, " ", "to")
+        assertThat(journeys).containsExactlyInAnyOrder(
+                DistinctJourney(fromNomisAgencyId="WYI", LocationType.PR, fromSiteName="from", toNomisAgencyId="GNI", LocationType.CO, toSiteName="to"),
+                DistinctJourney(fromNomisAgencyId="NEW", null, fromSiteName=null, toNomisAgencyId="GNI", LocationType.CO, toSiteName="to")
+        )
+    }
+
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveQueryRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveQueryRepositoryTest.kt
@@ -133,46 +133,6 @@ internal class MoveQueryRepositoryTest {
 
 
     @Test
-    fun `unique journeys and journey summaries`() {
-
-        val locationX  = Location(id = UUID.randomUUID(), locationType = LocationType.CO, nomisAgencyId = "locationX", siteName = "banana")
-        val locationY  = Location(id = UUID.randomUUID(), locationType = LocationType.CO, nomisAgencyId = "locationY", siteName = "apple")
-
-        locationRepository.save(locationX)
-        locationRepository.save(locationY)
-
-        priceRepository.save(Price(id = UUID.randomUUID(), fromLocation = wyi, toLocation = locationX, priceInPence = 201, supplier = Supplier.SERCO))
-
-        val moveWithUnbillableJourney = standardMove.copy(moveId = "M2")
-        val journey3 = journey(moveId = "M2", journeyId = "J3", billable = false, toNomisAgencyId = locationX.nomisAgencyId)
-
-        val moveWithUnmappedLocation = standardMove.copy(moveId = "M3")
-        val journey4 = journey(moveId = "M3", journeyId = "J4", billable = true, fromNomisAgencyId = "unmappedNomisAgencyId")
-
-        val moveWithUpricedLocation = standardMove.copy(moveId = "M4")
-        val journey5 = journey(moveId = "M4", journeyId = "J5", billable = true, fromNomisAgencyId = locationY.nomisAgencyId)
-
-        moveRepository.save(moveWithUnbillableJourney) // not unpriced just because journey is not billable
-        moveRepository.save(moveWithUpricedLocation) // unpriced but has location
-        moveRepository.save(moveWithUnmappedLocation) // unpriced since it has no mapped location
-
-        journeyRepository.save(journey3)
-        journeyRepository.save(journey4)
-        journeyRepository.save(journey5)
-
-        entityManager.flush()
-
-        val summaries = moveQueryRepository.journeysSummaryInDateRange(Supplier.SERCO, moveDate, moveDate)
-        assertThat(summaries).isEqualTo(JourneysSummary(4, 1998, 1, 2, Supplier.SERCO))
-
-        val unpricedUniqueJourneys = moveQueryRepository.uniqueJourneysInDateRange(Supplier.SERCO, moveDate, moveDate)
-        assertThat(unpricedUniqueJourneys.size).isEqualTo(2)
-
-        // Ordered by unmapped from locations first
-        assertThat(unpricedUniqueJourneys[0].fromNomisAgencyId).isEqualTo("unmappedNomisAgencyId")
-    }
-
-    @Test
     fun `moves count`() {
         val movesCount = moveQueryRepository.moveCountInDateRange(Supplier.SERCO, moveDate, moveDate)
         assertThat(movesCount).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/JourneysSheetTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/JourneysSheetTest.kt
@@ -20,7 +20,7 @@ internal class JourneysSheetTest(@Autowired private val template: JPCTemplatePro
     @Test
     internal fun `test unique journeys`() {
 
-        val journey = UniqueJourney(
+        val journey = JourneyWithPrices(
               fromNomisAgencyId = "FRO",
                 fromLocationType = LocationType.PR,
                 fromSiteName = "from",


### PR DESCRIPTION
Allow searching for one or two journeys.
No results page if there are no results.
Initial listing of results - but the rest of the work is for a different story

Fix move detail prices being in pence rather than pounds
Plus some other misc fixes for loading JS, rendering journeys.