### PR TITLE
P4-2518 changes to clean up session handling e.g. timeouts, max concurrent sessions etc.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/PersonPersister.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/PersonPersister.kt
@@ -32,7 +32,10 @@ class PersonPersister(
       saveFlushAndClear(personRepository, people)
     }
       .onSuccess { success() }
-      .onFailure { logger.warn("Error inserting people ${people.map { p -> p.personId }} - ${it.message}") }
+      .onFailure {
+        logger.warn("Error inserting people batch ${people.map { p -> p.personId }} - ${it.stackTraceToString()}")
+        people.clear()
+      }
   }
 
   fun persistProfiles(profiles: List<Profile>) {
@@ -55,6 +58,9 @@ class PersonPersister(
       saveFlushAndClear(profileRepository, profiles)
     }
       .onSuccess { success() }
-      .onFailure { logger.warn("Error inserting profiles ${profiles.map { p -> p.profileId }} - ${it.message}") }
+      .onFailure {
+        logger.warn("Error inserting profiles batch ${profiles.map { p -> p.profileId }} - ${it.message}")
+        profiles.clear()
+      }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ApplicationSecurityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ApplicationSecurityTest.kt
@@ -1,17 +1,21 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.controller
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.mock.web.MockHttpSession
 import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.logout
 import org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated
 import org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.unauthenticated
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.get
-import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
@@ -22,9 +26,13 @@ import java.time.LocalDate
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @ContextConfiguration(classes = [TestConfig::class])
-internal class LogoutApplicationTest(@Autowired private val wac: WebApplicationContext) {
+@TestPropertySource(properties = ["HMPPS_AUTH_BASE_URI=http://fake_auth_redirect_url"])
+internal class ApplicationSecurityTest(@Autowired private val wac: WebApplicationContext) {
 
-  private val mockMvc = MockMvcBuilders.webAppContextSetup(wac).build()
+  private val mockMvc = MockMvcBuilders
+    .webAppContextSetup(wac)
+    .apply<DefaultMockMvcBuilder>(SecurityMockMvcConfigurers.springSecurity())
+    .build()
 
   private val mockSession = MockHttpSession(wac.servletContext)
 
@@ -43,9 +51,22 @@ internal class LogoutApplicationTest(@Autowired private val wac: WebApplicationC
           .withAuthenticationName("Anonymous")
           .withRoles("PECS_JPC")
       }
-      .andDo { mockMvc.post("/logout") { session = mockSession } }
+      .andDo { mockMvc.perform(logout()) }
       .andExpect { unauthenticated() }
       .andExpect { status { isOk() } }
       .andReturn()
+  }
+
+  @Test
+  @WithMockUser(username = "Unauthorised_User")
+  fun `default session is invalidated on unauthorised access`() {
+    assertThat(mockSession.isInvalid).isFalse
+
+    mockMvc.get("/") { session = mockSession }
+      .andExpect { status { is3xxRedirection() } }
+      .andExpect { unauthenticated() }
+      .andExpect { request { redirectedUrl("http://fake_auth_redirect_url") } }
+
+    assertThat(mockSession.isInvalid).isTrue
   }
 }


### PR DESCRIPTION
Changes:

- Reduced session inactivity timeout to 30 mins.
- Max concurrent sessions for a user limited to one.
- Sessions are now automatically invalidated for any logins that fail.  Instead of waiting for the Spring background cleanup process.
- Session times now redirect back to the auth service.