### PR TITLE
P4-2529 Search by move reference ID

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
@@ -157,9 +157,10 @@ class HtmlController(@Autowired val moveService: MoveService, @Autowired val jou
             result: BindingResult, model: ModelMap,
             redirectAttributes: RedirectAttributes): String {
 
-        if(form.reference.isNullOrBlank()) return "redirect:$FIND_MOVE_URL/?no-results-for="
+        val moveRef = form.reference.toUpperCase().trim()
+        if(!moveRef.matches("[A-Za-z0-9]+".toRegex())) return "redirect:$FIND_MOVE_URL/?no-results-for=invalid-reference"
 
-        val maybeMove = moveService.findMoveByReference(form.reference.toUpperCase().trim())
+        val maybeMove = moveService.findMoveByReference(moveRef)
         val uri = maybeMove.orElse(null)?.let{ "$MOVES_URL/${it.moveId}" } ?: "$FIND_MOVE_URL/?no-results-for=${form.reference}"
         return "redirect:$uri"
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveQueryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveQueryRepository.kt
@@ -167,13 +167,13 @@ class MoveQueryRepository(@Autowired val jdbcTemplate: JdbcTemplate) {
         }
     }
 
-    fun moveWithPersonAndJourneys(moveId: String): Move {
-        val movePersonJourney = jdbcTemplate.query("$moveJourneySelectSQL where m.move_id = ? ",
-            arrayOf(moveId),
+    fun moveWithPersonAndJourneys(moveId: String, supplier: Supplier): Move? {
+        val movePersonJourney = jdbcTemplate.query("$moveJourneySelectSQL where m.move_id = ? and m.supplier = ? ",
+            arrayOf(moveId, supplier.name),
             moveJourneyRowMapper).groupBy { it.move.moveId }
 
         val moves = movePersonJourney.keys.map { k -> movePersonJourney.getValue(k).move() }
-        return moves[0]
+        return if(moves.isEmpty()) null else moves[0]
     }
 
     fun movesForMoveTypeInDateRange(supplier: Supplier, moveType: MoveType, startDate: LocalDate, endDateInclusive: LocalDate, limit: Int = 50, offset: Long = 0): List<Move> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveRepository.kt
@@ -7,4 +7,5 @@ interface MoveRepository : JpaRepository<Move, String>{
 
     fun findAllByMoveIdIn(ids: List<String>): List<Move>
 
+    fun findByReference(ref: String) : Optional<Move>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveRepository.kt
@@ -1,11 +1,13 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.move
 
 import org.springframework.data.jpa.repository.JpaRepository
-import java.util.*
+import java.util.Optional
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+
 
 interface MoveRepository : JpaRepository<Move, String>{
 
     fun findAllByMoveIdIn(ids: List<String>): List<Move>
 
-    fun findByReference(ref: String) : Optional<Move>
+    fun findByReferenceAndSupplier(ref: String, supplier: Supplier) : Optional<Move>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MoveService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MoveService.kt
@@ -7,7 +7,10 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import java.time.LocalDate
 
 @Service
-class MoveService(private val moveQueryRepository: MoveQueryRepository, private val eventRepository: EventRepository) {
+class MoveService(
+        private val moveQueryRepository: MoveQueryRepository,
+        private val moveRepository: MoveRepository,
+        private val eventRepository: EventRepository) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -25,6 +28,8 @@ class MoveService(private val moveQueryRepository: MoveQueryRepository, private 
 
 
     fun moves(supplier: Supplier, startDate: LocalDate) = moveQueryRepository.movesInDateRange(supplier, startDate, endOfMonth(startDate))
+
+    fun findMoveByReference(ref: String) = moveRepository.findByReference(ref)
 
     fun movesForMoveType(supplier: Supplier, moveType: MoveType, startDate: LocalDate) =
             moveQueryRepository.movesForMoveTypeInDateRange(supplier, moveType, startDate, endOfMonth(startDate))

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -76,6 +76,11 @@
 
     <section class="mt5">
         <h2 class="govuk-heading-m pt1 bt bw2">Moves by type</h2>
+
+        <div>
+            <a th:href="@{'/find-move'}" class="govuk-heading-s govuk-link">Find by move reference ID</a>
+        </div>
+
         <div th:each="summary: ${summaries}">
             <div th:include="fragments/move-by-type.html :: move" class="mv3"></div>
         </div>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+
+<head>
+    <title>Calculate Journey Variable Payments - GOV.UK</title>
+</head>
+
+<body>
+
+<div class="govuk-width-container" layout:fragment="content">
+    <h2>Resource not found</h2>
+</div>
+</body>
+
+</html>

--- a/src/main/resources/templates/find-move.html
+++ b/src/main/resources/templates/find-move.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+
+<head>
+    <title>Calculate Journey Variable Payments - GOV.UK</title>
+</head>
+
+<body>
+
+<div class="govuk-width-container" layout:fragment="content">
+
+    <div class="mv4">
+        <h1 class="govuk-heading-xl mv2" th:inline="text">Find move by move reference ID</h1>
+    </div>
+
+
+    <form th:action="@{/find-move}" th:object="${form}" method="post">
+
+        <div class="govuk-form-group" th:classappend="${#fields.hasErrors('*')} ? 'govuk-form-group--error'">
+            <div th:switch="${#request.getParameter('no-results-for')}">
+                <p th:case="${null}"></p>
+                <p th:case="''" class="govuk-error-message">
+                    <span class="govuk-visually-hidden">Error:</span> Please enter a move reference ID
+                </p>
+                <p th:case="*" class="govuk-error-message">
+                    <span class="govuk-visually-hidden">Error:</span> Could not find move for that move reference ID
+                </p>
+            </div>
+            <ol class="pl0 list">
+                <li class="mv3">
+                    <div class="govuk-form-group">
+                        <div id="event-name-hint" class="govuk-hint">
+                            <span class="db govuk-!-font-weight-bold">Enter a move reference ID to search all moves</span>
+                            For example XRN1295V
+                        </div>
+                        <input class="govuk-input govuk-input--width-20" id="reference" name="reference" type="text"
+                               aria-describedby="from-hint" th:field="*{reference}"
+                               th:classappend="${#fields.hasErrors('reference')} ? 'govuk-input--error'">
+                    </div>
+            </ol>
+        </div>
+
+        <div class="flex items-center">
+            <button class="govuk-button mv3 mr3" data-module="govuk-button">
+                Find Move
+            </button>
+            <a href="/dashboard" class="govuk-link">Cancel</a>
+        </div>
+    </form>
+
+</div>
+
+</body>
+
+</html>

--- a/src/main/resources/templates/find-move.html
+++ b/src/main/resources/templates/find-move.html
@@ -21,8 +21,8 @@
         <div class="govuk-form-group" th:classappend="${#fields.hasErrors('*')} ? 'govuk-form-group--error'">
             <div th:switch="${#request.getParameter('no-results-for')}">
                 <p th:case="${null}"></p>
-                <p th:case="''" class="govuk-error-message">
-                    <span class="govuk-visually-hidden">Error:</span> Please enter a move reference ID
+                <p th:case="'invalid-reference'" class="govuk-error-message">
+                    <span class="govuk-visually-hidden">Error:</span> Please enter a valid move reference ID
                 </p>
                 <p th:case="*" class="govuk-error-message">
                     <span class="govuk-visually-hidden">Error:</span> Could not find move for that move reference ID

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlControllerTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.controller
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -11,14 +12,16 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.mock.web.MockHttpSession
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.ResultMatcher
+import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
-import uk.gov.justice.digital.hmpps.pecs.jpc.move.move
+import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.defaultSupplierSerco
+import uk.gov.justice.digital.hmpps.pecs.jpc.move.moveM1
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.MoveService
-import java.time.LocalDate
 import java.util.*
 
 @SpringBootTest
@@ -28,44 +31,77 @@ import java.util.*
 class HtmlControllerTest(@Autowired private val wac: WebApplicationContext) {
 
   private val mockMvc = MockMvcBuilders.webAppContextSetup(wac).build()
+  private val mockSession = MockHttpSession(wac.servletContext)
 
   @MockBean
   lateinit var moveService: MoveService
 
+  @BeforeEach
+  fun beforeEach(){
+    mockSession.setAttribute("supplier", defaultSupplierSerco)
+  }
+
+  @Test
+  internal fun `GET move with valid Move ID for supplier`(){
+    val move = moveM1()
+    whenever(moveService.moveWithPersonJourneysAndEvents(move.moveId, defaultSupplierSerco)).thenReturn(move)
+
+    mockMvc.get("/moves/${move.moveId}") { session = mockSession}
+            .andExpect { view { name("move") } }
+            .andExpect { status { isOk } }
+
+    verify(moveService).moveWithPersonJourneysAndEvents(move.moveId, defaultSupplierSerco)
+  }
+
+  @Test
+  fun `GET move with invalid Move ID for supplier`(){
+    val move = moveM1()
+    whenever(moveService.moveWithPersonJourneysAndEvents(move.moveId, defaultSupplierSerco)).thenReturn(null)
+
+    mockMvc.get("/moves/${move.moveId}") { session = mockSession}
+        .andExpect { status { isNotFound } }
+        .andExpect { view { name("error/404") } }
+
+    verify(moveService).moveWithPersonJourneysAndEvents(move.moveId, defaultSupplierSerco)
+  }
+
   @Test
   internal fun `find a move by valid lowercase reference id with whitespace correctly redirects to move details page`() {
 
-    whenever(moveService.findMoveByReference("REF1")).thenReturn(Optional.of(move()))
+    whenever(moveService.findMoveByReferenceAndSupplier("REF1", defaultSupplierSerco)).thenReturn(Optional.of(moveM1()))
 
     mockMvc.post("/find-move") {
+      session = mockSession
       param("reference", "ref1 ")
     }
             .andExpect { redirectedUrl("/moves/M1") }
             .andExpect { status { is3xxRedirection } }
 
-    verify(moveService).findMoveByReference("REF1")
+    verify(moveService).findMoveByReferenceAndSupplier("REF1", defaultSupplierSerco)
   }
 
   @Test
   internal fun `find a move by a non-existent reference id calls the move service then redirects to search form`() {
 
-    whenever(moveService.findMoveByReference("REF1")).thenReturn(Optional.of(move()))
+    whenever(moveService.findMoveByReferenceAndSupplier("REF1", defaultSupplierSerco)).thenReturn(Optional.of(moveM1()))
 
     mockMvc.post("/find-move") {
+      session = mockSession
       param("reference", "nonexistentref")
     }
             .andExpect { redirectedUrl("/find-move/?no-results-for=nonexistentref") }
             .andExpect { status { is3xxRedirection } }
 
-    verify(moveService).findMoveByReference("NONEXISTENTREF")
+    verify(moveService).findMoveByReferenceAndSupplier("NONEXISTENTREF", defaultSupplierSerco)
   }
 
   @Test
   internal fun `find a move by invalid reference id redirects to search form without calling the move service`() {
 
-    whenever(moveService.findMoveByReference("REF1")).thenReturn(Optional.of(move()))
+    whenever(moveService.findMoveByReferenceAndSupplier("REF1", defaultSupplierSerco)).thenReturn(Optional.of(moveM1()))
 
     mockMvc.post("/find-move") {
+      session = mockSession
       param("reference", "select * from moves")
     }
             .andExpect { redirectedUrl("/find-move/?no-results-for=invalid-reference") }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlControllerTest.kt
@@ -1,0 +1,61 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.controller
+
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.mock.web.MockHttpSession
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
+import uk.gov.justice.digital.hmpps.pecs.jpc.move.move
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.MoveService
+import java.time.LocalDate
+import java.util.*
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@ContextConfiguration(classes = [TestConfig::class])
+class HtmlControllerTest(@Autowired private val wac: WebApplicationContext) {
+
+  private val mockMvc = MockMvcBuilders.webAppContextSetup(wac).build()
+
+  @MockBean
+  lateinit var moveService: MoveService
+
+  @Test
+  internal fun `find a move by valid reference id redirects to move details page`() {
+
+    whenever(moveService.findMoveByReference("REF1")).thenReturn(Optional.of(move()))
+
+    mockMvc.post("/find-move") {
+      param("reference", "REF1")
+    }
+            .andExpect { redirectedUrl("/moves/M1") }
+            .andExpect { status { is3xxRedirection } }
+
+    verify(moveService).findMoveByReference("REF1")
+  }
+
+  @Test
+  internal fun `find a move by invalid reference id redirects to search form`() {
+
+    whenever(moveService.findMoveByReference("REF1")).thenReturn(Optional.of(move()))
+
+    mockMvc.post("/find-move") {
+      param("reference", "BAD_REF")
+    }
+            .andExpect { redirectedUrl("/find-move/?no-results-for=BAD_REF") }
+            .andExpect { status { is3xxRedirection } }
+
+    verify(moveService).findMoveByReference("BAD_REF")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/ReportMoveTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/ReportMoveTest.kt
@@ -2,14 +2,14 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.importer.report
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.pecs.jpc.move.journey
-import uk.gov.justice.digital.hmpps.pecs.jpc.move.move
+import uk.gov.justice.digital.hmpps.pecs.jpc.move.journeyJ1
+import uk.gov.justice.digital.hmpps.pecs.jpc.move.moveM1
 
 internal class ReportMoveTest{
 
     @Test
     fun `Move model without journeys should have a null price`(){
-        val move = move()
+        val move = moveM1()
         assertThat(move.hasPrice()).isFalse
         assertThat(move.totalInPence()).isNull()
         assertThat(move.totalInPounds()).isNull()
@@ -18,7 +18,7 @@ internal class ReportMoveTest{
 
     @Test
     fun `Move model with a billable journey should be priced`(){
-        val move = move(journeys = listOf(journey()))
+        val move = moveM1(journeys = listOf(journeyJ1()))
         assertThat(move.hasPrice()).isTrue
         assertThat(move.totalInPence()).isEqualTo(100)
         assertThat(move.totalInPounds()).isEqualTo(1.0)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/TestReportFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/TestReportFactory.kt
@@ -2,10 +2,7 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.importer.report
 
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.Location
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
-import uk.gov.justice.digital.hmpps.pecs.jpc.move.Journey
-import uk.gov.justice.digital.hmpps.pecs.jpc.move.JourneyState
-import uk.gov.justice.digital.hmpps.pecs.jpc.move.Move
-import uk.gov.justice.digital.hmpps.pecs.jpc.move.MoveStatus
+import uk.gov.justice.digital.hmpps.pecs.jpc.move.*
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -22,7 +19,8 @@ const val defaultJourneyEventId="JE1"
 const val defaultProfileId="PR1"
 const val defaultPersonId="PE1"
 
-val defaultSupplier =  Supplier.SERCO
+val defaultSupplierSerco =  Supplier.SERCO
+val defaultMoveTypeStandard = MoveType.STANDARD
 
 fun fromPrisonNomisAgencyId() = "WYI"
 fun WYIPrisonLocation() = Location(id = UUID.randomUUID(), locationType = LocationType.PR, nomisAgencyId = "WYI", siteName = "from")
@@ -34,7 +32,7 @@ fun notMappedNomisAgencyId() =  "NOT_MAPPED_AGENCY_ID"
 
 fun reportMoveFactory(
         moveId: String = defaultMoveId,
-        supplier: Supplier = defaultSupplier,
+        supplier: Supplier = defaultSupplierSerco,
         profileId: String = defaultProfileId,
         status: MoveStatus = MoveStatus.completed,
         fromLocation: String = fromPrisonNomisAgencyId(),
@@ -92,7 +90,7 @@ fun moveEventFactory(
         eventId : String = defaultMoveEventId,
         moveId: String = defaultMoveId,
         type: String = EventType.MOVE_CANCEL.value,
-        supplier: Supplier = defaultSupplier,
+        supplier: Supplier = defaultSupplierSerco,
         occurredAt: LocalDateTime = defaultDateTime,
         notes: String = ""
 ): Event {
@@ -114,7 +112,7 @@ fun reportJourneyFactory(
         journeyId: String = defaultJourneyId,
         moveId: String = defaultMoveId,
         state: JourneyState = JourneyState.completed,
-        supplier: Supplier = defaultSupplier,
+        supplier: Supplier = defaultSupplierSerco,
         billable: Boolean = false,
         fromLocation: String = fromPrisonNomisAgencyId(),
         toLocation : String = toCourtNomisAgencyId(),
@@ -143,7 +141,7 @@ fun journeyEventFactory(
         journeyEventId: String = defaultJourneyEventId,
         journeyId: String = defaultJourneyId,
         type: String = EventType.JOURNEY_START.value,
-        supplier: Supplier = defaultSupplier,
+        supplier: Supplier = defaultSupplierSerco,
         occurredAt: LocalDateTime = defaultDateTime,
         notes: String = ""
 ): Event {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyQueryRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyQueryRepositoryTest.kt
@@ -46,9 +46,9 @@ internal class JourneyQueryRepositoryTest {
     val wyi = WYIPrisonLocation()
     val gni = GNICourtLocation()
 
-    val standardMove = move( dropOffOrCancelledDateTime = moveDate.atStartOfDay().plusHours(5)) // should appear before the one above
-    val journeyModel1 = journey()
-    val journeyModel2 = journey(journeyId = "J2")
+    val standardMove = moveM1( dropOffOrCancelledDateTime = defaultMoveDate10Sep2020.atStartOfDay().plusHours(5)) // should appear before the one above
+    val journeyModel1 = journeyJ1()
+    val journeyModel2 = journeyJ1(journeyId = "J2")
 
     @BeforeEach
     fun beforeEach(){
@@ -78,13 +78,13 @@ internal class JourneyQueryRepositoryTest {
         priceRepository.save(Price(id = UUID.randomUUID(), fromLocation = wyi, toLocation = locationX, priceInPence = 201, supplier = Supplier.SERCO, effectiveYear = 2020))
 
         val moveWithNonBillableJourney = standardMove.copy(moveId = "M2")
-        val journey3 = journey(moveId = "M2", journeyId = "J3", billable = false, toNomisAgencyId = locationX.nomisAgencyId)
+        val journey3 = journeyJ1(moveId = "M2", journeyId = "J3", billable = false, toNomisAgencyId = locationX.nomisAgencyId)
 
         val moveWithUnmappedLocation = standardMove.copy(moveId = "M3")
-        val journey4 = journey(moveId = "M3", journeyId = "J4", billable = true, fromNomisAgencyId = "unmappedNomisAgencyId")
+        val journey4 = journeyJ1(moveId = "M3", journeyId = "J4", billable = true, fromNomisAgencyId = "unmappedNomisAgencyId")
 
         val moveWithUpricedJourney = standardMove.copy(moveId = "M4")
-        val journey5 = journey(moveId = "M4", journeyId = "J5", billable = true, fromNomisAgencyId = locationY.nomisAgencyId)
+        val journey5 = journeyJ1(moveId = "M4", journeyId = "J5", billable = true, fromNomisAgencyId = locationY.nomisAgencyId)
 
         moveRepository.save(moveWithNonBillableJourney) // not unpriced just because journey is not billable
         moveRepository.save(moveWithUpricedJourney) // unpriced in 2020, but priced in 2021
@@ -96,10 +96,10 @@ internal class JourneyQueryRepositoryTest {
 
         entityManager.flush()
 
-        val summaries = journeyQueryRepository.journeysSummaryInDateRange(Supplier.SERCO, moveDate, moveDate)
+        val summaries = journeyQueryRepository.journeysSummaryInDateRange(Supplier.SERCO, defaultMoveDate10Sep2020, defaultMoveDate10Sep2020)
         assertThat(summaries).isEqualTo(JourneysSummary(4, 1998, 1, 2, Supplier.SERCO))
 
-        val unpricedUniqueJourneys = journeyQueryRepository.distinctJourneysAndPriceInDateRange(Supplier.SERCO, moveDate, moveDate)
+        val unpricedUniqueJourneys = journeyQueryRepository.distinctJourneysAndPriceInDateRange(Supplier.SERCO, defaultMoveDate10Sep2020, defaultMoveDate10Sep2020)
         assertThat(unpricedUniqueJourneys.size).isEqualTo(2)
 
         // Ordered by unmapped from locations first
@@ -115,17 +115,17 @@ internal class JourneyQueryRepositoryTest {
         priceRepository.save(Price(id = UUID.randomUUID(), fromLocation = locationY, toLocation = gni, priceInPence = 999, supplier = Supplier.SERCO, effectiveYear = 2021))
 
         val moveWithUpriced2020Journey = standardMove.copy(moveId = "M2")
-        val journeyNotPricedFor2020 = journey(moveId = "M2", journeyId = "J2", billable = true, fromNomisAgencyId = locationY.nomisAgencyId)
+        val journeyNotPricedFor2020 = journeyJ1(moveId = "M2", journeyId = "J2", billable = true, fromNomisAgencyId = locationY.nomisAgencyId)
 
         moveRepository.save(moveWithUpriced2020Journey)
         journeyRepository.save(journeyNotPricedFor2020)
 
         entityManager.flush()
 
-        val summaries = journeyQueryRepository.journeysSummaryInDateRange(Supplier.SERCO, moveDate, moveDate)
+        val summaries = journeyQueryRepository.journeysSummaryInDateRange(Supplier.SERCO, defaultMoveDate10Sep2020, defaultMoveDate10Sep2020)
         assertThat(summaries).isEqualTo(JourneysSummary(2, 999, 0, 1, Supplier.SERCO))
 
-        val unpricedUniqueJourneys = journeyQueryRepository.distinctJourneysAndPriceInDateRange(Supplier.SERCO, moveDate, moveDate)
+        val unpricedUniqueJourneys = journeyQueryRepository.distinctJourneysAndPriceInDateRange(Supplier.SERCO, defaultMoveDate10Sep2020, defaultMoveDate10Sep2020)
         assertThat(unpricedUniqueJourneys.size).isEqualTo(1)
         assertThat(unpricedUniqueJourneys[0].totalPriceInPence).isEqualTo(0)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveRepositoryTest.kt
@@ -20,7 +20,7 @@ internal class MoveRepositoryTest {
     @Test
     fun `save report model`() {
 
-        val move = move().copy(notes = "adfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffs" +
+        val move = moveM1().copy(notes = "adfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffs" +
                 "fasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfas" +
                 "adfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaf" +
                 "fsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaff" +
@@ -32,9 +32,9 @@ internal class MoveRepositoryTest {
                 "afafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaf" +
                 "fsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafa" +
                 "fsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfas")
-        val journeyModel = journey(moveId = move.moveId, events = listOf(event(eventId = "E1", eventableId = journey().journeyId)))
+        val journeyModel = journeyJ1(moveId = move.moveId, events = listOf(eventE1(eventId = "E1", eventableId = journeyJ1().journeyId)))
         val moveModel = move.copy(
-            events = listOf(event(eventId = "E2", eventableId = move.moveId)),
+            events = listOf(eventE1(eventId = "E2", eventableId = move.moveId)),
             journeys = listOf(journeyModel)
         )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/TestMoveFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/TestMoveFactory.kt
@@ -7,9 +7,9 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.price.effectiveYearForDate
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-val moveDate = LocalDate.of(2020, 9, 10)
+val defaultMoveDate10Sep2020 = LocalDate.of(2020, 9, 10)
 
-fun person() = Person(
+fun personPE1() = Person(
         personId = "PE1",
         updatedAt = defaultDateTime,
         prisonNumber = "PR101",
@@ -20,18 +20,18 @@ fun person() = Person(
         dateOfBirth = LocalDate.of(1980, 12, 25),
 )
 
-fun profile() = Profile(
+fun profilePR1() = Profile(
         profileId = "PR1",
         personId = "PE1",
         updatedAt = defaultDateTime
 )
 
-fun move(
+fun moveM1(
         moveId: String = "M1",
         fromNomisAgencyId: String = "WYI",
         toNomisAgencyId: String = "GNI",
-        dropOffOrCancelledDateTime: LocalDateTime = moveDate.atStartOfDay().plusHours(10),
-        person: Person? = person(),
+        dropOffOrCancelledDateTime: LocalDateTime = defaultMoveDate10Sep2020.atStartOfDay().plusHours(10),
+        person: Person? = personPE1(),
         journeys: List<Journey> = listOf()
 ) = Move(
         moveId = moveId,
@@ -41,14 +41,14 @@ fun move(
         moveType = MoveType.STANDARD,
         status = MoveStatus.completed,
         reference = "REF1",
-        moveDate = moveDate,
+        moveDate = defaultMoveDate10Sep2020,
         fromNomisAgencyId = fromNomisAgencyId,
         fromSiteName = "from",
         fromLocationType = LocationType.PR,
         toNomisAgencyId = toNomisAgencyId,
         toSiteName = "to",
         toLocationType = LocationType.PR,
-        pickUpDateTime = moveDate.atStartOfDay(),
+        pickUpDateTime = defaultMoveDate10Sep2020.atStartOfDay(),
         dropOffOrCancelledDateTime = dropOffOrCancelledDateTime,
         reportFromLocationType = "prison",
         reportToLocationType = null,
@@ -57,19 +57,19 @@ fun move(
         person = person,
         journeys = journeys)
 
-fun journey(
-        moveId: String = move().moveId,
+fun journeyJ1(
+        moveId: String = moveM1().moveId,
         journeyId: String = "J1",
         fromNomisAgencyId: String = "WYI",
         toNomisAgencyId: String = "GNI",
         state: JourneyState = JourneyState.completed,
         billable: Boolean = true,
-        pickUpDateTime: LocalDateTime? = moveDate.atStartOfDay(),
-        dropOffDateTime: LocalDateTime? = moveDate.atStartOfDay().plusHours(10),
+        pickUpDateTime: LocalDateTime? = defaultMoveDate10Sep2020.atStartOfDay(),
+        dropOffDateTime: LocalDateTime? = defaultMoveDate10Sep2020.atStartOfDay().plusHours(10),
         events: List<Event> = listOf()
 ) = Journey(
         journeyId = journeyId,
-        supplier = move().supplier,
+        supplier = moveM1().supplier,
         clientTimeStamp = defaultDateTime,
         updatedAt = defaultDateTime,
         state = state,
@@ -91,14 +91,14 @@ fun journey(
         )
 )
 
-fun event(eventId: String = "E1", eventType: EventType = EventType.MOVE_START, eventableId: String = move().moveId) = Event(
+fun eventE1(eventId: String = "E1", eventType: EventType = EventType.MOVE_START, eventableId: String = moveM1().moveId) = Event(
         eventId = eventId,
         updatedAt = defaultDateTime,
         type = eventType.value,
         eventableType = "move",
         eventableId = eventableId,
-        occurredAt = moveDate.atStartOfDay(),
-        recordedAt = moveDate.atStartOfDay(),
+        occurredAt = defaultMoveDate10Sep2020.atStartOfDay(),
+        recordedAt = defaultMoveDate10Sep2020.atStartOfDay(),
         notes = null,
         details = null,
         supplier = Supplier.SERCO

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MoveServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MoveServiceTest.kt
@@ -11,6 +11,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
 import uk.gov.justice.digital.hmpps.pecs.jpc.move.*
+import java.util.*
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -24,9 +25,12 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.move.*
     @MockBean
     lateinit var eventRepository: EventRepository
 
+    @MockBean
+    lateinit var moveRepository: MoveRepository
+
     @Test
     fun `move by move id`(){
-        val service = MoveService(moveQueryRepository, eventRepository)
+        val service = MoveService(moveQueryRepository, moveRepository, eventRepository)
         val journey = journey()
         val move = move(journeys = listOf(journey))
 
@@ -38,6 +42,18 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.move.*
         val retrievedMpve = service.moveWithPersonJourneysAndEvents("M1")
         assertThat(retrievedMpve).isEqualTo(move)
         assertThat(retrievedMpve.events).containsExactly(moveEvent)
+
+    }
+
+    @Test
+    fun `find move by move reference`(){
+        val service = MoveService(moveQueryRepository, moveRepository, eventRepository)
+
+        val move = move()
+        whenever(moveRepository.findByReference(eq("REF1"))).thenReturn(Optional.of(move))
+
+        val retrievedMpve = service.findMoveByReference("REF1")
+        assertThat(retrievedMpve).isEqualTo(Optional.of(move))
 
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MoveServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MoveServiceTest.kt
@@ -10,6 +10,7 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
+import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.defaultSupplierSerco
 import uk.gov.justice.digital.hmpps.pecs.jpc.move.*
 import java.util.*
 
@@ -31,17 +32,17 @@ import java.util.*
     @Test
     fun `move by move id`(){
         val service = MoveService(moveQueryRepository, moveRepository, eventRepository)
-        val journey = journey()
-        val move = move(journeys = listOf(journey))
+        val journey = journeyJ1()
+        val move = moveM1(journeys = listOf(journey))
 
-        val moveEvent = event()
+        val moveEvent = eventE1()
 
-        whenever(moveQueryRepository.moveWithPersonAndJourneys(eq("M1"))).thenReturn(move)
+        whenever(moveQueryRepository.moveWithPersonAndJourneys(eq("M1"), eq(defaultSupplierSerco))).thenReturn(move)
         whenever(eventRepository.findAllByEventableId(eq("M1"))).thenReturn(listOf(moveEvent))
 
-        val retrievedMpve = service.moveWithPersonJourneysAndEvents("M1")
+        val retrievedMpve = service.moveWithPersonJourneysAndEvents("M1", defaultSupplierSerco)
         assertThat(retrievedMpve).isEqualTo(move)
-        assertThat(retrievedMpve.events).containsExactly(moveEvent)
+        assertThat(retrievedMpve?.events).containsExactly(moveEvent)
 
     }
 
@@ -49,10 +50,10 @@ import java.util.*
     fun `find move by move reference`(){
         val service = MoveService(moveQueryRepository, moveRepository, eventRepository)
 
-        val move = move()
-        whenever(moveRepository.findByReference(eq("REF1"))).thenReturn(Optional.of(move))
+        val move = moveM1()
+        whenever(moveRepository.findByReferenceAndSupplier(eq("REF1"), eq(defaultSupplierSerco))).thenReturn(Optional.of(move))
 
-        val retrievedMpve = service.findMoveByReference("REF1")
+        val retrievedMpve = service.findMoveByReferenceAndSupplier("REF1", defaultSupplierSerco)
         assertThat(retrievedMpve).isEqualTo(Optional.of(move))
 
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/CancelledMovesSheetTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/CancelledMovesSheetTest.kt
@@ -21,9 +21,9 @@ internal class CancelledMovesSheetTest(@Autowired private val template: JPCTempl
 
     @Test
     internal fun `test cancelled prices`() {
-        val move = move(journeys = listOf(journey(state = JourneyState.cancelled)))
+        val move = moveM1(journeys = listOf(journeyJ1(state = JourneyState.cancelled)))
         val moves = listOf(move)
-        val sheet = CancelledMovesSheet(workbook, PriceSheet.Header(moveDate, ClosedRangeLocalDate(moveDate, moveDate), Supplier.SERCO))
+        val sheet = CancelledMovesSheet(workbook, PriceSheet.Header(defaultMoveDate10Sep2020, ClosedRangeLocalDate(defaultMoveDate10Sep2020, defaultMoveDate10Sep2020), Supplier.SERCO))
         sheet.writeMoves(moves)
 
         assertCellEquals(sheet, 10, 0, "REF1")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/JourneysSheetTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/JourneysSheetTest.kt
@@ -32,7 +32,7 @@ internal class JourneysSheetTest(@Autowired private val template: JPCTemplatePro
                 totalPriceInPence = 2200
         )
         
-        val sheet = JourneysSheet(workbook, PriceSheet.Header(moveDate, ClosedRangeLocalDate(moveDate, moveDate), Supplier.SERCO))
+        val sheet = JourneysSheet(workbook, PriceSheet.Header(defaultMoveDate10Sep2020, ClosedRangeLocalDate(defaultMoveDate10Sep2020, defaultMoveDate10Sep2020), Supplier.SERCO))
         sheet.writeJourneys(listOf(journey))
 
         assertCellEquals(sheet, 10, 0, "from") // from site name
@@ -57,7 +57,7 @@ internal class JourneysSheetTest(@Autowired private val template: JPCTemplatePro
                 totalPriceInPence = 0
         )
 
-        val sheet = JourneysSheet(workbook, PriceSheet.Header(moveDate, ClosedRangeLocalDate(moveDate, moveDate), Supplier.SERCO))
+        val sheet = JourneysSheet(workbook, PriceSheet.Header(defaultMoveDate10Sep2020, ClosedRangeLocalDate(defaultMoveDate10Sep2020, defaultMoveDate10Sep2020), Supplier.SERCO))
         sheet.writeJourneys(listOf(journey))
 
         assertCellEquals(sheet, 10, 0, "from") // from site name

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/MovesSummarySheetTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/MovesSummarySheetTest.kt
@@ -23,7 +23,7 @@ internal class MovesSummarySheetTest(@Autowired private val template: JPCTemplat
         val longHaulSummary = MovesSummary(MoveType.LONG_HAUL, 50.0, 10, 10, 400)
         val summaries = MoveTypeSummaries(1, listOf(standardSummary, longHaulSummary, MovesSummary(), MovesSummary(), MovesSummary(), MovesSummary()))
 
-        val sheet = SummarySheet(workbook, PriceSheet.Header(moveDate, ClosedRangeLocalDate(moveDate, moveDate), Supplier.SERCO))
+        val sheet = SummarySheet(workbook, PriceSheet.Header(defaultMoveDate10Sep2020, ClosedRangeLocalDate(defaultMoveDate10Sep2020, defaultMoveDate10Sep2020), Supplier.SERCO))
         sheet.writeSummaries(summaries)
 
         // Standard move summaries at row 9

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/RedirectionMovesSheetTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/RedirectionMovesSheetTest.kt
@@ -19,12 +19,12 @@ internal class RedirectionMovesSheetTest(@Autowired private val template: JPCTem
     @Test
     internal fun `test redirection prices`() {
 
-        val journey1 = journey()
-        val journey2 = journey(journeyId = "J2")
-        val move = move(journeys = listOf(journey1, journey2))
+        val journey1 = journeyJ1()
+        val journey2 = journeyJ1(journeyId = "J2")
+        val move = moveM1(journeys = listOf(journey1, journey2))
         val moves = listOf(move)
         
-        val sheet = RedirectionMovesSheet(workbook, PriceSheet.Header(moveDate, ClosedRangeLocalDate(moveDate, moveDate), Supplier.SERCO))
+        val sheet = RedirectionMovesSheet(workbook, PriceSheet.Header(defaultMoveDate10Sep2020, ClosedRangeLocalDate(defaultMoveDate10Sep2020, defaultMoveDate10Sep2020), Supplier.SERCO))
         sheet.writeMoves(moves)
 
         assertCellEquals(sheet, 10, 0, "REF1")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/StandardMovesSheetTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/StandardMovesSheetTest.kt
@@ -44,9 +44,9 @@ internal class StandardMovesSheetTest(@Autowired private val template: JPCTempla
 
     @Test
     internal fun `test prices`() {
-        val sms = StandardMovesSheet(workbook, PriceSheet.Header(moveDate, ClosedRangeLocalDate(moveDate, moveDate), Supplier.SERCO))
+        val sms = StandardMovesSheet(workbook, PriceSheet.Header(defaultMoveDate10Sep2020, ClosedRangeLocalDate(defaultMoveDate10Sep2020, defaultMoveDate10Sep2020), Supplier.SERCO))
 
-        val move = move(journeys = listOf(journey()))
+        val move = moveM1(journeys = listOf(journeyJ1()))
         val moves = listOf(move)
 
         sms.writeMoves(moves)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/SupplierPricesSheetTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/spreadsheet/SupplierPricesSheetTest.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.JPCTemplateProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.Location
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
-import uk.gov.justice.digital.hmpps.pecs.jpc.move.moveDate
+import uk.gov.justice.digital.hmpps.pecs.jpc.move.defaultMoveDate10Sep2020
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Price
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import java.util.*
@@ -22,7 +22,7 @@ internal class SupplierPricesSheetTest(@Autowired private val template: JPCTempl
 
     private val workbook: Workbook = XSSFWorkbook(template.get())
 
-    private val header: PriceSheet.Header =PriceSheet.Header(moveDate, ClosedRangeLocalDate(moveDate, moveDate), Supplier.SERCO)
+    private val header: PriceSheet.Header =PriceSheet.Header(defaultMoveDate10Sep2020, ClosedRangeLocalDate(defaultMoveDate10Sep2020, defaultMoveDate10Sep2020), Supplier.SERCO)
 
     private val supplierPricesSheet: SupplierPricesSheet = SupplierPricesSheet(workbook, header)
 


### PR DESCRIPTION
**This adds a link to "search moves by move reference ID" on the move summary page**

New findByReference method in MoveRepository
Used by findMoveByReference in MoveService

HtmlController has new findMove GET and performFindMove POST methods
The reference is validated. Unsuccessful search redirects back to the find a move search form with appropriate message.

Successful search redirects to the moves details page for the found move_id UUID

Queries for GET move and find move now restrict by supplier.

Add 404 page to return if a move doesn't exist (for that supplier)
