### PR TITLE
P4-2696 changes to (hopefully) fix a session related issue on the choose supplier screen

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/FilterConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/FilterConfiguration.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.config
 
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -12,15 +11,10 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.filter.ChooseSupplierFilter
 
 @Configuration
 class FilterConfiguration {
-
-  @Autowired
-  lateinit var timeSource: TimeSource
-
   @Bean
-  fun chooseFilter(): FilterRegistrationBean<ChooseSupplierFilter> {
-    val registrationBean: FilterRegistrationBean<ChooseSupplierFilter> = FilterRegistrationBean<ChooseSupplierFilter>()
-    registrationBean.filter = ChooseSupplierFilter(timeSource)
-    registrationBean.addUrlPatterns(DASHBOARD_URL, SELECT_MONTH_URL, JOURNEYS_URL, MOVES_BY_TYPE_URL)
-    return registrationBean
-  }
+  fun chooseFilter(): FilterRegistrationBean<ChooseSupplierFilter> =
+    FilterRegistrationBean<ChooseSupplierFilter>().apply {
+      this.filter = ChooseSupplierFilter()
+      this.addUrlPatterns(DASHBOARD_URL, SELECT_MONTH_URL, JOURNEYS_URL, MOVES_BY_TYPE_URL)
+    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
@@ -18,6 +18,7 @@ import org.springframework.web.servlet.ModelAndView
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import org.springframework.web.servlet.view.RedirectView
 import org.springframework.web.util.UriComponentsBuilder
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.constraint.ValidJourneySearch
 import uk.gov.justice.digital.hmpps.pecs.jpc.constraint.ValidMonthYear
 import uk.gov.justice.digital.hmpps.pecs.jpc.controller.HtmlController.Companion.DATE_ATTRIBUTE
@@ -47,7 +48,11 @@ data class MonthsWidget(val currentMonth: LocalDate, val nextMonth: LocalDate, v
   PICK_UP_ATTRIBUTE,
   DROP_OFF_ATTRIBUTE
 )
-class HtmlController(@Autowired val moveService: MoveService, @Autowired val journeyService: JourneyService) {
+class HtmlController(
+  @Autowired val moveService: MoveService,
+  @Autowired val journeyService: JourneyService,
+  @Autowired val timeSource: TimeSource
+) {
 
   private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -68,6 +73,8 @@ class HtmlController(@Autowired val moveService: MoveService, @Autowired val jou
     logger.info("chosen supplier Serco")
 
     model.addAttribute(SUPPLIER_ATTRIBUTE, Supplier.SERCO)
+    model.addAttribute(DATE_ATTRIBUTE, timeSource.startOfMonth())
+
     return RedirectView(DASHBOARD_URL)
   }
 
@@ -76,8 +83,12 @@ class HtmlController(@Autowired val moveService: MoveService, @Autowired val jou
     logger.info("chosen supplier GEOAmey")
 
     model.addAttribute(SUPPLIER_ATTRIBUTE, Supplier.GEOAMEY)
+    model.addAttribute(DATE_ATTRIBUTE, timeSource.startOfMonth())
+
     return RedirectView(DASHBOARD_URL)
   }
+
+  private fun TimeSource.startOfMonth() = this.date().withDayOfMonth(1)
 
   @RequestMapping("$MOVES_BY_TYPE_URL/{moveTypeString}")
   fun movesByType(
@@ -300,7 +311,8 @@ class HtmlController(@Autowired val moveService: MoveService, @Autowired val jou
   }
 
   private fun ModelMap.getStartOfMonth() =
-    this.getAttribute(DATE_ATTRIBUTE)?.let { it as LocalDate } ?: throw RuntimeException("date attribute not present in model")
+    this.getAttribute(DATE_ATTRIBUTE)?.let { it as LocalDate }
+      ?: throw RuntimeException("date attribute not present in model")
 
   private fun ModelMap.getEndOfMonth() = endOfMonth(getStartOfMonth())
 
@@ -323,5 +335,6 @@ class HtmlController(@Autowired val moveService: MoveService, @Autowired val jou
     const val SEARCH_JOURNEYS_URL = "/search-journeys"
     const val SEARCH_JOURNEYS_RESULTS_URL = "/journeys-results"
     const val FIND_MOVE_URL = "/find-move"
+    const val CHOOSE_SUPPLIER_URL = "/choose-supplier"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/filter/ChooseSupplierFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/filter/ChooseSupplierFilter.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.filter
 
 import org.slf4j.LoggerFactory
-import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
+import uk.gov.justice.digital.hmpps.pecs.jpc.controller.HtmlController
 import java.io.IOException
 import javax.servlet.Filter
 import javax.servlet.FilterChain
@@ -12,7 +12,7 @@ import javax.servlet.ServletResponse
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
-class ChooseSupplierFilter(private val timeSource: TimeSource) : Filter {
+class ChooseSupplierFilter : Filter {
 
   private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -22,16 +22,13 @@ class ChooseSupplierFilter(private val timeSource: TimeSource) : Filter {
 
   @Throws(IOException::class, ServletException::class)
   override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
-    val req = request as HttpServletRequest
-    val res = response as HttpServletResponse
-    val session = req.session
+    val session = (request as HttpServletRequest).session
 
-    when (session.getAttribute("supplier")) {
+    when (session.getAttribute(HtmlController.SUPPLIER_ATTRIBUTE)) {
       null -> {
-        logger.info("no supplier present in the session, redirecting to choose supplier")
+        logger.info("no supplier present in the session, redirecting to '${HtmlController.CHOOSE_SUPPLIER_URL}'")
 
-        session.setAttribute("date", timeSource.date().withDayOfMonth(1))
-        res.sendRedirect("/choose-supplier")
+        (response as HttpServletResponse).sendRedirect(HtmlController.CHOOSE_SUPPLIER_URL)
       }
       else -> chain.doFilter(request, response).also { logger.info("supplier present in the session") }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/filter/ChooseSupplierFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/filter/ChooseSupplierFilterTest.kt
@@ -6,8 +6,6 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
-import java.time.LocalDateTime
 import javax.servlet.FilterChain
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
@@ -23,9 +21,7 @@ internal class ChooseSupplierFilterTest {
 
   private val filterChain: FilterChain = mock()
 
-  private val timeSource: TimeSource = TimeSource { LocalDateTime.of(2020, 11, 18, 0, 0) }
-
-  private val filter: ChooseSupplierFilter = ChooseSupplierFilter(timeSource)
+  private val filter: ChooseSupplierFilter = ChooseSupplierFilter()
 
   @Test
   internal fun `filter redirects to choose supplier when no supplier selected`() {
@@ -35,7 +31,7 @@ internal class ChooseSupplierFilterTest {
     filter.doFilter(request, response, filterChain)
 
     verify(session).getAttribute("supplier")
-    verify(session).setAttribute("date", timeSource.date().withDayOfMonth(1))
+    verify(session, never()).setAttribute(any(), any())
     verify(response).sendRedirect("/choose-supplier")
   }
 


### PR DESCRIPTION
Changes:

So I have spent a bit of time trying to get to the bottom of this issue.  From what I can gather it only happens on the choose supplier screen.  I am not able to recreate it in my local development environment.

Looking at the code there may (possibly) be a race condition, this is an educated guess at this point.  So I have moved some of the logic closer to where it is actually needed/used.  The logic in question adds the chosen supplier to the users session (which ultimately gets persisted to the database session) and is then used straight after that by doing a redirect having chosen the supplier.  My suspicion is the time to persist it to the DB session and the point it is next used (it pulls it back from the session) after the redirect is the issue.

So as mentioned it is an educated guess change at this point in time given I cannot recreate it.