### PR TITLE
P4-2441 tweaked the report import command to load days individually instead of trying to do it all in one.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommands.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommands.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.importer.ManualPriceImporter
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.ReportsImporter
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import java.time.LocalDate
+import java.time.Period
 
 /**
  * These commands are a temporary measure/solution to allow manually running the import of locations, prices and reporting data.
@@ -27,10 +28,15 @@ class ImportCommands(@Autowired private val locationImporter: ManualLocationImpo
     manualPriceImporter.import(supplier)
   }
 
+  /**
+   * Due to potential the large volumes of data each day is imported as an individual import to reduce the memory footprint.
+   */
   @ShellMethod("Imports reports for both suppliers for the given dates. Date params are the in ISO date format e.g. YYYY-MM-DD.")
   fun importReports(from: LocalDate, to: LocalDate) {
     if (to.isBefore(from)) throw RuntimeException("To date must be equal to or greater than from date.")
 
-    reportsImporter.import(from, to)
+    for (i in 0..Period.between(from, to).days) {
+      reportsImporter.import(from, from.plusDays(i.toLong()))
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/ImportCommandsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/ImportCommandsTest.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.pecs.jpc.commands.ImportCommands
+import uk.gov.justice.digital.hmpps.pecs.jpc.importer.ManualLocationImporter
+import uk.gov.justice.digital.hmpps.pecs.jpc.importer.ManualPriceImporter
+import uk.gov.justice.digital.hmpps.pecs.jpc.importer.ReportsImporter
+import java.time.LocalDate
+
+internal class ImportCommandsTest {
+
+  private val locationImporter: ManualLocationImporter = mock()
+  private val manualPriceImporter: ManualPriceImporter = mock()
+  private val reportsImporter: ReportsImporter = mock()
+  private val date: LocalDate = LocalDate.EPOCH
+
+  private val commands: ImportCommands = ImportCommands(locationImporter, manualPriceImporter, reportsImporter)
+
+  @Test
+  internal fun `import one days reporting data`() {
+    commands.importReports(date, date)
+
+    verify(reportsImporter).import(date, date)
+    verify(reportsImporter, times(1)).import(any(), any())
+  }
+
+  @Test
+  internal fun `import two days reporting data`() {
+    commands.importReports(date, date.plusDays(1))
+
+    verify(reportsImporter).import(date, date)
+    verify(reportsImporter).import(date, date.plusDays(1))
+    verify(reportsImporter, times(2)).import(any(), any())
+  }
+}


### PR DESCRIPTION
Changes:

This changes the manual import-reports command to load days individually instead of trying to do all in one go to avoid potentially using larges amounts of memory if the import spans days, weeks or months.