### PR TITLE
P4-2654 updating move query to exclude moves without a move type.  These are incomplete (unpriced) moves in JPC.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveQueryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveQueryRepository.kt
@@ -176,9 +176,12 @@ class MoveQueryRepository(@Autowired val jdbcTemplate: JdbcTemplate) {
     }
   }
 
+  /**
+   * Excludes moves without a move_type. This is an indication of bad reporting data in the JSON data feeds.
+   */
   fun moveWithPersonAndJourneys(moveId: String, supplier: Supplier): Move? {
     val movePersonJourney = jdbcTemplate.query(
-      "$moveJourneySelectSQL where m.move_id = ? and m.supplier = ? ",
+      "$moveJourneySelectSQL where m.move_id = ? and m.supplier = ? and m.move_type is not null",
       arrayOf(moveId, supplier.name),
       moveJourneyRowMapper
     ).groupBy { it.move.moveId }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveQueryRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveQueryRepositoryTest.kt
@@ -28,37 +28,38 @@ import java.util.UUID
 internal class MoveQueryRepositoryTest {
 
   @Autowired
-  lateinit var locationRepository: LocationRepository
+  private lateinit var locationRepository: LocationRepository
 
   @Autowired
-  lateinit var priceRepository: PriceRepository
+  private lateinit var priceRepository: PriceRepository
 
   @Autowired
-  lateinit var moveRepository: MoveRepository
+  private lateinit var moveRepository: MoveRepository
 
   @Autowired
-  lateinit var moveQueryRepository: MoveQueryRepository
+  private lateinit var moveQueryRepository: MoveQueryRepository
 
   @Autowired
-  lateinit var journeyRepository: JourneyRepository
+  private lateinit var journeyRepository: JourneyRepository
 
   @Autowired
-  lateinit var personRepository: PersonRepository
+  private lateinit var personRepository: PersonRepository
 
   @Autowired
-  lateinit var profileRepository: ProfileRepository
+  private lateinit var profileRepository: ProfileRepository
 
   @Autowired
-  lateinit var entityManager: TestEntityManager
+  private lateinit var entityManager: TestEntityManager
 
-  val wyi = WYIPrisonLocation()
-  val gni = GNICourtLocation()
+  private val wyi = WYIPrisonLocation()
+  private val gni = GNICourtLocation()
 
-  val standardMove = moveM1(
+  private val standardMove = moveM1(
     dropOffOrCancelledDateTime = defaultMoveDate10Sep2020.atStartOfDay().plusHours(5)
   ) // should appear before the one above
-  val journeyModel1 = journeyJ1()
-  val journeyModel2 = journeyJ1(journeyId = "J2")
+  private val journeyModel1 = journeyJ1()
+  private val journeyModel2 = journeyJ1(journeyId = "J2")
+  private val moveWithMissingType = standardMove.copy(moveId = "MWMT", moveType = null)
 
   @BeforeEach
   fun beforeEach() {
@@ -80,6 +81,8 @@ internal class MoveQueryRepositoryTest {
     journeyRepository.save(journeyModel1)
     journeyRepository.save(journeyModel2)
 
+    moveRepository.save(moveWithMissingType)
+
     entityManager.flush()
   }
 
@@ -87,6 +90,12 @@ internal class MoveQueryRepositoryTest {
   fun `moveWithPersonAndJourneys with invalid moveId for supplier`() {
     val move = moveQueryRepository.moveWithPersonAndJourneys(standardMove.moveId, Supplier.GEOAMEY)
     assertThat(move).isNull()
+  }
+
+  @Test
+  fun `moveWithPersonAndJourneys with missing move_type is null`() {
+    assertThat(moveRepository.findById(moveWithMissingType.moveId)).isPresent
+    assertThat(moveQueryRepository.moveWithPersonAndJourneys(moveWithMissingType.moveId, moveWithMissingType.supplier)).isNull()
   }
 
   @Test


### PR DESCRIPTION
Changes:

- Updated query to retrieve moves for viewing in the application to only fetch complete and/or cancelled moves i.e. moves which have a move_type and are not null.