### PR TITLE
P4-2530 Effective Date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/price/PricesSpreadsheet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/price/PricesSpreadsheet.kt
@@ -51,7 +51,9 @@ class PricesSpreadsheet(private val spreadsheet: Workbook, val supplier: Supplie
                 supplier = supplier,
                 fromLocation = fromLocation,
                 toLocation = toLocation,
-                priceInPence = price)
+                priceInPence = price,
+                effectiveYear = 2020 // TODO remove this once we're not importing from spreadhsheet anymore
+        )
     }
 
     fun addError(row: Row, error: Throwable) = errors.add(PricesSpreadsheetError(supplier, row.rowNum + ROW_OFFSET, error.cause?.cause

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/Journey.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/Journey.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.Event
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.JourneyState
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.effectiveYearForDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import javax.persistence.*
@@ -66,9 +67,12 @@ data class Journey(
         val events: MutableSet<Event> = mutableSetOf(),
 
         @Transient
-        val priceInPence: Int? = null
+        val priceInPence: Int? = null,
 
+        @Column(name = "effective_year", nullable = false       )
+        val effectiveYear: Int
         ) {
+
 
         override fun toString(): String {
                 return "JourneyModel(journeyId='$journeyId', state=$state, fromNomisAgencyId='$fromNomisAgencyId', fromSiteName=$fromSiteName, fromLocationType=$fromLocationType, toNomisAgencyId=$toNomisAgencyId, toSiteName=$toSiteName, toLocationType=$toLocationType, pickUp=$pickUpDateTime, dropOff=$dropOffDateTime, vehicleRegistation=$vehicleRegistration, billable=$billable, notes=$notes, priceInPence=$priceInPence)"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MovePersister.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MovePersister.kt
@@ -2,13 +2,14 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.move
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.*
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.effectiveYearForDate
 import java.time.LocalDate
 
 @Component
-class MovePersister(private val moveRepository: MoveRepository) {
+class MovePersister(private val moveRepository: MoveRepository, private val timeSource: TimeSource) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -138,7 +139,7 @@ class MovePersister(private val moveRepository: MoveRepository) {
                  vehicleRegistration = reportJourney.vehicleRegistration,
                  notes = reportJourneyWithEvents.events.notes(),
                  events = events.toMutableSet(),
-                 effectiveYear = pickUp?.year ?: effectiveYearForDate(moveDate ?: LocalDate.now())
+                 effectiveYear = pickUp?.year ?: effectiveYearForDate(moveDate ?: timeSource.date())
             )
         }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveQueryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveQueryRepository.kt
@@ -57,7 +57,7 @@ class MoveQueryRepository(@Autowired val jdbcTemplate: JdbcTemplate) {
             " left join JOURNEYS j on j.move_id = sm.move_id " +
             " left join LOCATIONS jfl on j.from_nomis_agency_id = jfl.nomis_agency_id " +
             " left join LOCATIONS jtl on j.to_nomis_agency_id = jtl.nomis_agency_id " +
-            " left join PRICES p on jfl.location_id = p.from_location_id and jtl.location_id = p.to_location_id " +
+            " left join PRICES p on jfl.location_id = p.from_location_id and jtl.location_id = p.to_location_id and j.effective_year = p.effective_year " +
             " where sm.move_type is not null and sm.supplier = ? and sm.drop_off_or_cancelled >= ? and sm.drop_off_or_cancelled < ? " +
             " group by sm.move_id) as s on m.move_id = s.move_id " +
             "GROUP BY m.move_type"
@@ -78,7 +78,7 @@ class MoveQueryRepository(@Autowired val jdbcTemplate: JdbcTemplate) {
         "m.first_names, m.last_name, m.date_of_birth, m.latest_nomis_booking_id, m.gender, m.ethnicity, " +
         "fl.site_name as from_site_name, fl.location_type as from_location_type, " +
         "tl.site_name as to_site_name, tl.location_type as to_location_type, " +
-        "j.journey_id, j.supplier as journey_supplier, j.client_timestamp as journey_client_timestamp, " +
+        "j.journey_id, j.effective_year, j.supplier as journey_supplier, j.client_timestamp as journey_client_timestamp, " +
         "j.updated_at as journey_updated_at, j.billable, j.vehicle_registration, j.state as journey_state, " +
         "j.from_nomis_agency_id as journey_from_nomis_agency_id, j.to_nomis_agency_id as journey_to_nomis_agency_id, " +
         "j.pick_up as journey_pick_up, j.drop_off as journey_drop_off, j.notes as journey_notes, " +
@@ -91,7 +91,7 @@ class MoveQueryRepository(@Autowired val jdbcTemplate: JdbcTemplate) {
         "left join JOURNEYS j on j.move_id = m.move_id " +
         "left join LOCATIONS jfl on j.from_nomis_agency_id = jfl.nomis_agency_id " +
         "left join LOCATIONS jtl on j.to_nomis_agency_id = jtl.nomis_agency_id " +
-        "left join PRICES p on jfl.location_id = p.from_location_id and jtl.location_id = p.to_location_id "
+        "left join PRICES p on jfl.location_id = p.from_location_id and jtl.location_id = p.to_location_id and j.effective_year = p.effective_year "
 
     val moveJourneyRowMapper = RowMapper { resultSet: ResultSet, _: Int ->
         with(resultSet) {
@@ -141,7 +141,8 @@ class MoveQueryRepository(@Autowired val jdbcTemplate: JdbcTemplate) {
                     vehicleRegistration = getString("vehicle_registration"),
                     billable = getBoolean("billable"),
                     notes = getString("journey_notes"),
-                    priceInPence = if (getInt("price_in_pence") == 0 && wasNull()) null else getInt("price_in_pence")
+                    priceInPence = if (getInt("price_in_pence") == 0 && wasNull()) null else getInt("price_in_pence"),
+                    effectiveYear = getInt("effective_year")
                 )
             }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/Price.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/Price.kt
@@ -1,13 +1,14 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.price
 
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.Location
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 import javax.persistence.*
 import javax.validation.constraints.NotNull
 
 @Entity
-@Table(name = "PRICES", indexes = [Index(name = "supplier_from_to_index", columnList = "supplier, from_location_id, to_location_id", unique = true)])
+@Table(name = "PRICES", indexes = [Index(name = "supplier_from_to_year_index", columnList = "supplier, from_location_id, to_location_id, effective_year", unique = true)])
 data class Price(
         @Id
         @Column(name = "price_id", nullable = false)
@@ -28,6 +29,9 @@ data class Price(
 
         @NotNull
         val addedAt: LocalDateTime = LocalDateTime.now(),
+
+        @Column(name = "effective_year", nullable = false)
+        val effectiveYear: Int
 ){
         fun journey() = "${fromLocation.nomisAgencyId}-${toLocation.nomisAgencyId}"
 
@@ -45,3 +49,5 @@ enum class Supplier {
 }
 
 fun <T : Enum<*>> T.equalsStringCaseInsensitive(value: String) = this.name == value.toUpperCase()
+
+fun effectiveYearForDate(date: LocalDate)= if(date.monthValue >= 9) date.year else date.year -1

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingService.kt
@@ -33,7 +33,7 @@ class SupplierPricingService(val locationRepository: LocationRepository, val pri
   fun addPriceForSupplier(supplier: Supplier, fromAgencyId: String, toAgencyId: String, price: Money) {
     val locations = getFromAndToLocationBy(fromAgencyId, toAgencyId)
 
-    priceRepository.save(Price(supplier = supplier, fromLocation = locations.first, toLocation = locations.second, priceInPence = price.pence))
+    priceRepository.save(Price(supplier = supplier, fromLocation = locations.first, toLocation = locations.second, priceInPence = price.pence, effectiveYear = 2020))
   }
 
   fun updatePriceForSupplier(supplier: Supplier, fromAgencyId: String, toAgencyId: String, agreedNewPrice: Money) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
     database: POSTGRESQL
     show-sql: false
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     database-platform: org.hibernate.dialect.PostgreSQLDialect
   datasource:
     platform: postgres

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyQueryRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyQueryRepositoryTest.kt
@@ -127,6 +127,7 @@ internal class JourneyQueryRepositoryTest {
 
         val unpricedUniqueJourneys = journeyQueryRepository.distinctJourneysAndPriceInDateRange(Supplier.SERCO, moveDate, moveDate)
         assertThat(unpricedUniqueJourneys.size).isEqualTo(1)
+        assertThat(unpricedUniqueJourneys[0].totalPriceInPence).isEqualTo(0)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MovePersisterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MovePersisterTest.kt
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Import
 
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.*
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Price
@@ -34,6 +35,9 @@ internal class MovePersisterTest {
 
     @Autowired
     lateinit var entityManager: TestEntityManager
+
+    @Autowired
+    lateinit var timeSource: TimeSource
 
     final val from: LocalDate = LocalDate.of(2020, 9, 1)
     final val to: LocalDate = LocalDate.of(2020, 9, 6)
@@ -78,7 +82,7 @@ internal class MovePersisterTest {
                 )
         )
 
-        persister = MovePersister(moveRepository)
+        persister = MovePersister(moveRepository, timeSource)
     }
 
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveQueryRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveQueryRepositoryTest.kt
@@ -59,7 +59,7 @@ internal class MoveQueryRepositoryTest {
     fun beforeEach(){
         locationRepository.save(wyi)
         locationRepository.save(gni)
-        priceRepository.save(Price(id = UUID.randomUUID(), fromLocation = wyi, toLocation = gni, priceInPence = 999, supplier = Supplier.SERCO))
+        priceRepository.save(Price(id = UUID.randomUUID(), fromLocation = wyi, toLocation = gni, priceInPence = 999, supplier = Supplier.SERCO, effectiveYear = 2020))
 
         moveRepository.save(standardMove)
         journeyRepository.save(journeyModel1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/TestMoveFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/TestMoveFactory.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.move
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.*
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.effectiveYearForDate
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -67,7 +68,8 @@ fun journey(
         billable = billable,
         priceInPence = 100,
         vehicleRegistration = "REG200",
-        notes = "some notes"
+        notes = "some notes",
+        effectiveYear = effectiveYearForDate(defaultDate)
 )
 
 fun event(eventId: String = "E1", eventType: EventType = EventType.MOVE_START, eventableId: String = move().moveId) = Event(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceTest.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.price
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+internal class PriceTest{
+
+    @Test
+    fun `Aug 31st is in previous year's effective date`(){
+        val aug31_20201 = LocalDate.of(2021, 8, 31)
+        assertThat(effectiveYearForDate(aug31_20201)).isEqualTo(2020)
+    }
+
+    @Test
+    fun `Sept 1st is in this year's effective date`(){
+        val sept1_2021 = LocalDate.of(2021, 9, 1)
+        assertThat(effectiveYearForDate(sept1_2021)).isEqualTo(2021)
+    }
+}


### PR DESCRIPTION
Update Price and Journey so they have an effective year.
Default this to 2020 for the current spreadsheet price importer.

Change journey and move queries to require the join on journey / prices to include effective_year

MovePersister persists effective_year to journey based on:
journey start event or, if not present
move date or, if not present
the current date