### PR TITLE
P4-2761 adding simple free text monitoring around reports import whenever a persistence failure occurs.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MonitoringService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MonitoringService.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.service
+
+import io.sentry.Sentry
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+/**
+ * Simple service for capturing free text messages in the underlying monitoring tool.
+ */
+@Service
+class MonitoringService {
+
+  private val logger = LoggerFactory.getLogger(javaClass)
+
+  internal fun capture(message: String) {
+    if (Sentry.isEnabled()) Sentry.captureMessage(message) else logger.warn("Monitoring is disabled, ignoring message $message.")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
@@ -4,6 +4,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditableEvent
@@ -32,14 +33,24 @@ internal class ImportServiceTest {
   private val person: Person = mock()
   private val profile: Profile = mock()
   private val auditService: AuditService = mock()
+  private val monitoringService: MonitoringService = mock()
   private val importService: ImportService =
-    ImportService(timeSourceWithFixedDate, priceImporter, reportImporter, movePersister, personPersister, auditService)
+    ImportService(
+      timeSourceWithFixedDate,
+      priceImporter,
+      reportImporter,
+      movePersister,
+      personPersister,
+      auditService,
+      monitoringService
+    )
 
   @Test
   internal fun `price importer interactions for Serco`() {
     importService.importPrices(Supplier.SERCO)
 
     verify(priceImporter).import(Supplier.SERCO)
+    verifyZeroInteractions(monitoringService)
   }
 
   @Test
@@ -47,6 +58,7 @@ internal class ImportServiceTest {
     importService.importPrices(Supplier.GEOAMEY)
 
     verify(priceImporter).import(Supplier.GEOAMEY)
+    verifyZeroInteractions(monitoringService)
   }
 
   @Test
@@ -56,6 +68,7 @@ internal class ImportServiceTest {
     verify(reportImporter).importMovesJourneysEventsOn(timeSourceWithFixedDate.date())
     verify(reportImporter).importPeopleOn(timeSourceWithFixedDate.date())
     verify(reportImporter).importProfilesOn(timeSourceWithFixedDate.date())
+    verifyZeroInteractions(monitoringService)
   }
 
   @Test
@@ -69,5 +82,33 @@ internal class ImportServiceTest {
     verify(auditService).create(AuditableEvent.importReportEvent("moves", timeSourceWithFixedDate.date(), 1, 1))
     verify(auditService).create(AuditableEvent.importReportEvent("people", timeSourceWithFixedDate.date(), 1, 1))
     verify(auditService).create(AuditableEvent.importReportEvent("profiles", timeSourceWithFixedDate.date(), 1, 1))
+    verifyZeroInteractions(monitoringService)
+  }
+
+  @Test
+  internal fun `monitoring interactions when failure to persist moves`() {
+    whenever(reportImporter.importMovesJourneysEventsOn(timeSourceWithFixedDate.date())).thenReturn(listOf(move))
+    whenever(movePersister.persist(any())).thenReturn(0)
+
+    importService.importReportsOn(timeSourceWithFixedDate.date())
+    verify(monitoringService).capture("moves: persisted 0 out of 1 for reporting date ${timeSourceWithFixedDate.date()}.")
+  }
+
+  @Test
+  internal fun `monitoring interactions when failure to persist people`() {
+    whenever(reportImporter.importPeopleOn(timeSourceWithFixedDate.date())).thenReturn(sequenceOf(person))
+    whenever(personPersister.persistPeople(any())).thenReturn(0)
+
+    importService.importReportsOn(timeSourceWithFixedDate.date())
+    verify(monitoringService).capture("people: persisted 0 out of 1 for reporting date ${timeSourceWithFixedDate.date()}.")
+  }
+
+  @Test
+  internal fun `monitoring interactions when failure to persist profiles`() {
+    whenever(reportImporter.importProfilesOn(timeSourceWithFixedDate.date())).thenReturn(sequenceOf(profile))
+    whenever(personPersister.persistProfiles(any())).thenReturn(0)
+
+    importService.importReportsOn(timeSourceWithFixedDate.date())
+    verify(monitoringService).capture("profiles: persisted 0 out of 1 for reporting date ${timeSourceWithFixedDate.date()}.")
   }
 }


### PR DESCRIPTION
Changes:

- First cut at sending messages to Sentry IO monitoring service should there be any persistence failures during the importing of reporting data - moves, people and profiles.