### PR TITLE
P4-2518 correction after issue with log level was spotted release notes in the DPS gradle plugin.

### DIFF
--- a/applicationinsights.json
+++ b/applicationinsights.json
@@ -1,12 +1,16 @@
 {
   "role": {
-    "name": "application-name"
+    "name": "calculate-journey-variable-payments"
   },
   "customDimensions": {
-    "service.version": "\${BUILD_NUMBER}"
+    "service.version": "${BUILD_NUMBER}"
+  },
+  "instrumentation": {
+    "logging": {
+      "level": "DEBUG"
+    }
   },
   "selfDiagnostics": {
-    "destination": "console",
-    "level": "INFO"
+    "destination": "console"
   }
 }


### PR DESCRIPTION
Changes:

- The original file where this was taken from in the dps gradle spring plugin had the wrong log level.  This change corrects it.  In truth is has little impact at this point in time as we are not using Application Insights at time of writing.