### PR TITLE
P4-22533 Improve import

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-APP_DB_URL="jdbc:postgresql://127.0.0.1:5432/jpc?user=jpc&password=letmein"
+APP_DB_URL="jdbc:postgresql://127.0.0.1:5432/jpc?reWriteBatchedInserts=true&user=jpc&password=letmein"
 BASM_BUCKET_NAME=basm
 JPC_BUCKET_NAME=jpc
 S3_ENDPOINT=http://localhost:4572

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/Event.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/Event.kt
@@ -8,7 +8,7 @@ import javax.persistence.*
 import javax.validation.constraints.NotBlank
 
 @Entity
-@Table(name = "EVENTS")
+@Table(name = "EVENTS", indexes = [Index(name = "eventable_id_index", columnList = "eventable_id", unique = false)])
 data class Event constructor(
 
         @Json(name = "id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/EventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/EventRepository.kt
@@ -7,5 +7,7 @@ interface EventRepository : JpaRepository<Event, String> {
 
     fun findAllByEventableId(eventableId: String) : List<Event>
 
+    fun findAllByEventableIdIn(eventableIds: List<String>) : List<Event>
+
     fun findByEventableIdIn(eventableIds: List<String>) : List<Event>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/Journey.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/Journey.kt
@@ -10,7 +10,7 @@ import java.time.format.DateTimeFormatter
 import javax.persistence.*
 
 @Entity
-@Table(name = "JOURNEYS")
+@Table(name = "JOURNEYS", indexes = [Index(name = "move_id_index", columnList = "move_id", unique = false)])
 data class Journey(
         @Json(name = "id")
         @Id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyRepository.kt
@@ -5,4 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface JourneyRepository : JpaRepository<Journey, String> {
 
     fun findAllByMoveId(moveId: String) : List<Journey>
+
+    fun findAllByMoveIdIn(moveIds: List<String>) : List<Journey>
+
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveRepository.kt
@@ -5,5 +5,6 @@ import java.util.*
 
 interface MoveRepository : JpaRepository<Move, String>{
 
-    fun findByProfileId(profileId : String): Optional<Move>
+    fun findAllByMoveIdIn(ids: List<String>): List<Move>
+
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/Persister.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/Persister.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.move
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+fun <T>saveFlushAndClear(repo: JpaRepository<T, String>, entities: MutableCollection<T>){
+    repo.saveAll(entities)
+    repo.flush()
+    entities.clear()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/PersonPersister.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/PersonPersister.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.move
 
 import org.slf4j.LoggerFactory
+import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.Person
@@ -16,12 +17,14 @@ class PersonPersister(private val personRepository: PersonRepository,
     fun persistPeople(people: List<Person>) {
         logger.info("Persisting ${people.size} people")
         var counter = 1
+        val peopleToSave = mutableListOf<Person>()
         people.forEach { person ->
-            Result.runCatching { personRepository.save(person)
+            Result.runCatching { peopleToSave += person
                 if (counter++ % 1000 == 0) {
-                    logger.info("Persisted $counter moves out of ${people.size} (flushing moves to the database).")
-                    personRepository.flush()
+                    logger.info("Persisted $counter people out of ${people.size} (flushing people to the database).")
+                    saveFlushAndClear(personRepository, peopleToSave)
                 }
+                saveFlushAndClear(personRepository, peopleToSave)
             }.onFailure { logger.warn("Error inserting person id ${person.personId}" + it.message) }
         }
     }
@@ -29,12 +32,14 @@ class PersonPersister(private val personRepository: PersonRepository,
     fun persistProfiles(profiles: List<Profile>) {
         logger.info("Persisting ${profiles.size} profiles")
         var counter = 1
+        val profilesToSave = mutableListOf<Profile>()
         profiles.forEach { profile ->
-            Result.runCatching { profileRepository.save(profile)
+            Result.runCatching { profilesToSave += profile
                 if (counter++ % 1000 == 0) {
-                    logger.info("Persisted $counter moves out of ${profiles.size} (flushing moves to the database).")
-                    profileRepository.flush()
+                    logger.info("Persisted $counter profiles out of ${profiles.size} (flushing profiles to the database).")
+                    saveFlushAndClear(profileRepository, profilesToSave)
                 }
+                saveFlushAndClear(profileRepository, profilesToSave)
             }.onFailure { logger.warn("Error inserting $profile" + it.message) }
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,12 @@ spring:
     hibernate:
       ddl-auto: create
     database-platform: org.hibernate.dialect.PostgreSQLDialect
+    properties:
+      hibernate.jdbc.batch_size: 5
+      hibernate.order_inserts: true
+      hibernate.order_updates: true
+      hibernate.jdbc.batch_versioned_data: true
+      hibernate.generate_statistics: false
   datasource:
     platform: postgres
     url: ${APP_DB_URL}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -52,6 +52,16 @@
     <appender-ref ref="consoleAppender"/>
   </logger>
 
+<!--  <logger name="org.hibernate.engine.jdbc.batch.internal.BatchingBatch" additivity="false" level="DEBUG">-->
+<!--    <appender-ref ref="logAppender"/>-->
+<!--    <appender-ref ref="consoleAppender"/>-->
+<!--  </logger>-->
+
+<!--  <logger name="org.hibernate" additivity="false" level="INFO">-->
+<!--    <appender-ref ref="logAppender"/>-->
+<!--    <appender-ref ref="consoleAppender"/>-->
+<!--  </logger>-->
+
   <root level="INFO">
     <appender-ref ref="logAppender"/>
   </root>

--- a/src/main/resources/templates/move.html
+++ b/src/main/resources/templates/move.html
@@ -170,7 +170,6 @@
                             </dt>
                             <dd class="govuk-summary-list__value" th:switch="${#lists.size(journey.events)}">
                                 <p th:case="'0'"></p>
-                                <p th:case="'1'" th:text="${move.events[0]}"></p>
                                 <div th:case="*">
                                     <ul class="pl2">
                                         <li th:each="event: ${journey.events}">


### PR DESCRIPTION
**ddl-auto set to create - will re-create all database tables**

Improve import speed: add batch select of moves and associated journeys and events in chunks of 100
----
Unsuccessful (but non-harmful) attempt to batch inserts / updates by adding the following to application.yml:
    properties:
      hibernate.jdbc.batch_size: 5
      hibernate.order_inserts: true
      hibernate.order_updates: true
      hibernate.jdbc.batch_versioned_data: true
      hibernate.generate_statistics: false

In conjunction with applying saveAll to a collection of entities.

MovePersister successfully improved to batch select moves and associated journeys and events in chunks of 100

Add move_id index to Journey
Add eventable_id index to Event

Fix bug in move.html where the Journey Event JSON was being displayed if there was only a single Journey Event