### PR TITLE
P4-2675 changes to fix an issue with the price importer throwing a duplicate price exception.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.ReportImporter
 import uk.gov.justice.digital.hmpps.pecs.jpc.move.MovePersister
 import uk.gov.justice.digital.hmpps.pecs.jpc.move.PersonPersister
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.effectiveYearForDate
 import java.time.Duration
 import java.time.LocalDate
 
@@ -27,7 +28,7 @@ class ImportService(
   private val logger = LoggerFactory.getLogger(javaClass)
 
   @Transactional
-  fun importPrices(supplier: Supplier) = import { priceImporter.import(supplier) }
+  fun importPrices(supplier: Supplier) = import { priceImporter.import(supplier, effectiveYearForDate(timeSource.date())) }
 
   // The transaction boundary for this method is being set in the underlying persistence classes on purpose.
   fun importReportsOn(date: LocalDate) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/price/PricesSpreadsheetTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/price/PricesSpreadsheetTest.kt
@@ -27,7 +27,7 @@ internal class PricesSpreadsheetTest {
   @Nested
   inner class RecordingErrors {
 
-    private val spreadsheet: PricesSpreadsheet = PricesSpreadsheet(workbookSpy, Supplier.GEOAMEY, emptyList(), priceRepository)
+    private val spreadsheet: PricesSpreadsheet = PricesSpreadsheet(workbookSpy, Supplier.GEOAMEY, emptyList(), priceRepository, 2020)
 
     private val row: Row = sheet.createRow(0)
 
@@ -54,7 +54,7 @@ internal class PricesSpreadsheetTest {
     private val toLocation: Location = Location(LocationType.CC, "to agency id", "to site")
 
     private val spreadsheet: PricesSpreadsheet =
-      PricesSpreadsheet(workbookSpy, Supplier.GEOAMEY, listOf(fromLocation, toLocation), priceRepository)
+      PricesSpreadsheet(workbookSpy, Supplier.GEOAMEY, listOf(fromLocation, toLocation), priceRepository, 2020)
 
     private val row: Row = sheet.createRow(1).apply {
       this.createCell(0).setCellValue(1.0)
@@ -128,7 +128,7 @@ internal class PricesSpreadsheetTest {
 
     @Test
     internal fun `throws error if duplicate price`() {
-      whenever(priceRepository.findBySupplierAndFromLocationAndToLocation(Supplier.GEOAMEY, fromLocation, toLocation)).thenReturn(price)
+      whenever(priceRepository.findBySupplierAndFromLocationAndToLocationAndEffectiveYear(Supplier.GEOAMEY, fromLocation, toLocation, 2020)).thenReturn(price)
 
       assertThatThrownBy { spreadsheet.mapToPrice(row) }
         .isInstanceOf(RuntimeException::class.java)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
@@ -49,7 +49,7 @@ internal class ImportServiceTest {
   internal fun `price importer interactions for Serco`() {
     importService.importPrices(Supplier.SERCO)
 
-    verify(priceImporter).import(Supplier.SERCO)
+    verify(priceImporter).import(Supplier.SERCO, 2020)
     verifyZeroInteractions(monitoringService)
   }
 
@@ -57,7 +57,7 @@ internal class ImportServiceTest {
   internal fun `price importer interactions for GEOAmey`() {
     importService.importPrices(Supplier.GEOAMEY)
 
-    verify(priceImporter).import(Supplier.GEOAMEY)
+    verify(priceImporter).import(Supplier.GEOAMEY, 2020)
     verifyZeroInteractions(monitoringService)
   }
 


### PR DESCRIPTION
Changes:

- This changes the price importer to check existing prices effective year.  Without this we can get duplicate errors when really there shouldn't be.  For example we can have a 2019 price in the system where the **from** and **to** are the same as a 2020 price we are trying to import, this is not a duplicate!