### PR TITLE
P4-2657 futher changes to include report date (a long with some refactoring) to audit imports.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditableEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditableEvent.kt
@@ -31,13 +31,13 @@ data class AuditableEvent(
       )
     }
 
-    fun createLogInEvent(authentication: Authentication) = createEvent(AuditEventType.LOG_IN, authentication)
+    fun logInEvent(authentication: Authentication) = createEvent(AuditEventType.LOG_IN, authentication)
 
-    fun createLogOutEvent(authentication: Authentication) = createEvent(AuditEventType.LOG_OUT, authentication)
+    fun logOutEvent(authentication: Authentication) = createEvent(AuditEventType.LOG_OUT, authentication)
 
-    fun createDownloadSpreadsheetEvent(
+    fun downloadSpreadsheetEvent(
       date: LocalDate,
-      supplier: String,
+      supplier: Supplier,
       authentication: Authentication
     ) =
       createEvent(
@@ -46,7 +46,7 @@ data class AuditableEvent(
         mapOf("month" to date.format(DateTimeFormatter.ofPattern("yyyy-MM")), "supplier" to supplier)
       )
 
-    fun createAddPriceEvent(
+    fun addPriceEvent(
       newPrice: Price,
       authentication: Authentication? = SecurityContextHolder.getContext().authentication,
     ): AuditableEvent {
@@ -61,7 +61,7 @@ data class AuditableEvent(
       return createEvent(AuditEventType.JOURNEY_PRICE, authentication, metadata)
     }
 
-    fun createUpdatePriceEvent(
+    fun updatePriceEvent(
       updatedPrice: Price,
       oldPrice: Money,
       authentication: Authentication? = SecurityContextHolder.getContext().authentication,
@@ -78,7 +78,7 @@ data class AuditableEvent(
       return createEvent(AuditEventType.JOURNEY_PRICE, authentication, metadata)
     }
 
-    fun createJourneyPriceBulkUpdateEvent(
+    fun journeyPriceBulkUpdateEvent(
       supplier: Supplier,
       multiplier: Double,
       authentication: Authentication? = SecurityContextHolder.getContext().authentication,
@@ -89,7 +89,7 @@ data class AuditableEvent(
       true
     )
 
-    fun createLocationEvent(
+    fun locationEvent(
       oldLocation: Location,
       newLocation: Location? = null,
       authentication: Authentication? = SecurityContextHolder.getContext().authentication
@@ -121,11 +121,12 @@ data class AuditableEvent(
       )
     }
 
-    fun createImportEvent(type: String, processed: Int, saved: Int) =
+    fun importReportEvent(type: String, reportDate: LocalDate, processed: Int, saved: Int) =
       createEvent(
         type = AuditEventType.REPORTING_DATA_IMPORT,
         metadata = mapOf(
           "type" to type,
+          "report_date" to reportDate.toString(),
           "processed" to processed,
           "saved" to saved
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/LogInAuditHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/LogInAuditHandler.kt
@@ -13,7 +13,7 @@ class LogInAuditHandler(private val auditService: AuditService) :
     response: HttpServletResponse?,
     authentication: Authentication?
   ) {
-    auditService.create(AuditableEvent.createLogInEvent(authentication!!))
+    auditService.create(AuditableEvent.logInEvent(authentication!!))
     super.onAuthenticationSuccess(request, response, authentication)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/LogOutAuditHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/LogOutAuditHandler.kt
@@ -15,7 +15,7 @@ class LogOutAuditHandler(
     response: HttpServletResponse?,
     authentication: Authentication?
   ) {
-    auditService.create(AuditableEvent.createLogOutEvent(authentication!!))
+    auditService.create(AuditableEvent.logOutEvent(authentication!!))
     defaultTargetUrl = authLogoutSuccessUri
     super.onLogoutSuccess(request, response, authentication)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/OutputSpreadsheetController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/OutputSpreadsheetController.kt
@@ -10,9 +10,9 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditableEvent
+import org.springframework.web.bind.annotation.SessionAttributes
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
-import uk.gov.justice.digital.hmpps.pecs.jpc.service.AuditService
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.SpreadsheetService
 import java.io.FileInputStream
 import java.io.IOException
@@ -21,10 +21,10 @@ import java.time.format.DateTimeFormatter
 import javax.servlet.http.HttpServletResponse
 
 @RestController
+@SessionAttributes(HtmlController.SUPPLIER_ATTRIBUTE)
 class OutputSpreadsheetController(
   private val spreadsheetService: SpreadsheetService,
-  private val timeSource: TimeSource,
-  private val auditService: AuditService
+  private val timeSource: TimeSource
 ) {
   @GetMapping("/generate-prices-spreadsheet/{supplier}")
   @Throws(IOException::class)
@@ -37,11 +37,9 @@ class OutputSpreadsheetController(
     response: HttpServletResponse?,
     authentication: Authentication?
   ): ResponseEntity<InputStreamResource?>? {
-    auditService.create(AuditableEvent.createDownloadSpreadsheetEvent(movesFrom, supplier, authentication!!))
-
-    return spreadsheetService.spreadsheet(supplier, movesFrom)?.let { file ->
+    return spreadsheetService.spreadsheet(authentication!!, Supplier.valueOfCaseInsensitive(supplier), movesFrom)?.let { file ->
       val uploadDateTime = timeSource.dateTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH_mm"))
-      val filename = "Journey_Variable_Payment_Output_${supplier}_$uploadDateTime.xlsx"
+      val filename = "Journey_Variable_Payment_Output_${Supplier.valueOfCaseInsensitive(supplier)}_$uploadDateTime.xlsx"
       val mediaType: MediaType = MediaType.parseMediaType("application/vnd.ms-excel")
       val resource = InputStreamResource(FileInputStream(file))
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BulkPricesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BulkPricesService.kt
@@ -46,6 +46,6 @@ class BulkPricesService(
 
     logger.info("$total $supplier prices added for effective year ${nextEffectiveYearForDate(now)}")
 
-    auditService.create(AuditableEvent.createJourneyPriceBulkUpdateEvent(supplier, multiplier))
+    auditService.create(AuditableEvent.journeyPriceBulkUpdateEvent(supplier, multiplier))
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
@@ -39,7 +39,7 @@ class ImportService(
     import { reportImporter.importMovesJourneysEventsOn(date) }?.let {
       val moves = it.toList()
       movePersister.persist(moves).let { persisted ->
-        auditService.create(AuditableEvent.createImportEvent("moves", moves.size, persisted))
+        auditService.create(AuditableEvent.importReportEvent("moves", date, moves.size, persisted))
       }
     }
   }
@@ -50,7 +50,7 @@ class ImportService(
     import { reportImporter.importPeopleOn(date) }?.let {
       val people = it.toList()
       personPersister.persistPeople(people).let { persisted ->
-        auditService.create(AuditableEvent.createImportEvent("people", people.size, persisted))
+        auditService.create(AuditableEvent.importReportEvent("people", date, people.size, persisted))
       }
     }
 
@@ -59,7 +59,7 @@ class ImportService(
     import { reportImporter.importProfilesOn(date) }?.let {
       val profiles = it.toList()
       personPersister.persistProfiles(profiles).let { persisted ->
-        auditService.create(AuditableEvent.createImportEvent("profiles", profiles.size, persisted))
+        auditService.create(AuditableEvent.importReportEvent("profiles", date, profiles.size, persisted))
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MapFriendlyLocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MapFriendlyLocationService.kt
@@ -30,7 +30,7 @@ class MapFriendlyLocationService(
       it.siteName = friendlyLocationName.trim().toUpperCase()
       it.locationType = locationType
 
-      val event = AuditableEvent.createLocationEvent(
+      val event = AuditableEvent.locationEvent(
         oldLocation,
         locationRepository.save(it).copy(),
       )
@@ -39,7 +39,7 @@ class MapFriendlyLocationService(
       return
     }
 
-    val event = AuditableEvent.createLocationEvent(
+    val event = AuditableEvent.locationEvent(
       locationRepository.save(
         Location(
           locationType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SpreadsheetService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SpreadsheetService.kt
@@ -1,21 +1,27 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.service
 
 import org.slf4j.LoggerFactory
+import org.springframework.security.core.Authentication
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditableEvent
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.spreadsheet.PricesSpreadsheetGenerator
 import java.io.File
 import java.time.LocalDate
 
 @Service
-class SpreadsheetService(private val pricesSpreadsheetGenerator: PricesSpreadsheetGenerator) {
+class SpreadsheetService(
+  private val pricesSpreadsheetGenerator: PricesSpreadsheetGenerator,
+  private val auditService: AuditService
+) {
 
   private val logger = LoggerFactory.getLogger(javaClass)
 
-  fun spreadsheet(supplierName: String, startDate: LocalDate): File? {
+  fun spreadsheet(authentication: Authentication, supplier: Supplier, startDate: LocalDate): File? {
+    logger.info("Generating spreadsheet for supplier '$supplier', moves from '$startDate''")
 
-    logger.info("Generating spreadsheet for supplier '$supplierName', moves from '$startDate''")
-
-    return pricesSpreadsheetGenerator.generate(Supplier.valueOfCaseInsensitive(supplierName), startDate)
+    return pricesSpreadsheetGenerator.generate(supplier, startDate).also {
+      auditService.create(AuditableEvent.downloadSpreadsheetEvent(startDate, supplier, authentication))
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingService.kt
@@ -68,7 +68,7 @@ class SupplierPricingService(
         priceInPence = price.pence,
         effectiveYear = effectiveYear
       )
-    ).let { auditService.create(AuditableEvent.createAddPriceEvent(it)) }
+    ).let { auditService.create(AuditableEvent.addPriceEvent(it)) }
   }
 
   fun updatePriceForSupplier(
@@ -93,7 +93,7 @@ class SupplierPricingService(
       existingPrice.apply {
         this.priceInPence = agreedNewPrice.pence
       }
-    ).let { auditService.create(AuditableEvent.createUpdatePriceEvent(it, oldPrice)) }
+    ).let { auditService.create(AuditableEvent.updatePriceEvent(it, oldPrice)) }
   }
 
   private fun getFromAndToLocationBy(from: String, to: String): Pair<Location, Location> =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/OutputSpreadsheetControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/OutputSpreadsheetControllerTest.kt
@@ -31,7 +31,7 @@ class OutputSpreadsheetControllerTest(@Autowired val mockMvc: MockMvc) {
     whenever(timeSource.dateTime()).thenReturn(LocalDateTime.of(2020, 10, 13, 15, 25))
     whenever(timeSource.date()).thenReturn(LocalDate.of(2020, 10, 13))
 
-    mockMvc.get("/generate-prices-spreadsheet/SERCO?moves_from=2020-10-01") { }
+    mockMvc.get("/generate-prices-spreadsheet/serco?moves_from=2020-10-01") { }
       .andExpect {
         status { isOk() }
         content { contentType("application/vnd.ms-excel") }
@@ -39,6 +39,25 @@ class OutputSpreadsheetControllerTest(@Autowired val mockMvc: MockMvc) {
           string(
             "Content-Disposition",
             "attachment;filename=Journey_Variable_Payment_Output_SERCO_2020-10-13_15_25.xlsx"
+          )
+        }
+      }
+  }
+
+  @Test
+  @WithMockUser(roles = ["PECS_JPC"])
+  fun `can generate spreadsheet with correct name for Geoamey`() {
+    whenever(timeSource.dateTime()).thenReturn(LocalDateTime.of(2020, 10, 13, 15, 25))
+    whenever(timeSource.date()).thenReturn(LocalDate.of(2020, 10, 13))
+
+    mockMvc.get("/generate-prices-spreadsheet/geoamey?moves_from=2020-10-01") { }
+      .andExpect {
+        status { isOk() }
+        content { contentType("application/vnd.ms-excel") }
+        header {
+          string(
+            "Content-Disposition",
+            "attachment;filename=Journey_Variable_Payment_Output_GEOAMEY_2020-10-13_15_25.xlsx"
           )
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AuditServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AuditServiceTest.kt
@@ -73,14 +73,14 @@ internal class AuditServiceTest {
 
   @Test
   internal fun `create log in audit event`() {
-    service.create(AuditableEvent.createLogInEvent(authentication))
+    service.create(AuditableEvent.logInEvent(authentication))
 
     verifyEvent(AuditEventType.LOG_IN, "MOCK NAME")
   }
 
   @Test
   internal fun `create log out audit event`() {
-    service.create(AuditableEvent.createLogOutEvent(authentication))
+    service.create(AuditableEvent.logOutEvent(authentication))
 
     verifyEvent(AuditEventType.LOG_OUT, "MOCK NAME")
   }
@@ -88,27 +88,27 @@ internal class AuditServiceTest {
   @Test
   internal fun `create download spreadsheet audit event`() {
     service.create(
-      AuditableEvent.createDownloadSpreadsheetEvent(
+      AuditableEvent.downloadSpreadsheetEvent(
         LocalDate.of(2021, 2, 1),
-        "serco",
+        Supplier.SERCO,
         authentication
       )
     )
 
-    verifyEvent(AuditEventType.DOWNLOAD_SPREADSHEET, "MOCK NAME", mapOf("month" to "2021-02", "supplier" to "serco"))
+    verifyEvent(AuditEventType.DOWNLOAD_SPREADSHEET, "MOCK NAME", mapOf("month" to "2021-02", "supplier" to "SERCO"))
   }
 
   @Test
   internal fun `create new location audit event`() {
     assertThatThrownBy {
-      AuditableEvent.createLocationEvent(
+      AuditableEvent.locationEvent(
         Location(LocationType.PR, "TEST1", "TEST 1 NAME")
       )
     }.isInstanceOf(RuntimeException::class.java)
       .hasMessage("Attempted to create audit event LOCATION without a user")
 
     service.create(
-      AuditableEvent.createLocationEvent(
+      AuditableEvent.locationEvent(
         Location(LocationType.AP, "TEST2", "TEST 2 NAME"),
         authentication = authentication
       )!!
@@ -124,7 +124,7 @@ internal class AuditServiceTest {
   @Test
   internal fun `create location name change audit event`() {
     assertThatThrownBy {
-      AuditableEvent.createLocationEvent(
+      AuditableEvent.locationEvent(
         Location(LocationType.PR, "TEST1", "TEST 1 NAME"),
         Location(LocationType.PR, "TEST1", "TEST A NAME")
       )
@@ -132,7 +132,7 @@ internal class AuditServiceTest {
       .hasMessage("Attempted to create audit event LOCATION without a user")
 
     service.create(
-      AuditableEvent.createLocationEvent(
+      AuditableEvent.locationEvent(
         Location(LocationType.AP, "TEST2", "TEST 2 NAME"),
         Location(LocationType.AP, "TEST2", "TEST B NAME"),
         authentication = authentication
@@ -149,7 +149,7 @@ internal class AuditServiceTest {
   @Test
   internal fun `create location type change audit event`() {
     assertThatThrownBy {
-      AuditableEvent.createLocationEvent(
+      AuditableEvent.locationEvent(
         Location(LocationType.AP, "TEST1", "TEST 1 NAME"),
         Location(LocationType.CO, "TEST1", "TEST 1 NAME")
       )
@@ -157,7 +157,7 @@ internal class AuditServiceTest {
       .hasMessage("Attempted to create audit event LOCATION without a user")
 
     service.create(
-      AuditableEvent.createLocationEvent(
+      AuditableEvent.locationEvent(
         Location(LocationType.HP, "TEST2", "TEST 2 NAME"),
         Location(LocationType.PR, "TEST2", "TEST 2 NAME"),
         authentication = authentication
@@ -174,7 +174,7 @@ internal class AuditServiceTest {
   @Test
   internal fun `create journey price set audit event`() {
     assertThatThrownBy {
-      AuditableEvent.createAddPriceEvent(
+      AuditableEvent.addPriceEvent(
         Price(
           supplier = Supplier.SERCO,
           fromLocation = Location(LocationType.CC, "TEST2", "TEST2"),
@@ -187,7 +187,7 @@ internal class AuditServiceTest {
       .hasMessage("Attempted to create audit event JOURNEY_PRICE without a user")
 
     service.create(
-      AuditableEvent.createAddPriceEvent(
+      AuditableEvent.addPriceEvent(
         Price(
           supplier = Supplier.SERCO,
           fromLocation = Location(LocationType.CC, "TEST2", "TEST2"),
@@ -215,7 +215,7 @@ internal class AuditServiceTest {
   @Test
   internal fun `create journey price change audit event`() {
     assertThatThrownBy {
-      AuditableEvent.createUpdatePriceEvent(
+      AuditableEvent.updatePriceEvent(
         Price(
           supplier = Supplier.SERCO,
           fromLocation = Location(LocationType.CC, "TEST2", "TEST2"),
@@ -229,7 +229,7 @@ internal class AuditServiceTest {
       .hasMessage("Attempted to create audit event JOURNEY_PRICE without a user")
 
     service.create(
-      AuditableEvent.createUpdatePriceEvent(
+      AuditableEvent.updatePriceEvent(
         Price(
           supplier = Supplier.SERCO,
           fromLocation = Location(LocationType.CC, "TEST2", "TEST2"),
@@ -257,9 +257,9 @@ internal class AuditServiceTest {
 
   @Test
   internal fun `create journey price bulk update audit event`() {
-    service.create(AuditableEvent.createJourneyPriceBulkUpdateEvent(Supplier.SERCO, 1.5))
+    service.create(AuditableEvent.journeyPriceBulkUpdateEvent(Supplier.SERCO, 1.5))
     service.create(
-      AuditableEvent.createJourneyPriceBulkUpdateEvent(
+      AuditableEvent.journeyPriceBulkUpdateEvent(
         Supplier.GEOAMEY,
         2.0,
         authentication = authentication
@@ -275,6 +275,17 @@ internal class AuditServiceTest {
       AuditEventType.JOURNEY_PRICE_BULK_UPDATE,
       "MOCK NAME",
       mapOf("supplier" to Supplier.GEOAMEY, "multiplier" to 2.0)
+    )
+  }
+
+  @Test
+  internal fun `create import reports audit event`() {
+    service.create(AuditableEvent.importReportEvent("moves", LocalDate.of(2021, 2, 22), 20, 10))
+
+    verifyEvent(
+      AuditEventType.REPORTING_DATA_IMPORT,
+      "_TERMINAL_",
+      mapOf("type" to "moves", "report_date" to "2021-02-22", "processed" to 20, "saved" to 10)
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
@@ -66,8 +66,8 @@ internal class ImportServiceTest {
 
     importService.importReportsOn(timeSourceWithFixedDate.date())
 
-    verify(auditService).create(AuditableEvent.createImportEvent("moves", 1, 1))
-    verify(auditService).create(AuditableEvent.createImportEvent("people", 1, 1))
-    verify(auditService).create(AuditableEvent.createImportEvent("profiles", 1, 1))
+    verify(auditService).create(AuditableEvent.importReportEvent("moves", timeSourceWithFixedDate.date(), 1, 1))
+    verify(auditService).create(AuditableEvent.importReportEvent("people", timeSourceWithFixedDate.date(), 1, 1))
+    verify(auditService).create(AuditableEvent.importReportEvent("profiles", timeSourceWithFixedDate.date(), 1, 1))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SpreadsheetServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SpreadsheetServiceTest.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.service
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.Authentication
+import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditableEvent
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import uk.gov.justice.digital.hmpps.pecs.jpc.spreadsheet.PricesSpreadsheetGenerator
+import java.time.LocalDate
+
+internal class SpreadsheetServiceTest {
+
+  private val authentication: Authentication = mock()
+
+  private val pricesSpreadsheetGenerator: PricesSpreadsheetGenerator = mock()
+
+  private val auditService: AuditService = mock()
+
+  private val service: SpreadsheetService = SpreadsheetService(pricesSpreadsheetGenerator, auditService)
+
+  @Test
+  internal fun `service interactions for Serco`() {
+    verifyInteractionsFor(Supplier.SERCO)
+  }
+
+  @Test
+  internal fun `service interactions for GEOAmey`() {
+    verifyInteractionsFor(Supplier.GEOAMEY)
+  }
+
+  private fun verifyInteractionsFor(supplier: Supplier) {
+    service.spreadsheet(authentication, supplier, LocalDate.of(2021, 2, 22))
+
+    verify(pricesSpreadsheetGenerator).generate(supplier, LocalDate.of(2021, 2, 22))
+    verify(auditService).create(
+      AuditableEvent.downloadSpreadsheetEvent(
+        LocalDate.of(2021, 2, 22),
+        supplier,
+        authentication
+      )
+    )
+  }
+}


### PR DESCRIPTION
Changes:

- Fixing issues with the download spreadsheet where can use free text for supplier.
- Shifted the auditing of the spreadsheet download into the service so this is captured where it might take place.
- Shorted the build function names in the AuditableEvent.  
- Testing locally I spotted I had missed the report_date from the importing of reports. Also added missing test coverage.