### PR TITLE
P4-2623 fixing the profile and person persister.  Fixing the commit points.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/PersonPersister.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/PersonPersister.kt
@@ -17,31 +17,31 @@ class PersonPersister(
     logger.info("Persisting ${people.size} people")
     var counter = 1
     val peopleToSave = mutableListOf<Person>()
-    people.forEach { person ->
-      Result.runCatching {
+    Result.runCatching {
+      people.forEach { person ->
         peopleToSave += person
         if (counter++ % 1000 == 0) {
           logger.info("Persisted $counter people out of ${people.size} (flushing people to the database).")
           saveFlushAndClear(personRepository, peopleToSave)
         }
-        saveFlushAndClear(personRepository, peopleToSave)
-      }.onFailure { logger.warn("Error inserting person id ${person.personId}" + it.message) }
-    }
+      }
+      saveFlushAndClear(personRepository, peopleToSave)
+    }.onFailure { logger.warn("Error inserting people ${peopleToSave.map { p -> p.personId }} - ${it.message}") }
   }
 
   fun persistProfiles(profiles: List<Profile>) {
     logger.info("Persisting ${profiles.size} profiles")
     var counter = 1
     val profilesToSave = mutableListOf<Profile>()
-    profiles.forEach { profile ->
-      Result.runCatching {
+    Result.runCatching {
+      profiles.forEach { profile ->
         profilesToSave += profile
         if (counter++ % 1000 == 0) {
           logger.info("Persisted $counter profiles out of ${profiles.size} (flushing profiles to the database).")
           saveFlushAndClear(profileRepository, profilesToSave)
         }
-        saveFlushAndClear(profileRepository, profilesToSave)
-      }.onFailure { logger.warn("Error inserting $profile" + it.message) }
-    }
+      }
+      saveFlushAndClear(profileRepository, profilesToSave)
+    }.onFailure { logger.warn("Error inserting profiles ${profilesToSave.map { p -> p.profileId }} - ${it.message}") }
   }
 }


### PR DESCRIPTION
Changes:

- The profile and people persister was committing for every iteration of a loop (for an entity) instead of persisting every 1000 entities.  This change moves the final commit out of the loop to prevent this from happening.
- Updated unit tests to verify the number of times the commit is invoked.