### PR TITLE
P4-2514 fixing issue with template resolution.  Old method worked in IDE but not standalone JAR.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MapFriendlyLocationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MapFriendlyLocationController.kt
@@ -19,17 +19,17 @@ import javax.validation.Valid
 import javax.validation.constraints.NotEmpty
 
 @Controller
-@SessionAttributes(HtmlController.SUPPLIER_ATTRIBUTE, HtmlController.PICK_UP_ATTRIBUTE, HtmlController.DROP_OFF_ATTRIBUTE)
+@SessionAttributes(HtmlController.SUPPLIER_ATTRIBUTE, PICK_UP_ATTRIBUTE, DROP_OFF_ATTRIBUTE)
 class MapFriendlyLocationController(private val service: MapFriendlyLocationService) {
 
     @GetMapping("/map-location/{agency-id}")
     fun mapFriendlyLocation(@PathVariable("agency-id") agencyId: String, model: ModelMap): String {
-        val from = model.getAttribute(HtmlController.PICK_UP_ATTRIBUTE)
-        val to = model.getAttribute(HtmlController.DROP_OFF_ATTRIBUTE)
+        val from = model.getAttribute(PICK_UP_ATTRIBUTE)
+        val to = model.getAttribute(DROP_OFF_ATTRIBUTE)
         val url = UriComponentsBuilder.fromUriString(HtmlController.SEARCH_JOURNEYS_RESULTS_URL)
 
-        from.takeUnless { it == "" }.apply { url.queryParam(HtmlController.PICK_UP_ATTRIBUTE, from) }
-        to.takeUnless { it == "" }.apply { url.queryParam(HtmlController.DROP_OFF_ATTRIBUTE, to) }
+        from.takeUnless { it == "" }.apply { url.queryParam(PICK_UP_ATTRIBUTE, from) }
+        to.takeUnless { it == "" }.apply { url.queryParam(DROP_OFF_ATTRIBUTE, to) }
 
         model.addAttribute("cancelLink", url.build().toUriString())
 
@@ -46,17 +46,17 @@ class MapFriendlyLocationController(private val service: MapFriendlyLocationServ
 
     @PostMapping("/map-location")
     fun mapFriendlyLocation(@Valid @ModelAttribute("form") form: MapLocationForm, result: BindingResult, model: ModelMap, redirectAttributes: RedirectAttributes): String {
-        val from = model.getAttribute(HtmlController.PICK_UP_ATTRIBUTE)
-        val to = model.getAttribute(HtmlController.DROP_OFF_ATTRIBUTE)
+        val from = model.getAttribute(PICK_UP_ATTRIBUTE)
+        val to = model.getAttribute(DROP_OFF_ATTRIBUTE)
         val url = UriComponentsBuilder.fromUriString(HtmlController.SEARCH_JOURNEYS_RESULTS_URL)
 
-        from.takeUnless { it == "" }.apply { url.queryParam(HtmlController.PICK_UP_ATTRIBUTE, from) }
-        to.takeUnless { it == "" }.apply { url.queryParam(HtmlController.DROP_OFF_ATTRIBUTE, to) }
+        from.takeUnless { it == "" }.apply { url.queryParam(PICK_UP_ATTRIBUTE, from) }
+        to.takeUnless { it == "" }.apply { url.queryParam(DROP_OFF_ATTRIBUTE, to) }
 
         model.addAttribute("cancelLink", url.build().toUriString())
 
         if (result.hasErrors()) {
-            return "/map-location"
+            return "map-location"
         }
 
         service.mapFriendlyLocation(form.agencyId, form.locationName, LocationType.valueOf(form.locationType))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MapFriendlyLocationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MapFriendlyLocationControllerTest.kt
@@ -80,7 +80,7 @@ internal class MapFriendlyLocationControllerTest(@Autowired private val wac: Web
       param("locationType", "CC")
     }
             .andExpect { model { attributeHasFieldErrorCode("form", "locationName", "NotEmpty") } }
-            .andExpect { view { name("/map-location") } }
+            .andExpect { view { name("map-location") } }
             .andExpect { status { isOk } }
 
     verify(service, never()).locationAlreadyExists(any(), any())
@@ -97,7 +97,7 @@ internal class MapFriendlyLocationControllerTest(@Autowired private val wac: Web
       param("locationType", "CC")
     }
             .andExpect { model { attributeErrorCount("form", 1) } }
-            .andExpect { view { name("/map-location") } }
+            .andExpect { view { name("map-location") } }
             .andExpect { status { isOk } }
 
     verify(service).locationAlreadyExists(agencyId, "Duplicate location")


### PR DESCRIPTION
This fixes an issue whereby supplying a blank friendly name when running the application in the IDE the desired validation behaviour occurs.  However if failed when running as a standalone JAR.

A bit of digging and came across a known issue when using Thymeleaf and Spring Boot [here](https://github.com/spring-projects/spring-boot/issues/1744)