### PR TITLE
Fix Journey Search

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
@@ -25,9 +25,9 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.controller.HtmlController.Companion
 import uk.gov.justice.digital.hmpps.pecs.jpc.controller.HtmlController.Companion.SUPPLIER_ATTRIBUTE
 import uk.gov.justice.digital.hmpps.pecs.jpc.move.MoveType
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.effectiveYearForDate
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.JourneyService
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.MoveService
-import uk.gov.justice.digital.hmpps.pecs.jpc.service.SupplierPricingService
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.endOfMonth
 import uk.gov.justice.digital.hmpps.pecs.jpc.util.MonthYearParser
 import java.time.LocalDate
@@ -185,7 +185,9 @@ class HtmlController(@Autowired val moveService: MoveService, @Autowired val jou
             return RedirectView(SEARCH_JOURNEYS_URL)
         }
 
-        val journeys = journeyService.distinctPricedJourneys(supplier, pickUpLocation, dropOffLocation)
+        val startOfMonth = model.getAttribute(DATE_ATTRIBUTE) as LocalDate
+        val effectiveYear = effectiveYearForDate(startOfMonth)
+        val journeys = journeyService.prices(supplier, pickUpLocation, dropOffLocation, effectiveYear)
 
         if (journeys.isEmpty()) {
             model.addAttribute("pickUpLocation", pickUpLocation ?: "")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/JourneyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/JourneyService.kt
@@ -21,6 +21,6 @@ class JourneyService(private val journeyQueryRepository: JourneyQueryRepository)
     fun journeysSummary(supplier: Supplier, startDate: LocalDate) =
             journeyQueryRepository.journeysSummaryInDateRange(supplier, startDate, endOfMonth(startDate))
 
-    fun distinctPricedJourneys(supplier: Supplier, fromSiteName: String?, toSiteName: String?) =
-            journeyQueryRepository.distinctPricedJourneys(supplier, fromSiteName?.trim()?.toUpperCase(), toSiteName?.trim()?.toUpperCase())
+    fun prices(supplier: Supplier, fromSiteName: String?, toSiteName: String?, effectiveYear : Int) =
+            journeyQueryRepository.prices(supplier, fromSiteName?.trim()?.toUpperCase(), toSiteName?.trim()?.toUpperCase(), effectiveYear)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyQueryRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyQueryRepositoryTest.kt
@@ -131,25 +131,17 @@ internal class JourneyQueryRepositoryTest {
     }
 
     @Test
-    fun `distinct journeys filtered on from location with empty to location`() {
-        val journey2 = journey(moveId = "M1", journeyId = "J2", toNomisAgencyId = "NEW")
-        journeyRepository.save(journey2)
-        entityManager.flush()
-
-        val journeys = journeyQueryRepository.distinctPricedJourneys(Supplier.SERCO, "from", "")
-        assertThat(journeys).containsExactlyInAnyOrder(
+    fun `journey prices filtered on from location with empty to location`() {
+        val prices = journeyQueryRepository.prices(Supplier.SERCO, "from", "", 2020)
+        assertThat(prices).containsExactlyInAnyOrder(
                 JourneyWithPrice(fromNomisAgencyId="WYI", LocationType.PR, fromSiteName="from", toNomisAgencyId="GNI", LocationType.CO, toSiteName="to", volume = null, unitPriceInPence = 999, totalPriceInPence = null),
         )
     }
 
     @Test
     fun `distinct journeys filtered on to location with whitespace from location`() {
-        val journey2 = journey(moveId = "M1", journeyId = "J2", fromNomisAgencyId = "NEW", toNomisAgencyId = "GNI")
-        journeyRepository.save(journey2)
-        entityManager.flush()
-
-        val journeys = journeyQueryRepository.distinctPricedJourneys(Supplier.SERCO, " ", "to")
-        assertThat(journeys).containsExactlyInAnyOrder(
+        val prices = journeyQueryRepository.prices(Supplier.SERCO, " ", "to", 2020)
+        assertThat(prices).containsExactlyInAnyOrder(
                 JourneyWithPrice(fromNomisAgencyId="WYI", LocationType.PR, fromSiteName="from", toNomisAgencyId="GNI", LocationType.CO, toSiteName="to", volume = null, unitPriceInPence = 999, totalPriceInPence = null),
         )
     }


### PR DESCRIPTION
Manage JPC should show all pricing, including for journeys that haven't been made.

This commit addresses that by removing the journeys table from the query.

Also, Manage JPC now takes effective year from the currently selected year.