### PR TITLE
P4-2623 refactoring the profile and person persister used during the report import process.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/PersonPersisterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/PersonPersisterTest.kt
@@ -53,21 +53,21 @@ internal class PersonPersisterTest(
   }
 
   @Test
-  fun `save invoked once for 999 people`() {
+  fun `save invoked once for 500 people`() {
     PersonPersister(
       personRepositorySpy,
       profileRepositorySpy
-    ).persistPeople(entities(999) { id -> reportPersonFactory().copy(personId = id) })
+    ).persistPeople(entities(500) { id -> reportPersonFactory().copy(personId = id) })
 
     verify(personRepositorySpy).saveAll(any())
   }
 
   @Test
-  fun `save invoked twice for 1000 people`() {
+  fun `save invoked twice for 501 people`() {
     PersonPersister(
       personRepositorySpy,
       profileRepositorySpy
-    ).persistPeople(entities(1000) { id -> reportPersonFactory().copy(personId = id) })
+    ).persistPeople(entities(501) { id -> reportPersonFactory().copy(personId = id) })
 
     verify(personRepositorySpy, times(2)).saveAll(any())
   }
@@ -83,21 +83,21 @@ internal class PersonPersisterTest(
   }
 
   @Test
-  fun `save invoked once for 999 profiles`() {
+  fun `save invoked once for 500 profiles`() {
     PersonPersister(
       personRepositorySpy,
       profileRepositorySpy
-    ).persistProfiles(entities(999) { id -> profileFactory().copy(profileId = id, personId = id) })
+    ).persistProfiles(entities(500) { id -> profileFactory().copy(profileId = id, personId = id) })
 
     verify(profileRepositorySpy).saveAll(any())
   }
 
   @Test
-  fun `save invoked twice for 1000 profiles`() {
+  fun `save invoked twice for 501 profiles`() {
     PersonPersister(
       personRepositorySpy,
       profileRepositorySpy
-    ).persistProfiles(entities(1000) { id -> profileFactory().copy(profileId = id, personId = id) })
+    ).persistProfiles(entities(501) { id -> profileFactory().copy(profileId = id, personId = id) })
 
     verify(profileRepositorySpy, times(2)).saveAll(any())
   }


### PR DESCRIPTION
Changes:

- Refactoring the import and persistence of profiles and people.
- As part of the refactoring I have reduced the batch size at which entities are flushed to the DB to every 500 instead of 1000.