### PR TITLE
P4-2961 resolve issue where by a price for the same from and to locations for each supplier were be returned in supplier specific journey queries i.e. two prices instead of one.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyQueryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyQueryRepository.kt
@@ -99,7 +99,7 @@ class JourneyQueryRepository(@Autowired val jdbcTemplate: JdbcTemplate) {
                      inner join JOURNEYS j on j.move_id = m.move_id
                      left join LOCATIONS jfl on j.from_nomis_agency_id = jfl.nomis_agency_id
                      left join LOCATIONS jtl on j.to_nomis_agency_id = jtl.nomis_agency_id
-                     left join PRICES p on jfl.location_id = p.from_location_id and jtl.location_id = p.to_location_id and j.effective_year = p.effective_year
+                     left join PRICES p on jfl.location_id = p.from_location_id and jtl.location_id = p.to_location_id and j.effective_year = p.effective_year and p.supplier = ?
                      where m.move_type is not null and m.supplier = ? and m.drop_off_or_cancelled >= ? 
                         and m.drop_off_or_cancelled < ?
             GROUP BY j.from_nomis_agency_id, j.to_nomis_agency_id, jfl.site_name, jtl.site_name, jfl.location_type, jtl.location_type, p.price_in_pence
@@ -110,6 +110,7 @@ class JourneyQueryRepository(@Autowired val jdbcTemplate: JdbcTemplate) {
     return jdbcTemplate.query(
       uniqueJourneysSQL,
       journeyWithPricesRowMapper,
+      supplier.name,
       supplier.name,
       Timestamp.valueOf(startDate.atStartOfDay()),
       Timestamp.valueOf(endDateInclusive.plusDays(1).atStartOfDay())
@@ -145,7 +146,7 @@ class JourneyQueryRepository(@Autowired val jdbcTemplate: JdbcTemplate) {
              inner join JOURNEYS j on j.move_id = m.move_id  
              left join LOCATIONS jfl on j.from_nomis_agency_id = jfl.nomis_agency_id 
              left join LOCATIONS jtl on j.to_nomis_agency_id = jtl.nomis_agency_id 
-             left join PRICES p on jfl.location_id = p.from_location_id and jtl.location_id = p.to_location_id and j.effective_year = p.effective_year
+             left join PRICES p on jfl.location_id = p.from_location_id and jtl.location_id = p.to_location_id and j.effective_year = p.effective_year and p.supplier = ?
              where m.move_type is not null and m.supplier = ? and m.drop_off_or_cancelled >= ?  
              and m.drop_off_or_cancelled < ?
              GROUP BY journey) as js
@@ -154,6 +155,7 @@ class JourneyQueryRepository(@Autowired val jdbcTemplate: JdbcTemplate) {
     return jdbcTemplate.query(
       journeysSummarySQL,
       journeysSummaryRowMapper,
+      supplier.name,
       supplier.name,
       Timestamp.valueOf(startDate.atStartOfDay()),
       Timestamp.valueOf(endDateInclusive.plusDays(1).atStartOfDay())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyQueryRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/move/JourneyQueryRepositoryTest.kt
@@ -55,6 +55,7 @@ internal class JourneyQueryRepositoryTest {
   fun beforeEach() {
     locationRepository.save(wyi)
     locationRepository.save(gni)
+
     priceRepository.save(
       Price(
         id = UUID.randomUUID(),
@@ -62,6 +63,17 @@ internal class JourneyQueryRepositoryTest {
         toLocation = gni,
         priceInPence = 999,
         supplier = Supplier.SERCO,
+        effectiveYear = 2020
+      )
+    )
+
+    priceRepository.save(
+      Price(
+        id = UUID.randomUUID(),
+        fromLocation = wyi,
+        toLocation = gni,
+        priceInPence = 666,
+        supplier = Supplier.GEOAMEY,
         effectiveYear = 2020
       )
     )


### PR DESCRIPTION
Changes:

- This change resolves an issue whereby we were seeing the same journeys summed up twice (for different prices) in the journeys tab of the downloaded spreadsheet. This is the result of there being multiple prices at a given from and to location for both suppliers and the other suppliers price was not being excluded in the underlying SQL query.