### PR TITLE
P4-2710 initial work for putting in WireMock so we can fake the BaSM API calls when running locally.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
     networks:
       - hmpps
     container_name: hmpps-auth
+    depends_on:
+      - hmpps-book-secure-move-api
     ports:
       - "9090:8080"
     healthcheck:
@@ -53,6 +55,17 @@ services:
     environment:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=dev
+
+  hmpps-book-secure-move-api:
+    image: rodolpheche/wiremock:latest
+    networks:
+      - hmpps
+    container_name: hmpps-book-secure-move-api
+    ports:
+      - "9999:8080"
+    volumes:
+      - $PWD/wiremock-docker:/home/wiremock
+    command: --verbose --global-response-templating
 
 networks:
   hmpps:

--- a/wiremock-docker/__files/basm-api/locations/COURT1.json
+++ b/wiremock-docker/__files/basm-api/locations/COURT1.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "7bad3789-0d49-44dc-bb8f-4ff32414fa0b",
+      "id": "1bad3789-0d49-44dc-bb8f-4ff32414fa0a",
       "type": "locations",
       "attributes": {
         "key": "court1",

--- a/wiremock-docker/__files/basm-api/locations/COURT1.json
+++ b/wiremock-docker/__files/basm-api/locations/COURT1.json
@@ -1,0 +1,44 @@
+{
+  "data": [
+    {
+      "id": "7bad3789-0d49-44dc-bb8f-4ff32414fa0b",
+      "type": "locations",
+      "attributes": {
+        "key": "court1",
+        "title": "Court One",
+        "location_type": "court",
+        "nomis_agency_id": "COURT1",
+        "can_upload_documents": false,
+        "young_offender_institution": false,
+        "premise": null,
+        "locality": null,
+        "city": null,
+        "country": null,
+        "postcode": "C111 ONE",
+        "latitude": null,
+        "longitude": null,
+        "disabled_at": null
+      },
+      "relationships": {
+        "suppliers": {
+          "data": []
+        }
+      }
+    }
+  ],
+  "included": [],
+  "meta": {
+    "pagination": {
+      "per_page": 20,
+      "total_pages": 1,
+      "total_objects": 1
+    }
+  },
+  "links": {
+    "self": "https://basmhost/api/reference/locations?filter%5Bnomis_agency_id%5D=COURT1&filter%5Byoung_offender_institution%5D=false&include=suppliers&page=1&per_page=20",
+    "first": "https://basmhost/api/reference/locations?filter%5Bnomis_agency_id%5D=COURT1&filter%5Byoung_offender_institution%5D=false&include=suppliers&page=1&per_page=20",
+    "prev": null,
+    "next": null,
+    "last": "https://basmhost/api/reference/locations?filter%5Bnomis_agency_id%5D=COURT1&filter%5Byoung_offender_institution%5D=false&include=suppliers&page=1&per_page=20"
+  }
+}

--- a/wiremock-docker/__files/basm-api/locations/COURT2.json
+++ b/wiremock-docker/__files/basm-api/locations/COURT2.json
@@ -1,13 +1,13 @@
 {
   "data": [
     {
-      "id": "7bad3789-0d49-44dc-bb8f-4ff32414fa0b",
+      "id": "2bad3789-0d49-44dc-bb8f-4ff32414fa0b",
       "type": "locations",
       "attributes": {
         "key": "court2",
         "title": "Court Two",
         "location_type": "court",
-        "nomis_agency_id": "COURT1",
+        "nomis_agency_id": "COURT2",
         "can_upload_documents": false,
         "young_offender_institution": false,
         "premise": null,

--- a/wiremock-docker/__files/basm-api/locations/COURT2.json
+++ b/wiremock-docker/__files/basm-api/locations/COURT2.json
@@ -1,0 +1,44 @@
+{
+  "data": [
+    {
+      "id": "7bad3789-0d49-44dc-bb8f-4ff32414fa0b",
+      "type": "locations",
+      "attributes": {
+        "key": "court2",
+        "title": "Court Two",
+        "location_type": "court",
+        "nomis_agency_id": "COURT1",
+        "can_upload_documents": false,
+        "young_offender_institution": false,
+        "premise": null,
+        "locality": null,
+        "city": null,
+        "country": null,
+        "postcode": "C2 TWO",
+        "latitude": null,
+        "longitude": null,
+        "disabled_at": null
+      },
+      "relationships": {
+        "suppliers": {
+          "data": []
+        }
+      }
+    }
+  ],
+  "included": [],
+  "meta": {
+    "pagination": {
+      "per_page": 20,
+      "total_pages": 1,
+      "total_objects": 1
+    }
+  },
+  "links": {
+    "self": "https://basmhost/api/reference/locations?filter%5Bnomis_agency_id%5D=COURT2&filter%5Byoung_offender_institution%5D=false&include=suppliers&page=1&per_page=20",
+    "first": "https://basmhost/api/reference/locations?filter%5Bnomis_agency_id%5D=COURT2&filter%5Byoung_offender_institution%5D=false&include=suppliers&page=1&per_page=20",
+    "prev": null,
+    "next": null,
+    "last": "https://basmhost/api/reference/locations?filter%5Bnomis_agency_id%5D=COURT2&filter%5Byoung_offender_institution%5D=false&include=suppliers&page=1&per_page=20"
+  }
+}

--- a/wiremock-docker/__files/basm-api/locations/PRISON1.json
+++ b/wiremock-docker/__files/basm-api/locations/PRISON1.json
@@ -1,0 +1,44 @@
+{
+  "data": [
+    {
+      "id": "7bad3789-0d49-44dc-bb8f-4ff32414fa0b",
+      "type": "locations",
+      "attributes": {
+        "key": "prison1",
+        "title": "Prison One",
+        "location_type": "prison",
+        "nomis_agency_id": "PRISON1",
+        "can_upload_documents": false,
+        "young_offender_institution": false,
+        "premise": null,
+        "locality": null,
+        "city": null,
+        "country": null,
+        "postcode": "P111 ONE",
+        "latitude": null,
+        "longitude": null,
+        "disabled_at": null
+      },
+      "relationships": {
+        "suppliers": {
+          "data": []
+        }
+      }
+    }
+  ],
+  "included": [],
+  "meta": {
+    "pagination": {
+      "per_page": 20,
+      "total_pages": 1,
+      "total_objects": 1
+    }
+  },
+  "links": {
+    "self": "https://basmhost/api/reference/locations?filter%5Bnomis_agency_id%5D=PRISON1&filter%5Byoung_offender_institution%5D=false&include=suppliers&page=1&per_page=20",
+    "first": "https://basmhost/api/reference/locations?filter%5Bnomis_agency_id%5D=PRISON1&filter%5Byoung_offender_institution%5D=false&include=suppliers&page=1&per_page=20",
+    "prev": null,
+    "next": null,
+    "last": "https://basmhost/api/reference/locations?filter%5Bnomis_agency_id%5D=PRISON1&filter%5Byoung_offender_institution%5D=false&include=suppliers&page=1&per_page=20"
+  }
+}

--- a/wiremock-docker/__files/basm-api/locations/PRISON1.json
+++ b/wiremock-docker/__files/basm-api/locations/PRISON1.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "7bad3789-0d49-44dc-bb8f-4ff32414fa0b",
+      "id": "2bad3789-0d49-44dc-bb8f-4ff32414fa0c",
       "type": "locations",
       "attributes": {
         "key": "prison1",

--- a/wiremock-docker/__files/basm-api/locations/PRISON2.json
+++ b/wiremock-docker/__files/basm-api/locations/PRISON2.json
@@ -1,0 +1,44 @@
+{
+  "data": [
+    {
+      "id": "7bad3789-0d49-44dc-bb8f-4ff32414fa0b",
+      "type": "locations",
+      "attributes": {
+        "key": "prison2",
+        "title": "Prison Two",
+        "location_type": "prison",
+        "nomis_agency_id": "PRISON2",
+        "can_upload_documents": false,
+        "young_offender_institution": false,
+        "premise": null,
+        "locality": null,
+        "city": null,
+        "country": null,
+        "postcode": "P222 TWO",
+        "latitude": null,
+        "longitude": null,
+        "disabled_at": null
+      },
+      "relationships": {
+        "suppliers": {
+          "data": []
+        }
+      }
+    }
+  ],
+  "included": [],
+  "meta": {
+    "pagination": {
+      "per_page": 20,
+      "total_pages": 1,
+      "total_objects": 1
+    }
+  },
+  "links": {
+    "self": "https://basmhost/api/reference/locations?filter%5Bnomis_agency_id%5D=PRISON2&filter%5Byoung_offender_institution%5D=false&include=suppliers&page=1&per_page=20",
+    "first": "https://basmhost/api/reference/locations?filter%5Bnomis_agency_id%5D=PRISON2&filter%5Byoung_offender_institution%5D=false&include=suppliers&page=1&per_page=20",
+    "prev": null,
+    "next": null,
+    "last": "https://basmhost/api/reference/locations?filter%5Bnomis_agency_id%5D=PRISON2&filter%5Byoung_offender_institution%5D=false&include=suppliers&page=1&per_page=20"
+  }
+}

--- a/wiremock-docker/__files/basm-api/locations/PRISON2.json
+++ b/wiremock-docker/__files/basm-api/locations/PRISON2.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "7bad3789-0d49-44dc-bb8f-4ff32414fa0b",
+      "id": "4bad3789-0d49-44dc-bb8f-4ff32414fa0d",
       "type": "locations",
       "attributes": {
         "key": "prison2",

--- a/wiremock-docker/mappings/basm_api_location_COURT1.json
+++ b/wiremock-docker/mappings/basm_api_location_COURT1.json
@@ -1,0 +1,16 @@
+{
+  "request" : {
+    "url" : "/api/reference/locations?filter%5Bnomis_agency_id%5D=COURT1",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName" : "basm-api/locations/COURT1.json",
+    "transformers": [
+      "response-template"
+    ]
+  }
+}

--- a/wiremock-docker/mappings/basm_api_location_COURT2.json
+++ b/wiremock-docker/mappings/basm_api_location_COURT2.json
@@ -1,0 +1,16 @@
+{
+  "request" : {
+    "url" : "/api/reference/locations?filter%5Bnomis_agency_id%5D=COURT2",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName" : "basm-api/locations/COURT2.json",
+    "transformers": [
+      "response-template"
+    ]
+  }
+}

--- a/wiremock-docker/mappings/basm_api_location_PRISON1.json
+++ b/wiremock-docker/mappings/basm_api_location_PRISON1.json
@@ -1,0 +1,16 @@
+{
+  "request" : {
+    "url" : "/api/reference/locations?filter%5Bnomis_agency_id%5D=PRISON1",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName" : "basm-api/locations/PRISON1.json",
+    "transformers": [
+      "response-template"
+    ]
+  }
+}

--- a/wiremock-docker/mappings/basm_api_location_PRISON2.json
+++ b/wiremock-docker/mappings/basm_api_location_PRISON2.json
@@ -1,0 +1,16 @@
+{
+  "request" : {
+    "url" : "/api/reference/locations?filter%5Bnomis_agency_id%5D=PRISON2",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName" : "basm-api/locations/PRISON2.json",
+    "transformers": [
+      "response-template"
+    ]
+  }
+}


### PR DESCRIPTION
Introducing stubbed BaSM API for local development.  This is just to support calls for locations based on their NOMIS agency id.