### PR TITLE
P4 2657 import auditing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditEventType.kt
@@ -1,12 +1,13 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.auditing
 
 enum class AuditEventType(val label: String) {
+  DOWNLOAD_SPREADSHEET("Download spreadsheet"),
+  JOURNEY_PRICE("Journey price"),
+  JOURNEY_PRICE_BULK_UPDATE("Journey price bulk update"),
+  LOCATION("Location"),
   LOG_IN("Log in"),
   LOG_OUT("Log out"),
-  DOWNLOAD_SPREADSHEET("Download spreadsheet"),
-  LOCATION("Location"),
-  JOURNEY_PRICE("Journey price"),
-  JOURNEY_PRICE_BULK_UPDATE("Journey price bulk update");
+  REPORTING_DATA_IMPORT("Reporting data import");
 
   companion object {
     /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/LogInAuditHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/LogInAuditHandler.kt
@@ -2,19 +2,18 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.auditing
 
 import org.springframework.security.core.Authentication
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler
-import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.AuditService
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
-class LogInAuditHandler(private val auditService: AuditService, private val timeSource: TimeSource) :
+class LogInAuditHandler(private val auditService: AuditService) :
   SavedRequestAwareAuthenticationSuccessHandler() {
   override fun onAuthenticationSuccess(
     request: HttpServletRequest?,
     response: HttpServletResponse?,
     authentication: Authentication?
   ) {
-    auditService.create(AuditableEvent.createLogInEvent(timeSource, authentication))
+    auditService.create(AuditableEvent.createLogInEvent(authentication!!))
     super.onAuthenticationSuccess(request, response, authentication)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/LogOutAuditHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/LogOutAuditHandler.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.auditing
 
 import org.springframework.security.core.Authentication
 import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler
-import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.AuditService
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
@@ -10,14 +9,13 @@ import javax.servlet.http.HttpServletResponse
 class LogOutAuditHandler(
   private val auditService: AuditService,
   private val authLogoutSuccessUri: String,
-  private val timeSource: TimeSource
 ) : SimpleUrlLogoutSuccessHandler() {
   override fun onLogoutSuccess(
     request: HttpServletRequest?,
     response: HttpServletResponse?,
     authentication: Authentication?
   ) {
-    auditService.create(AuditableEvent.createLogOutEvent(timeSource, authentication))
+    auditService.create(AuditableEvent.createLogOutEvent(authentication!!))
     defaultTargetUrl = authLogoutSuccessUri
     super.onLogoutSuccess(request, response, authentication)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommands.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommands.kt
@@ -40,7 +40,7 @@ class ImportCommands(
 
     if (to.isBefore(from)) throw RuntimeException("To date must be equal to or greater than from date.")
     for (i in 0..ChronoUnit.DAYS.between(from, to)) {
-      importService.importReports(from.plusDays(i), from.plusDays(i))
+      importService.importReportsOn(from.plusDays(i))
     }
 
     logger.info("Finished import of reports from $from to $to.")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/SecurityConfiguration.kt
@@ -47,9 +47,6 @@ class SecurityConfiguration<S : Session> : WebSecurityConfigurerAdapter() {
   @Autowired
   private lateinit var auditService: AuditService
 
-  @Autowired
-  private lateinit var timeSource: TimeSource
-
   @Throws(Exception::class)
   override fun configure(http: HttpSecurity) {
     http {
@@ -82,10 +79,10 @@ class SecurityConfiguration<S : Session> : WebSecurityConfigurerAdapter() {
   }
 
   @Bean
-  fun logInHandler() = LogInAuditHandler(auditService, timeSource)
+  fun logInHandler() = LogInAuditHandler(auditService)
 
   @Bean
-  fun logOutHandler() = LogOutAuditHandler(auditService, authLogoutSuccessUri, timeSource)
+  fun logOutHandler() = LogOutAuditHandler(auditService, authLogoutSuccessUri)
 
   @Bean
   fun clusteredConcurrentSessionRegistry(): SpringSessionBackedSessionRegistry<S> =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/OutputSpreadsheetController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/OutputSpreadsheetController.kt
@@ -5,6 +5,7 @@ import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
@@ -33,9 +34,10 @@ class OutputSpreadsheetController(
       name = "moves_from",
       required = true
     ) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) movesFrom: LocalDate,
-    response: HttpServletResponse?
+    response: HttpServletResponse?,
+    authentication: Authentication?
   ): ResponseEntity<InputStreamResource?>? {
-    auditService.create(AuditableEvent.createDownloadSpreadsheetEvent(movesFrom, supplier, timeSource))
+    auditService.create(AuditableEvent.createDownloadSpreadsheetEvent(movesFrom, supplier, authentication!!))
 
     return spreadsheetService.spreadsheet(supplier, movesFrom)?.let { file ->
       val uploadDateTime = timeSource.dateTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH_mm"))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MovePersister.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MovePersister.kt
@@ -20,7 +20,10 @@ class MovePersister(
 
   private val logger = LoggerFactory.getLogger(javaClass)
 
-  fun persist(moves: List<Move>) {
+  /**
+   * Returns the number of successfully persisted moves.
+   */
+  fun persist(moves: List<Move>): Int {
 
     var counter = 0
     val movesToSave = mutableListOf<Move>()
@@ -112,6 +115,8 @@ class MovePersister(
     }
 
     logger.info("Persisted $counter moves out of total ${moves.size}.")
+
+    return counter
   }
 
   fun processJourneys(move: Move, journeys: List<Journey>, journeyEvents: List<Event>): List<Journey> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MovePersister.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/MovePersister.kt
@@ -21,7 +21,7 @@ class MovePersister(
   private val logger = LoggerFactory.getLogger(javaClass)
 
   /**
-   * Returns the number of successfully persisted moves.
+   * Returns the total number of successfully persisted moves.
    */
   fun persist(moves: List<Move>): Int {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/PersonPersister.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/PersonPersister.kt
@@ -13,7 +13,10 @@ class PersonPersister(
 
   private val logger = LoggerFactory.getLogger(javaClass)
 
-  fun persistPeople(people: List<Person>) {
+  /**
+   * Returns the number of successfully persisted people.
+   */
+  fun persistPeople(people: List<Person>): Int {
     logger.info("Persisting ${people.size} people")
     var counter = 0
     val peopleToSave = mutableListOf<Person>()
@@ -25,6 +28,8 @@ class PersonPersister(
     }
 
     if (peopleToSave.isNotEmpty()) savePeople(peopleToSave) { logger.info("Persisted $counter people out of ${people.size} (flushing people to the database).") }
+
+    return counter
   }
 
   private fun savePeople(people: MutableList<Person>, success: () -> Unit) {
@@ -38,7 +43,10 @@ class PersonPersister(
       }
   }
 
-  fun persistProfiles(profiles: List<Profile>) {
+  /**
+   * Returns the number of successfully persisted profiles.
+   */
+  fun persistProfiles(profiles: List<Profile>): Int {
     logger.info("Persisting ${profiles.size} profiles")
     var counter = 0
     val profilesToSave = mutableListOf<Profile>()
@@ -51,6 +59,8 @@ class PersonPersister(
     }
 
     if (profilesToSave.isNotEmpty()) saveProfiles(profilesToSave) { logger.info("Persisted $counter profiles out of ${profiles.size} (flushing profiles to the database).") }
+
+    return counter
   }
 
   private fun saveProfiles(profiles: MutableList<Profile>, success: () -> Unit) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/PersonPersister.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/PersonPersister.kt
@@ -14,7 +14,7 @@ class PersonPersister(
   private val logger = LoggerFactory.getLogger(javaClass)
 
   /**
-   * Returns the number of successfully persisted people.
+   * Returns the total number of successfully persisted people.
    */
   fun persistPeople(people: List<Person>): Int {
     logger.info("Persisting ${people.size} people")
@@ -44,7 +44,7 @@ class PersonPersister(
   }
 
   /**
-   * Returns the number of successfully persisted profiles.
+   * Returns the total number of successfully persisted profiles.
    */
   fun persistProfiles(profiles: List<Profile>): Int {
     logger.info("Persisting ${profiles.size} profiles")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/schedule/ReportsImporterScheduler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/schedule/ReportsImporterScheduler.kt
@@ -25,6 +25,6 @@ class ReportsImporterScheduler(
 
     logger.info("Importing previous days reporting data: $yesterday.")
 
-    importService.importReports(yesterday, yesterday)
+    importService.importReportsOn(yesterday)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AuditService.kt
@@ -6,15 +6,16 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditEvent
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditEventRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditableEvent
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 
 @Service
 @Transactional
-class AuditService(private val auditEventRepository: AuditEventRepository) {
+class AuditService(private val auditEventRepository: AuditEventRepository, private val timeSource: TimeSource) {
   fun create(event: AuditableEvent) {
     auditEventRepository.save(
       AuditEvent(
         event.type,
-        event.timestamp,
+        timeSource.dateTime(),
         event.username.trim().toUpperCase(),
         event.extras?.let { Klaxon().toJsonString(it) }
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BulkPricesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BulkPricesService.kt
@@ -46,6 +46,6 @@ class BulkPricesService(
 
     logger.info("$total $supplier prices added for effective year ${nextEffectiveYearForDate(now)}")
 
-    auditService.create(AuditableEvent.createJourneyPriceBulkUpdateEvent(supplier, multiplier, timeSource))
+    auditService.create(AuditableEvent.createJourneyPriceBulkUpdateEvent(supplier, multiplier))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
@@ -2,8 +2,8 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.service
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
-import uk.gov.justice.digital.hmpps.pecs.jpc.importer.location.LocationsImporter
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.price.PriceImporter
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.ReportImporter
 import uk.gov.justice.digital.hmpps.pecs.jpc.move.MovePersister
@@ -13,9 +13,9 @@ import java.time.Duration
 import java.time.LocalDate
 
 @Service
+@Transactional
 class ImportService(
   private val timeSource: TimeSource,
-  private val locationsImporter: LocationsImporter,
   private val priceImporter: PriceImporter,
   private val reportImporter: ReportImporter,
   private val movePersister: MovePersister,
@@ -24,8 +24,6 @@ class ImportService(
 
   private val logger = LoggerFactory.getLogger(javaClass)
 
-  fun importLocations() = import(locationsImporter::import)
-
   fun importPrices(supplier: Supplier) = import { priceImporter.import(supplier) }
 
   fun importReports(reportsFrom: LocalDate, reportsTo: LocalDate) {
@@ -33,25 +31,28 @@ class ImportService(
     importPeopleProfiles(reportsFrom, reportsTo)
   }
 
-  fun importMovesJourneysEvents(reportsFrom: LocalDate, reportsTo: LocalDate) {
+  private fun importMovesJourneysEvents(reportsFrom: LocalDate, reportsTo: LocalDate) {
     logger.info("Importing moves, journeys and events from '$reportsFrom' to '$reportsTo'.")
-    val movesJourneysEvents = import { reportImporter.importMovesJourneysEvents(reportsFrom, reportsTo) }
-    movesJourneysEvents?.let { movePersister.persist(it.toList()) }
+
+    import { reportImporter.importMovesJourneysEvents(reportsFrom, reportsTo) }?.let {
+      val total = movePersister.persist(it.toList())
+    }
   }
 
-  fun importPeopleProfiles(reportsFrom: LocalDate, reportsTo: LocalDate) {
+  private fun importPeopleProfiles(reportsFrom: LocalDate, reportsTo: LocalDate) {
     logger.info("Importing people from '$reportsFrom' to '$reportsTo'.")
-    val people = import { reportImporter.importPeople(reportsFrom, reportsTo) }
-    people?.let { personPersister.persistPeople(it.toList()) }
+
+    import { reportImporter.importPeople(reportsFrom, reportsTo) }?.let {
+      val total = personPersister.persistPeople(it.toList())
+    }
 
     logger.info("Importing profiles from '$reportsFrom' to '$reportsTo'.")
-    val profiles = import { reportImporter.importProfiles(reportsFrom, reportsTo) }
-    profiles?.let { personPersister.persistProfiles(it.toList()) }
+
+    import { reportImporter.importProfiles(reportsFrom, reportsTo) }?.let {
+      val total = personPersister.persistProfiles(it.toList())
+    }
   }
 
-  /**
-   * @return a pair representing the return result of the importer, and an import status
-   */
   private fun <T> import(import: () -> T): T? {
     logger.info("Attempting import of ${import.javaClass}")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MapFriendlyLocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MapFriendlyLocationService.kt
@@ -31,7 +31,6 @@ class MapFriendlyLocationService(
       it.locationType = locationType
 
       val event = AuditableEvent.createLocationEvent(
-        timeSource,
         oldLocation,
         locationRepository.save(it).copy(),
       )
@@ -41,7 +40,6 @@ class MapFriendlyLocationService(
     }
 
     val event = AuditableEvent.createLocationEvent(
-      timeSource,
       locationRepository.save(
         Location(
           locationType,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/TestConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/TestConfig.kt
@@ -77,7 +77,7 @@ class TestConfig {
   }
 
   @Bean
-  fun reportImporter() = ReportImporter(reportingResourceProvider(), timeSource())
+  fun reportImporter() = ReportImporter(reportingResourceProvider())
 
   @Bean
   fun jpcTemplateProvider(): JPCTemplateProvider {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommandsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommandsTest.kt
@@ -40,23 +40,23 @@ internal class ImportCommandsTest {
   internal fun `import one days reporting data`() {
     commands.importReports(date, date)
 
-    verify(importService).importReports(date, date)
-    verify(importService, times(1)).importReports(any(), any())
+    verify(importService).importReportsOn(date)
+    verify(importService, times(1)).importReportsOn(any())
   }
 
   @Test
   internal fun `import two days reporting data`() {
     commands.importReports(date, date.plusDays(1))
 
-    verify(importService).importReports(date, date)
-    verify(importService).importReports(LocalDate.of(2020, 10, 1), LocalDate.of(2020, 10, 1))
-    verify(importService, times(2)).importReports(any(), any())
+    verify(importService).importReportsOn(date)
+    verify(importService).importReportsOn(LocalDate.of(2020, 10, 1))
+    verify(importService, times(2)).importReportsOn(any())
   }
 
   @Test
   internal fun `import spanning entire leap year of reporting data`() {
     commands.importReports(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 12, 31))
 
-    verify(importService, times(366)).importReports(any(), any())
+    verify(importService, times(366)).importReportsOn(any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/schedule/ReportsImporterSchedulerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/schedule/ReportsImporterSchedulerTest.kt
@@ -16,6 +16,6 @@ class ReportsImporterSchedulerTest {
   fun `previous days reports data import invoked with correct dates`() {
     ReportsImporterScheduler(importService, timeSource).importPreviousDaysReports()
 
-    verify(importService).importReports(timeSource.date().minusDays(1), timeSource.date().minusDays(1))
+    verify(importService).importReportsOn(timeSource.date().minusDays(1))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BulkPricesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BulkPricesServiceTest.kt
@@ -47,7 +47,6 @@ internal class BulkPricesServiceTest {
           AuditableEvent(
             AuditEventType.JOURNEY_PRICE_BULK_UPDATE,
             "_TERMINAL_",
-            timeSourceEffectiveYear2020.dateTime(),
             mapOf("supplier" to Supplier.SERCO, "multiplier" to 1.5)
           )
         )
@@ -76,7 +75,6 @@ internal class BulkPricesServiceTest {
           AuditableEvent(
             AuditEventType.JOURNEY_PRICE_BULK_UPDATE,
             "_TERMINAL_",
-            timeSourceEffectiveYear2021.dateTime(),
             mapOf("supplier" to Supplier.GEOAMEY, "multiplier" to 2.0)
           )
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
@@ -1,11 +1,18 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.service
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditableEvent
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.price.PriceImporter
+import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.Person
+import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.Profile
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.ReportImporter
+import uk.gov.justice.digital.hmpps.pecs.jpc.move.Move
 import uk.gov.justice.digital.hmpps.pecs.jpc.move.MovePersister
 import uk.gov.justice.digital.hmpps.pecs.jpc.move.PersonPersister
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
@@ -16,10 +23,17 @@ internal class ImportServiceTest {
   private val timeSourceWithFixedDate: TimeSource = TimeSource { LocalDateTime.of(2021, 2, 18, 12, 0, 0) }
   private val priceImporter: PriceImporter = mock()
   private val reportImporter: ReportImporter = mock()
-  private val movePersister: MovePersister = mock()
-  private val personPersister: PersonPersister = mock()
+  private val movePersister: MovePersister = mock { on { persist(any()) } doReturn 1 }
+  private val personPersister: PersonPersister = mock {
+    on { persistPeople(any()) } doReturn 1
+    on { persistProfiles(any()) } doReturn 1
+  }
+  private val move: Move = mock()
+  private val person: Person = mock()
+  private val profile: Profile = mock()
+  private val auditService: AuditService = mock()
   private val importService: ImportService =
-    ImportService(timeSourceWithFixedDate, priceImporter, reportImporter, movePersister, personPersister)
+    ImportService(timeSourceWithFixedDate, priceImporter, reportImporter, movePersister, personPersister, auditService)
 
   @Test
   internal fun `price importer interactions for Serco`() {
@@ -37,10 +51,23 @@ internal class ImportServiceTest {
 
   @Test
   internal fun `report importer interactions`() {
-    importService.importReports(timeSourceWithFixedDate.date(), timeSourceWithFixedDate.date())
+    importService.importReportsOn(timeSourceWithFixedDate.date())
 
-    verify(reportImporter).importMovesJourneysEvents(timeSourceWithFixedDate.date(), timeSourceWithFixedDate.date())
-    verify(reportImporter).importPeople(timeSourceWithFixedDate.date(), timeSourceWithFixedDate.date())
-    verify(reportImporter).importProfiles(timeSourceWithFixedDate.date(), timeSourceWithFixedDate.date())
+    verify(reportImporter).importMovesJourneysEventsOn(timeSourceWithFixedDate.date())
+    verify(reportImporter).importPeopleOn(timeSourceWithFixedDate.date())
+    verify(reportImporter).importProfilesOn(timeSourceWithFixedDate.date())
+  }
+
+  @Test
+  internal fun `auditing interactions`() {
+    whenever(reportImporter.importMovesJourneysEventsOn(timeSourceWithFixedDate.date())).thenReturn(listOf(move))
+    whenever(reportImporter.importPeopleOn(timeSourceWithFixedDate.date())).thenReturn(sequenceOf(person))
+    whenever(reportImporter.importProfilesOn(timeSourceWithFixedDate.date())).thenReturn(sequenceOf(profile))
+
+    importService.importReportsOn(timeSourceWithFixedDate.date())
+
+    verify(auditService).create(AuditableEvent.createImportEvent("moves", 1, 1))
+    verify(auditService).create(AuditableEvent.createImportEvent("people", 1, 1))
+    verify(auditService).create(AuditableEvent.createImportEvent("profiles", 1, 1))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.service
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
+import uk.gov.justice.digital.hmpps.pecs.jpc.importer.price.PriceImporter
+import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.ReportImporter
+import uk.gov.justice.digital.hmpps.pecs.jpc.move.MovePersister
+import uk.gov.justice.digital.hmpps.pecs.jpc.move.PersonPersister
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import java.time.LocalDateTime
+
+internal class ImportServiceTest {
+
+  private val timeSourceWithFixedDate: TimeSource = TimeSource { LocalDateTime.of(2021, 2, 18, 12, 0, 0) }
+  private val priceImporter: PriceImporter = mock()
+  private val reportImporter: ReportImporter = mock()
+  private val movePersister: MovePersister = mock()
+  private val personPersister: PersonPersister = mock()
+  private val importService: ImportService =
+    ImportService(timeSourceWithFixedDate, priceImporter, reportImporter, movePersister, personPersister)
+
+  @Test
+  internal fun `price importer interactions for Serco`() {
+    importService.importPrices(Supplier.SERCO)
+
+    verify(priceImporter).import(Supplier.SERCO)
+  }
+
+  @Test
+  internal fun `price importer interactions for GEOAmey`() {
+    importService.importPrices(Supplier.GEOAMEY)
+
+    verify(priceImporter).import(Supplier.GEOAMEY)
+  }
+
+  @Test
+  internal fun `report importer interactions`() {
+    importService.importReports(timeSourceWithFixedDate.date(), timeSourceWithFixedDate.date())
+
+    verify(reportImporter).importMovesJourneysEvents(timeSourceWithFixedDate.date(), timeSourceWithFixedDate.date())
+    verify(reportImporter).importPeople(timeSourceWithFixedDate.date(), timeSourceWithFixedDate.date())
+    verify(reportImporter).importProfiles(timeSourceWithFixedDate.date(), timeSourceWithFixedDate.date())
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingServiceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.service
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
@@ -20,7 +21,6 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.price.PriceRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.effectiveYearForDate
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 internal class SupplierPricingServiceTest {
 
@@ -33,12 +33,13 @@ internal class SupplierPricingServiceTest {
   private val price: Price = mock {
     on { priceInPence } doReturn priceInPence
     on { price() } doReturn Money.Factory.valueOf(priceInPence / 100.0)
+    on { fromLocation } doReturn fromLocation
+    on { toLocation } doReturn toLocation
   }
   private val service: SupplierPricingService =
     SupplierPricingService(
       locationRepository,
       priceRepository,
-      { LocalDateTime.of(2021, 1, 1, 12, 0) },
       auditService
     )
   private val priceCaptor = argumentCaptor<Price>()
@@ -86,6 +87,7 @@ internal class SupplierPricingServiceTest {
   internal fun `add new price for supplier`() {
     whenever(locationRepository.findByNomisAgencyId("FROM")).thenReturn(fromLocation)
     whenever(locationRepository.findByNomisAgencyId("TO")).thenReturn(toLocation)
+    whenever(priceRepository.save(any())).thenReturn(price)
 
     service.addPriceForSupplier(
       Supplier.SERCO,
@@ -134,6 +136,7 @@ internal class SupplierPricingServiceTest {
         effectiveYearForDate(effectiveDate)
       )
     ).thenReturn(price)
+    whenever(priceRepository.save(any())).thenReturn(price)
 
     service.updatePriceForSupplier(
       Supplier.SERCO,


### PR DESCRIPTION
Changes:

- Auditing of imports a long with some refactorings.
- I have removed the ability to specify a date range at the service level when importing reports.   Due to large volumes of data we should only be doing one day at a time.
- Some tweaks around auditing e.g. tidying up the meta data to use snakecase which is more in line with JSON.
- Some tweaks to the auditable events also.  Removed timesource (I know this was my suggestion originally) as just too noisy.
- I think there is still some possible tidy up needed around the authentication.  If it is needed then it shouldn't be nullable via the interface.
