### PR TITLE
P4-2613 changes to fix journey ordering in the move detail screen.  Also some minor refactorings.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommands.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommands.kt
@@ -22,11 +22,14 @@ class ImportCommands(
 
   @ShellMethod("Imports prices for the given supplier from S3. This command deletes all existing prices for the given supplier.")
   fun importPrices(supplier: Supplier) {
-    importService.importPrices(supplier)
+    when (supplier) {
+      Supplier.UNKNOWN -> throw RuntimeException("UNKNOWN is not a valid supplier")
+      else -> importService.importPrices(supplier)
+    }
   }
 
   /**
-   * Due to potential the large volumes of data each day is imported as an individual import to reduce the memory footprint.
+   * Due to the potential the large volumes of data, each day is imported as an individual import to reduce the memory footprint.
    */
   @ShellMethod("Imports reports for both suppliers for the given dates. Date params are the in ISO date format e.g. YYYY-MM-DD.")
   fun importReports(from: LocalDate, to: LocalDate) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommands.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommands.kt
@@ -29,7 +29,7 @@ class ImportCommands(
   }
 
   /**
-   * Due to the potential the large volumes of data, each day is imported as an individual import to reduce the memory footprint.
+   * Due to potentially large volumes of data, each day is imported as an individual import to reduce the memory footprint.
    */
   @ShellMethod("Imports reports for both suppliers for the given dates. Date params are the in ISO date format e.g. YYYY-MM-DD.")
   fun importReports(from: LocalDate, to: LocalDate) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MovePersister.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MovePersister.kt
@@ -6,7 +6,6 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.Event
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.EventType
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.effectiveYearForDate
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -119,7 +118,7 @@ class MovePersister(
       }
   }
 
-  fun fakeCancelledJourney(move: Move): Journey {
+  internal fun fakeCancelledJourney(move: Move): Journey {
     return Journey(
       journeyId = UUID.randomUUID().toString(),
       updatedAt = LocalDateTime.now(),
@@ -132,7 +131,7 @@ class MovePersister(
       state = JourneyState.cancelled,
       vehicleRegistration = null,
       notes = "FAKE JOURNEY ADDED FOR CANCELLED BILLABLE MOVE",
-      effectiveYear = effectiveYearForDate(move.moveDate ?: LocalDate.now()),
+      effectiveYear = effectiveYearForDate(move.moveDate ?: timeSource.date()),
       events = listOf()
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/Price.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/Price.kt
@@ -63,10 +63,8 @@ enum class Supplier {
 
   companion object {
     fun valueOfCaseInsensitive(value: String?) =
-      kotlin.runCatching { Supplier.valueOf(value!!.toUpperCase()) }.getOrDefault(Supplier.UNKNOWN)
+      kotlin.runCatching { valueOf(value!!.toUpperCase()) }.getOrDefault(UNKNOWN)
   }
 }
-
-fun <T : Enum<*>> T.equalsStringCaseInsensitive(value: String) = this.name == value.toUpperCase()
 
 fun effectiveYearForDate(date: LocalDate) = if (date.monthValue >= 9) date.year else date.year - 1

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MoveService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MoveService.kt
@@ -23,11 +23,11 @@ class MoveService(
     return maybeMove?.let {
       val moveEvents = eventRepository.findAllByEventableId(it.moveId)
       val journeyId2Events =
-        eventRepository.findByEventableIdIn(it.journeys.map { it.journeyId }).groupBy { it.eventableId }
+        eventRepository.findByEventableIdIn(it.journeys.map { j -> j.journeyId }).groupBy { e -> e.eventableId }
 
       val journeysWithEvents = it.journeys.map { journey ->
         journey.copy(events = journeyId2Events[journey.journeyId] ?: listOf())
-      }
+      }.sortedBy { journey -> journey.pickUpDateTime }
 
       it.copy(events = moveEvents, journeys = journeysWithEvents)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommandsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommandsTest.kt
@@ -4,7 +4,9 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportService
 import java.time.LocalDate
 
@@ -14,6 +16,25 @@ internal class ImportCommandsTest {
   private val date: LocalDate = LocalDate.of(2020, 9, 30)
 
   private val commands: ImportCommands = ImportCommands(importService)
+
+  @Test
+  internal fun `import prices for Serco`() {
+    commands.importPrices(Supplier.SERCO)
+
+    verify(importService).importPrices(Supplier.SERCO)
+  }
+
+  @Test
+  internal fun `import prices for Geoamey`() {
+    commands.importPrices(Supplier.GEOAMEY)
+
+    verify(importService).importPrices(Supplier.GEOAMEY)
+  }
+
+  @Test
+  internal fun `import prices for Unknown fails`() {
+    assertThatThrownBy { commands.importPrices(Supplier.UNKNOWN) }.isInstanceOf(RuntimeException::class.java)
+  }
 
   @Test
   internal fun `import one days reporting data`() {


### PR DESCRIPTION
Changes:

- Journeys are now ordered by the pickup time for a move upon retrieval for displaying on the move details page.
- Update tests to verify the ordering is applied at time of retrieval in the service layer.
- Some minor refactorings and tidy-ups done as well.