### PR TITLE
P4-2514 adding links to navigate to map location.  Also fixing some of the back and cancel links to go back to journeys for review page.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/constraint/DuplicateLocationConstraintsValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/constraint/DuplicateLocationConstraintsValidator.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.constraint
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.pecs.jpc.controller.MapFriendlyLocationController.MapLocationForm
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.MapFriendlyLocationService
+import javax.validation.ConstraintValidator
+import javax.validation.ConstraintValidatorContext
+
+@Component
+class DuplicateLocationConstraintsValidator(val service: MapFriendlyLocationService) : ConstraintValidator<ValidDuplicateLocation?, MapLocationForm?> {
+
+  override fun initialize(arg0: ValidDuplicateLocation?) {}
+
+  override fun isValid(form: MapLocationForm?, context: ConstraintValidatorContext): Boolean {
+    return form == null || form.locationName.isEmpty() || !service.locationAlreadyExists(form.agencyId, form.locationName)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/constraint/ValidDuplicateLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/constraint/ValidDuplicateLocation.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.constraint
+
+import javax.validation.Constraint
+import kotlin.reflect.KClass
+
+
+@MustBeDocumented
+@Constraint(validatedBy = [DuplicateLocationConstraintsValidator::class])
+@Target(AnnotationTarget.TYPE, AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ValidDuplicateLocation(val message: String = "There is a problem, Schedule 34 location entered already exists, please enter a new schedule 34 location", val groups: Array<KClass<*>> = [], val payload: Array<KClass<out Any>> = [])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
@@ -5,7 +5,13 @@ import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.stereotype.Controller
 import org.springframework.ui.ModelMap
 import org.springframework.validation.BindingResult
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.SessionAttributes
 import org.springframework.web.servlet.view.RedirectView
 import uk.gov.justice.digital.hmpps.pecs.jpc.constraint.ValidJourneySearch
 import uk.gov.justice.digital.hmpps.pecs.jpc.constraint.ValidMonthYear
@@ -76,14 +82,21 @@ class HtmlController(@Autowired val moveService: MoveService, @Autowired val jou
     fun journeys(
             @ModelAttribute(name = DATE_ATTRIBUTE) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startOfMonth: LocalDate,
             @ModelAttribute(name = SUPPLIER_ATTRIBUTE) supplier: Supplier,
-            @ModelAttribute(name = "locationName") locationName: String,
-            @ModelAttribute(name = "agencyId") agencyId: String,
+            @ModelAttribute(name = "flashAttrMappedLocationName") locationName: String?,
+            @ModelAttribute(name = "flashAttrMappedAgencyId") agencyId: String?,
             model: ModelMap,
     ): String {
 
+        removeAttributesIf(locationName.isNullOrEmpty(), model, "flashAttrMappedLocationName", "flashAttrMappedAgencyId")
+
         model.addAttribute("journeysSummary", journeyService.journeysSummary(supplier, startOfMonth))
         model.addAttribute("journeys", journeyService.distinctJourneysExcludingPriced(supplier, startOfMonth))
+
         return "journeys"
+    }
+
+    private fun removeAttributesIf(condition : Boolean, model: ModelMap, vararg attributeNames: String) {
+        if (condition) attributeNames.forEach { model.remove(it) }
     }
 
     @RequestMapping(DASHBOARD_URL)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MapFriendlyLocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MapFriendlyLocationService.kt
@@ -20,7 +20,7 @@ class MapFriendlyLocationService(private val locationRepository: LocationReposit
 
   fun mapFriendlyLocation(agencyId: String, friendlyLocationName: String, locationType: LocationType) {
     locationRepository.findByNomisAgencyId(agencyId.trim().toUpperCase())?.let {
-      it.siteName = friendlyLocationName
+      it.siteName = friendlyLocationName.trim().toUpperCase()
       it.locationType = locationType
 
       locationRepository.save(it)

--- a/src/main/resources/templates/add-price.html
+++ b/src/main/resources/templates/add-price.html
@@ -10,7 +10,7 @@
 <body>
 
 <div class="govuk-width-container" layout:fragment="content">
-    <a href="/dashboard" class="govuk-back-link">Back</a>
+    <a href="/journeys" class="govuk-back-link">Back</a>
 
     <div class="mv4">
         <h1 class="govuk-heading-xl mv2" th:inline="text">Add price</h1>
@@ -58,7 +58,7 @@
             <button class="govuk-button mv3 mr3" data-module="govuk-button">
                 Confirm and save
             </button>
-            <a href="/dashboard" class="govuk-link">Cancel</a>
+            <a href="/journeys" class="govuk-link">Cancel</a>
         </div>
     </form>
 </div>

--- a/src/main/resources/templates/fragments/journey-summary.html
+++ b/src/main/resources/templates/fragments/journey-summary.html
@@ -2,7 +2,7 @@
     <ul class="list pl0 flex mv0">
         <li class="w-40">
             <div class="pa3">
-                <a th:href="@{/journeys}" class="govuk-heading-m govuk-link">Total moves by journey</a>
+                <a th:href="@{/journeys}" class="govuk-heading-m govuk-link">Journeys for review</a>
             </div>
         </li>
         <li class="flex-auto bl">

--- a/src/main/resources/templates/journeys.html
+++ b/src/main/resources/templates/journeys.html
@@ -23,16 +23,14 @@
         </ol>
     </div>
 
-    <div
-            class="ba bw2 b--green flex justify-between items-center ph4 pv3 mt2"
+    <div class="ba bw2 b--green flex justify-between items-center ph4 pv3 mt2"
             data-module="app-message"
             data-allow-dismiss tabindex="-1"
             role="alert"
             aria-labelledby="app-message__heading"
-            th:if="${mappedLocationName}"
-    >
+            th:unless="${flashAttrMappedLocationName == null}">
         <p class="govuk-heading-m govuk-!-font-weight-bold ma0" id="app-message__heading" th:inline="text">
-            [[${mappedAgencyId}]] successfully mapped to [[${mappedLocationName}]]
+            [[${flashAttrMappedAgencyId}]] successfully mapped to [[${flashAttrMappedLocationName}]]
         </p>
         <a href="/journeys" class="govuk-link">Dismiss</a>
     </div>
@@ -96,22 +94,22 @@
             </thead>
             <thbody class="govuk-table__body">
                 <tr class="govuk-table__row" th:each="journey: ${journeys}">
-                    <td class="govuk-table__cell" scope="row" th:inline="text">[[${journey.fromSiteName ?: "Not
-                        mapped"}]]
+                    <td class="govuk-table__cell" scope="row" th:inline="text">[[${journey.fromSiteName ?: journey.fromNomisAgencyId}]]</td>
+                    <td>
+                        <span th:unless="${journey.fromSiteName == null}" th:inline="text">[[${journey.fromLocationType}]]</span>
+                        <span th:if="${journey.fromSiteName == null}">
+                            <a th:href="@{'/map-location/' + ${journey.fromNomisAgencyId}}" class="ma0 govuk-link">Map location</a>
+                        </span>
                     </td>
-                    <td class="govuk-table__cell" scope="row" th:inline="text">[[${journey.fromLocationType ?: "Not
-                        mapped"}]]
+                    <td class="govuk-table__cell" scope="row" th:inline="text">[[${journey.toSiteName ?: journey.toNomisAgencyId}]]</td>
+                    <td>
+                        <span th:unless="${journey.toSiteName == null}" th:inline="text">[[${journey.toLocationType}]]</span>
+                        <span th:if="${journey.toSiteName == null}">
+                            <a th:href="@{'/map-location/' + ${journey.toNomisAgencyId}}" class="ma0 govuk-link">Map location</a>
+                        </span>
                     </td>
-                    <td class="govuk-table__cell" scope="row" th:inline="text">[[${journey.toSiteName ?: "Not
-                        mapped"}]]
-                    </td>
-                    <td class="govuk-table__cell" scope="row" th:inline="text">[[${journey.toLocationType ?: "Not
-                        mapped"}]]
-                    </td>
-                    <td class="govuk-table__cell" scope="row" th:inline="text">[[${journey.volume}]]
-                    </td>
-                    <td class="govuk-table__cell" scope="row"
-                        th:inline="text">
+                    <td class="govuk-table__cell" scope="row" th:inline="text">[[${journey.volume}]]</td>
+                    <td class="govuk-table__cell" scope="row" th:inline="text">
                         <span th:unless="${journey.unitPriceInPence == null}" th:inline="text">£[[${#numbers.formatDecimal(journey.unitPriceInPounds(), 1, 'COMMA', 2, 'POINT')}]]</span>
                         <span th:if="${journey.unitPriceInPence == null}">
                             <a th:href="@{'/add-price/' + ${journey.fromNomisAgencyId} + '-' + ${journey.toNomisAgencyId}}" class="ma0 govuk-link">Add prices</a>

--- a/src/main/resources/templates/map-location.html
+++ b/src/main/resources/templates/map-location.html
@@ -10,7 +10,7 @@
 <body>
 
 <div class="govuk-width-container" layout:fragment="content">
-    <a href="/dashboard" class="govuk-back-link">Back</a>
+    <a href="/journeys" class="govuk-back-link">Back</a>
 
     <div class="mv4">
         <div th:if="${operation == 'create'}">
@@ -24,7 +24,7 @@
     </div>
 
     <form th:action="@{/map-location}" th:object="${form}" method="post">
-        <div class="govuk-form-group" th:classappend="${#fields.hasErrors('locationName')} ? 'govuk-form-group--error'">
+        <div class="govuk-form-group" th:classappend="${#fields.hasErrors('*')} ? 'govuk-form-group--error'">
             <ol class="list pl0">
                 <li class="mv3">
                     <p class="govuk-label govuk-body govuk-!-font-weight-bold">Pick up location</p>
@@ -34,8 +34,8 @@
                 <li class="mv3">
                     <label class="govuk-label govuk-body govuk-!-font-weight-bold" for="location-name">Maps to Schedule
                         34 location</label>
-                    <p th:if="${#fields.hasErrors('locationName')}" class="govuk-error-message">
-                        <span class="govuk-visually-hidden">Error:</span> <span th:errors="*{locationName}"></span>
+                    <p th:if="${#fields.hasErrors('*')}" class="govuk-error-message">
+                        <span class="govuk-visually-hidden">Error:</span> <span th:errors="*"></span>
                     </p>
                     <input class="govuk-input govuk-input--width-20" id="location-name" name="location-name" type="text"
                            th:field="*{locationName}"
@@ -65,7 +65,7 @@
             <button class="govuk-button mv3 mr3" data-module="govuk-button">
                 Confirm and save
             </button>
-            <a href="/dashboard" class="govuk-link">Cancel</a>
+            <a href="/journeys" class="govuk-link">Cancel</a>
         </div>
     </form>
 </div>


### PR DESCRIPTION
Changes:

- Move summary page - 'Total moves by journey' renamed to 'Journeys for review'
- Wires in the navigation to the map location page from the journeys for review page.
- Displays the NOMIS agency ids instead of '**Not mapped**' in the journeys for review page.

@danielepolencic this addresses some of the issues Sangeetha has raised (I'll try and look at some more).