### PR TITLE
P4-2441 resolving days in daterange.  Should use ChronoUnit.DAYS and not Period.getDays()

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommands.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommands.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.importer.ManualPriceImporter
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.ReportsImporter
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import java.time.LocalDate
-import java.time.Period
+import java.time.temporal.ChronoUnit
 
 /**
  * These commands are a temporary measure/solution to allow manually running the import of locations, prices and reporting data.
@@ -35,8 +35,8 @@ class ImportCommands(@Autowired private val locationImporter: ManualLocationImpo
   fun importReports(from: LocalDate, to: LocalDate) {
     if (to.isBefore(from)) throw RuntimeException("To date must be equal to or greater than from date.")
 
-    for (i in 0..Period.between(from, to).days) {
-      reportsImporter.import(from.plusDays(i.toLong()), from.plusDays(i.toLong()))
+    for (i in 0..ChronoUnit.DAYS.between(from, to)) {
+      reportsImporter.import(from.plusDays(i), from.plusDays(i))
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommandsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommandsTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.pecs.jpc
+package uk.gov.justice.digital.hmpps.pecs.jpc.commands
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
@@ -35,5 +35,12 @@ internal class ImportCommandsTest {
     verify(reportsImporter).import(date, date)
     verify(reportsImporter).import(LocalDate.of(2020, 10, 1), LocalDate.of(2020, 10, 1))
     verify(reportsImporter, times(2)).import(any(), any())
+  }
+
+  @Test
+  internal fun `import spanning entire leap year of reporting data`() {
+    commands.importReports(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 12, 31))
+
+    verify(reportsImporter, times(366)).import(any(), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/filter/ChooseSupplierFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/filter/ChooseSupplierFilterTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.pecs.jpc
+package uk.gov.justice.digital.hmpps.pecs.jpc.filter
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock


### PR DESCRIPTION
Period.between(from, to).getDays() only returns the days portion.  Eg. if your daterange is 3 months and 10 days then you would get just 10 days.