### PR TITLE
P4-2691 resolve issue where by a price for the same from and to locations for each supplier were be returned in supplier specific queries i.e. two prices instead of one.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
@@ -231,6 +231,8 @@ class HtmlController(@Autowired val moveService: MoveService, @Autowired val jou
 
   @GetMapping(SEARCH_JOURNEYS_URL)
   fun searchJourneys(model: ModelMap): Any {
+    logger.info("getting search journey")
+
     val effectiveYear = model.getEffectiveYear()
 
     model.addAttribute("form", SearchJourneyForm())
@@ -250,6 +252,7 @@ class HtmlController(@Autowired val moveService: MoveService, @Autowired val jou
     model: ModelMap,
     redirectAttributes: RedirectAttributes,
   ): String {
+    logger.info("performing search journeys for $supplier")
 
     if (result.hasErrors()) return "search-journeys"
 
@@ -274,6 +277,8 @@ class HtmlController(@Autowired val moveService: MoveService, @Autowired val jou
     @ModelAttribute(name = SUPPLIER_ATTRIBUTE) supplier: Supplier,
     model: ModelMap
   ): Any {
+    logger.info("getting search journey results for $supplier")
+
     if (pickUpLocation.isNullOrEmpty() && dropOffLocation.isNullOrEmpty()) {
       return RedirectView(SEARCH_JOURNEYS_URL)
     }


### PR DESCRIPTION
Changes:

- This change resolves an issue whereby we were seeing multiple prices for a standard journey in the move view when there should only have been one.  The is the result of there being multiple prices at a given from and to location for both suppliers.
- Also added a bit more logging (unrelated to this particular fix.