### PR TITLE
P4-2645 resolves issue with incorrect rounding of prices.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/price/PricesSpreadsheet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/price/PricesSpreadsheet.kt
@@ -4,10 +4,10 @@ import org.apache.poi.ss.usermodel.Row
 import org.apache.poi.ss.usermodel.Workbook
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.InboundSpreadsheet
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.Location
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Money
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Price
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 
-private const val JOURNEY_ID = 0
 private const val FROM_LOCATION = 1
 private const val TO_LOCATION = 2
 private const val PRICE = 3
@@ -43,7 +43,7 @@ class PricesSpreadsheet(private val spreadsheet: Workbook, val supplier: Supplie
     val toLocationName =
       row.getFormattedStringCell(TO_LOCATION) ?: throw RuntimeException("To location name cannot be blank")
 
-    val price = Result.runCatching { (row.getCell(PRICE).numericCellValue * 100).toInt() }
+    val price = Result.runCatching { Money.valueOf(row.getCell(PRICE).numericCellValue).pence }
       .onSuccess { if (it == 0) throw RuntimeException("Price must be greater than zero") }
       .getOrElse { throw RuntimeException("Error retrieving price for supplier '$supplier'", it) }
 
@@ -58,7 +58,7 @@ class PricesSpreadsheet(private val spreadsheet: Workbook, val supplier: Supplie
       fromLocation = fromLocation,
       toLocation = toLocation,
       priceInPence = price,
-      effectiveYear = 2020 // TODO remove this once we're not importing from spreadhsheet anymore
+      effectiveYear = 2020 // TODO remove this once we're not importing from spreadsheet anymore
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/Journey.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/Journey.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.dateTimeConverter
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.journeyStateConverter
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.supplierConverter
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Money
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -118,7 +119,7 @@ data class Journey(
 
   fun hasPrice() = priceInPence != null
   fun isBillable() = if (billable) "YES" else "NO"
-  fun priceInPounds() = priceInPence?.let { it.toDouble() / 100 }
+  fun priceInPounds() = priceInPence?.let { Money(it).pounds() }
   fun pickUpDate() = pickUpDateTime?.format(dateFormatter)
   fun pickUpTime() = pickUpDateTime?.format(timeFormatter)
   fun dropOffDate() = dropOffDateTime?.format(dateFormatter)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyWithPrice.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyWithPrice.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.move
 
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Money
 
 data class JourneyWithPrice(
   val fromNomisAgencyId: String,
@@ -13,8 +14,8 @@ data class JourneyWithPrice(
   val unitPriceInPence: Int?,
   val totalPriceInPence: Int?
 ) {
-  fun unitPriceInPounds() = unitPriceInPence?.let { it.toDouble() / 100 }
-  fun totalPriceInPounds() = totalPriceInPence?.let { it.toDouble() / 100 }
+  fun unitPriceInPounds() = unitPriceInPence?.let { Money(it).pounds() }
+  fun totalPriceInPounds() = totalPriceInPence?.let { Money(it).pounds() }
   fun billableJourneyCount() = unitPriceInPence?.let { totalPriceInPence!! / it } ?: 0
   fun fromSiteName() = fromSiteName ?: fromNomisAgencyId
   fun toSiteName() = toSiteName ?: toNomisAgencyId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/Move.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/Move.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.dateTimeConverter
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.moveStatusConverter
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.supplierConverter
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Money
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -145,7 +146,7 @@ data class Move(
     }
 
   fun hasPrice() = totalInPence() != null
-  fun totalInPounds() = totalInPence()?.let { it.toDouble() / 100 }
+  fun totalInPounds() = totalInPence()?.let { Money(it).pounds() }
   fun moveDate() = moveDate?.format(dateFormatter)
   fun pickUpDate() = pickUpDateTime?.format(dateFormatter)
   fun pickUpTime() = pickUpDateTime?.format(timeFormatter)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MovesSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MovesSummary.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.move
 
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Money
+
 data class MovesSummary(
   val moveType: MoveType? = null,
   val percentage: Double = 0.0,
@@ -7,5 +9,5 @@ data class MovesSummary(
   val volumeUnpriced: Int = 0,
   val totalPriceInPence: Int = 0
 ) {
-  val totalPriceInPounds = totalPriceInPence.toDouble() / 100
+  val totalPriceInPounds = Money(totalPriceInPence).pounds()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/Money.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/Money.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.price
 
+import kotlin.math.roundToInt
+
 /**
  * Simple value object to encapsulate a monetary amount in pence. Negative amounts are not allowed.
  */
@@ -16,6 +18,10 @@ data class Money(val pence: Int) {
   operator fun times(multiplier: Double) = valueOf(pounds() * multiplier)
 
   companion object Factory {
-    fun valueOf(pounds: Double) = Money((pounds * 100).toInt())
+    /**
+     * This rounds the amount towards positive infinity, e.g. 10.004 would be rounded to 1000 pence and 10.005 would be
+     * rounded to 1001 pence.
+     */
+    fun valueOf(pounds: Double) = Money((pounds * 100).roundToInt())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/price/PricesSpreadsheetTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/price/PricesSpreadsheetTest.kt
@@ -55,7 +55,7 @@ internal class PricesSpreadsheetTest {
       this.createCell(0).setCellValue(1.0)
       this.createCell(1).setCellValue("from site")
       this.createCell(2).setCellValue("to site")
-      this.createCell(3).setCellValue(100.00)
+      this.createCell(3).setCellValue(100.005)
     }
 
     @Test
@@ -64,7 +64,7 @@ internal class PricesSpreadsheetTest {
 
       assertThat(price.fromLocation).isEqualTo(fromLocation)
       assertThat(price.toLocation).isEqualTo(toLocation)
-      assertThat(price.priceInPence).isEqualTo(10000)
+      assertThat(price.priceInPence).isEqualTo(10001)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/MoneyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/MoneyTest.kt
@@ -5,9 +5,28 @@ import org.junit.jupiter.api.Test
 
 internal class MoneyTest {
   @Test
-  internal fun `multiplier override`() {
+  internal fun `multiplier operator override`() {
     assertThat(Money.valueOf(10.00) * 1.2).isEqualTo(Money.valueOf(12.00))
     assertThat(Money.valueOf(10.00) * 1.5).isEqualTo(Money.valueOf(15.00))
     assertThat(Money.valueOf(12.00) * 2.0).isEqualTo(Money.valueOf(24.00))
+  }
+
+  @Test
+  internal fun `double monetary values rounds down when rounding digit is below 5`() {
+    assertThat(Money.valueOf(10.000).pence).isEqualTo(1000)
+    assertThat(Money.valueOf(10.001).pence).isEqualTo(1000)
+    assertThat(Money.valueOf(10.002).pence).isEqualTo(1000)
+    assertThat(Money.valueOf(10.003).pence).isEqualTo(1000)
+    assertThat(Money.valueOf(10.004).pence).isEqualTo(1000)
+  }
+
+  @Test
+  internal fun `double monetary values rounds up when rounding digit is 5 or more`() {
+    assertThat(Money.valueOf(10.005).pence).isEqualTo(1001)
+    assertThat(Money.valueOf(10.006).pence).isEqualTo(1001)
+    assertThat(Money.valueOf(10.007).pence).isEqualTo(1001)
+    assertThat(Money.valueOf(10.008).pence).isEqualTo(1001)
+    assertThat(Money.valueOf(10.009).pence).isEqualTo(1001)
+    assertThat(Money.valueOf(10.999).pence).isEqualTo(1100)
   }
 }


### PR DESCRIPTION
Changes:

- This fixes an issue whereby the incorrect rounding was being applied to prices.  It was not applying round up at 5 or above and down below 5.
- All rounding related operations moved to the existing Money class so now done in a central place.