### PR TITLE
P4-2613 resolving the ordering of journey events. Was using the order they were pulled from the DB.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MoveService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MoveService.kt
@@ -26,7 +26,7 @@ class MoveService(
         eventRepository.findByEventableIdIn(it.journeys.map { j -> j.journeyId }).groupBy { e -> e.eventableId }
 
       val journeysWithEvents = it.journeys.map { journey ->
-        journey.copy(events = journeyId2Events[journey.journeyId] ?: listOf())
+        journey.copy(events = journeyId2Events[journey.journeyId]?.sortedBy { e -> e.occurredAt } ?: listOf())
       }.sortedBy { journey -> journey.pickUpDateTime }
 
       it.copy(events = moveEvents, journeys = journeysWithEvents)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/TestMoveFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/TestMoveFactory.kt
@@ -114,3 +114,20 @@ fun eventE1(
   details = null,
   supplier = Supplier.SERCO
 )
+
+fun journeyEventJE1(
+  eventId: String = "JE1",
+  eventType: EventType = EventType.JOURNEY_START,
+  eventableId: String = journeyJ1().journeyId
+) = Event(
+  details = null,
+  eventableType = "journey",
+  eventableId = eventableId,
+  eventId = eventId,
+  notes = null,
+  occurredAt = journeyJ1().pickUpDateTime!!,
+  recordedAt = journeyJ1().pickUpDateTime!!,
+  supplier = Supplier.SERCO,
+  type = eventType.value,
+  updatedAt = defaultDateTime,
+)


### PR DESCRIPTION
Changes:

- Order the the journey events based on their pickup time for the presentation layer.  Was originally just using the order in which they were pulled from the DB hence sometimes it worked and other times it didn't.