### PR TITLE
P4-2652 excluding moves with null move types from the move lookup functionality.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MoveService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MoveService.kt
@@ -37,7 +37,8 @@ class MoveService(
     moveQueryRepository.movesInDateRange(supplier, startDate, endOfMonth(startDate))
 
   fun findMoveByReferenceAndSupplier(ref: String, supplier: Supplier) =
-    moveRepository.findByReferenceAndSupplier(ref, supplier)
+    // At time of writing the need for filtering null moves types is a result of poor supplier data.
+    moveRepository.findByReferenceAndSupplier(ref, supplier).filter { it.moveType != null }
 
   fun movesForMoveType(supplier: Supplier, moveType: MoveType, startDate: LocalDate) =
     moveQueryRepository.movesForMoveTypeInDateRange(supplier, moveType, startDate, endOfMonth(startDate))


### PR DESCRIPTION
Changes:

- Show a consistent error message to the user when searching for a move (that has no move type). 