### PR TITLE
P4-2666 changes to (fix) improve the robustness of the move import process.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/Event.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/Event.kt
@@ -59,12 +59,9 @@ data class Event constructor(
   @Column(name = "recorded_at")
   val recordedAt: LocalDateTime,
 
-  var notes: String?,
+  @Column(nullable = true, length = 1024)
+  val notes: String?,
 ) : Comparable<Event> {
-
-  init {
-    notes = notes?.take(255)
-  }
 
   fun hasType(et: EventType) = type == et.value
   override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/Journey.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/Journey.kt
@@ -94,7 +94,8 @@ data class Journey(
   val billable: Boolean,
 
   @Json(ignored = true)
-  var notes: String? = null,
+  @Column(nullable = true, length = 1024)
+  val notes: String? = null,
 
   @Json(ignored = true)
   @Transient
@@ -108,11 +109,6 @@ data class Journey(
   @Column(name = "effective_year", nullable = false)
   val effectiveYear: Int? = null
 ) {
-
-  init {
-    notes = notes?.take(255)
-  }
-
   override fun toString(): String {
     return "JourneyModel(journeyId='$journeyId', state=$state, fromNomisAgencyId='$fromNomisAgencyId', fromSiteName=$fromSiteName, fromLocationType=$fromLocationType, toNomisAgencyId=$toNomisAgencyId, toSiteName=$toSiteName, toLocationType=$toLocationType, pickUp=$pickUpDateTime, dropOff=$dropOffDateTime, vehicleRegistation=$vehicleRegistration, billable=$billable, notes=$notes, priceInPence=$priceInPence)"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/Move.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/Move.kt
@@ -113,10 +113,11 @@ data class Move(
   val cancellationReason: String? = null,
 
   @Json(name = "cancellation_reason_comment")
-  @Column(name = "cancellation_reason_comment")
+  @Column(name = "cancellation_reason_comment", nullable = true, length = 1024)
   var cancellationReasonComment: String? = null,
 
   @Json(ignored = true)
+  @Column(nullable = false, length = 1024)
   var notes: String = "",
 
   @Json(ignored = true)
@@ -135,11 +136,6 @@ data class Move(
   @Transient
   val person: Person? = null
 ) {
-  init {
-    notes = notes.take(255)
-    cancellationReasonComment = cancellationReasonComment?.take(255)
-  }
-
   fun totalInPence() =
     if (journeys.isEmpty() || journeys.count { it.priceInPence == null } > 0) null else journeys.sumBy {
       it.priceInPence ?: 0

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/PersonPersister.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/PersonPersister.kt
@@ -19,7 +19,7 @@ class PersonPersister(
     val peopleToSave = mutableListOf<Person>()
     people.forEach { person ->
       peopleToSave += person
-      if (++counter % 500 == 0) {
+      if (++counter % 50 == 0) {
         savePeople(peopleToSave) { logger.info("Persisted $counter people out of ${people.size} (flushing people to the database).") }
       }
     }
@@ -45,7 +45,7 @@ class PersonPersister(
     profiles.forEach { profile ->
       profilesToSave += profile
 
-      if (++counter % 500 == 0) {
+      if (++counter % 50 == 0) {
         saveProfiles(profilesToSave) { logger.info("Persisted $counter profiles out of ${profiles.size} (flushing profiles to the database).") }
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.service
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.location.LocationsImporter
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.price.PriceImporter
@@ -13,7 +12,6 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import java.time.Duration
 import java.time.LocalDate
 
-@Transactional
 @Service
 class ImportService(
   private val timeSource: TimeSource,

--- a/src/main/resources/db/migration/ddl/V1_2__alter_column_lengths.sql
+++ b/src/main/resources/db/migration/ddl/V1_2__alter_column_lengths.sql
@@ -1,0 +1,8 @@
+ALTER TABLE moves ALTER COLUMN cancellation_reason_comment TYPE varchar(1024);
+
+ALTER TABLE moves ALTER COLUMN notes TYPE varchar(1024);
+
+ALTER TABLE events ALTER COLUMN notes TYPE varchar(1024);
+
+ALTER TABLE journeys ALTER COLUMN notes TYPE varchar(1024);
+

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MoveRepositoryTest.kt
@@ -19,21 +19,7 @@ internal class MoveRepositoryTest {
 
   @Test
   fun `save report model`() {
-
-    val move = moveM1().copy(
-      notes = "adfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffs" +
-        "fasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfas" +
-        "adfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaf" +
-        "fsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaff" +
-        "sfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasa" +
-        "dfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsa" +
-        "fafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasa" +
-        "dfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafaf" +
-        "affsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadf" +
-        "afafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaf" +
-        "fsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafa" +
-        "fsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffsfas"
-    )
+    val move = moveM1().copy(notes = "a".repeat(1024))
     val journeyModel =
       journeyJ1(moveId = move.moveId, events = listOf(eventE1(eventId = "E1", eventableId = journeyJ1().journeyId)))
     val moveModel = move.copy(
@@ -49,6 +35,6 @@ internal class MoveRepositoryTest {
     val retrievedMove = moveRepository.findById(persistedReport.moveId).get()
 
     assertThat(retrievedMove).isEqualTo(moveModel)
-    assertThat(retrievedMove.notes).contains("adfafafsafafaffsfasadfafafsafafaffsfasadfafafsafafaffs")
+    assertThat(retrievedMove.notes).contains("a".repeat(1024))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/PersonPersisterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/PersonPersisterTest.kt
@@ -57,21 +57,21 @@ internal class PersonPersisterTest(
   }
 
   @Test
-  fun `save invoked once for 500 people`() {
+  fun `save invoked once for 50 people`() {
     PersonPersister(
       personRepositorySpy,
       profileRepositorySpy
-    ).persistPeople(entities(500) { id -> reportPersonFactory().copy(personId = id) })
+    ).persistPeople(entities(50) { id -> reportPersonFactory().copy(personId = id) })
 
     verify(personRepositorySpy).saveAll(personCaptor.capture())
   }
 
   @Test
-  fun `save invoked twice for 501 people`() {
+  fun `save invoked twice for 51 people`() {
     PersonPersister(
       personRepositorySpy,
       profileRepositorySpy
-    ).persistPeople(entities(501) { id -> reportPersonFactory().copy(personId = id) })
+    ).persistPeople(entities(51) { id -> reportPersonFactory().copy(personId = id) })
 
     verify(personRepositorySpy, times(2)).saveAll(personCaptor.capture())
   }
@@ -87,21 +87,21 @@ internal class PersonPersisterTest(
   }
 
   @Test
-  fun `save invoked once for 500 profiles`() {
+  fun `save invoked once for 50 profiles`() {
     PersonPersister(
       personRepositorySpy,
       profileRepositorySpy
-    ).persistProfiles(entities(500) { id -> profileFactory().copy(profileId = id, personId = id) })
+    ).persistProfiles(entities(50) { id -> profileFactory().copy(profileId = id, personId = id) })
 
     verify(profileRepositorySpy).saveAll(profileCaptor.capture())
   }
 
   @Test
-  fun `save invoked twice for 501 profiles`() {
+  fun `save invoked twice for 51 profiles`() {
     PersonPersister(
       personRepositorySpy,
       profileRepositorySpy
-    ).persistProfiles(entities(501) { id -> profileFactory().copy(profileId = id, personId = id) })
+    ).persistProfiles(entities(51) { id -> profileFactory().copy(profileId = id, personId = id) })
 
     verify(profileRepositorySpy, times(2)).saveAll(profileCaptor.capture())
   }


### PR DESCRIPTION
Changes:

- Increase lengths of certain DB columns that caused the failure of the importer due to being too long (using DB migration).
- Reworked the MovePersister to not fail and exit if an move fails to import.  It will skip any bad moves.
- Move the MovePersister away from batch importing of moves.  Will now push a single move to the DB with is relevant other data.
- Reduced the batch size of the Person/Profile importer (Will actually look at moving away from batch inserts in a separate PR).