### PR TITLE
P4-2611 pinning db version to be in-line with RDS to ensure no compatibility issues.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,9 @@ version: '3.1'
 
 services:
 
+# Pinning to specific DB version to be inline with RDS instances.
   db:
-    image: postgres:latest
+    image: postgres:10.16
     container_name: jpc-database
     depends_on:
       - localstack


### PR DESCRIPTION
Changes:

- Minor change to docker-compose file to pin to a specific DB version to avoid potential versioning issues/incompatibilities with the RDS instances in dev, preprod and prod.