### PR TITLE
P4-2714 new service to load in the nomis location refrence data to help with agency id mappings.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/ImporterConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/ImporterConfiguration.kt
@@ -29,4 +29,7 @@ class ImporterConfiguration {
   @Bean
   fun supplierPrices() =
     SupplierPrices { supplier, year -> priceRepository.findBySupplierAndEffectiveYear(supplier, year) }
+
+  @Bean
+  fun nomisReferenceData() = NomisReferenceDataProvider { resourceLoader.getResource("classpath:/spreadsheets/nomis-locations.csv").inputStream }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/NomisReferenceDataProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/NomisReferenceDataProvider.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.config
+
+import java.io.InputStream
+
+/**
+ * Responsible for providing the NOMIS locations reference data via an [InputStream].
+ */
+fun interface NomisReferenceDataProvider {
+  /**
+   * The caller is responsible for closing the [InputStream].
+   */
+  fun get(): InputStream
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AgencyDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AgencyDetailsService.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.NomisReferenceDataProvider
+import javax.annotation.PostConstruct
+
+private const val HEADER_ROW = 0
+private const val NOMIS_AGENCY_ID = 0
+private const val NAME = 1
+
+@Service
+class AgencyDetailsService(
+  private val referenceData: NomisReferenceDataProvider,
+  private val monitoringService: MonitoringService
+) {
+  private val logger = LoggerFactory.getLogger(javaClass)
+
+  private val locations: MutableMap<String, String> = mutableMapOf()
+
+  fun findAgencyLocationNameBy(agencyId: String): String? =
+    when (val location = locations[agencyId.trim().toUpperCase()]) {
+      null -> {
+        logger.warn("No match found looking up reference data for agency id '${agencyId.trim().toUpperCase()}'")
+        monitoringService.capture("No match found looking up reference data for agency id '${agencyId.trim().toUpperCase()}'")
+        null
+      }
+      else -> location
+    }
+
+  @PostConstruct
+  internal fun loadInMemoryNomisLocationsReferenceData() {
+    Result.runCatching {
+      referenceData.get().reader().useLines { seq ->
+        seq.filterIndexed { line, _ -> line != HEADER_ROW }
+          .map { line -> line.split(",") }
+          .associateByTo(locations, { it[NOMIS_AGENCY_ID].trim().toUpperCase() }, { it[NAME].trim().toUpperCase() })
+      }
+    }.onSuccess {
+      logger.info("NOMIS locations reference data loaded ${locations.size} locations")
+    }.onFailure {
+      logger.error("An error occurred loading the NOMIS location reference data.", it)
+
+      monitoringService.capture("An error occurred loading the NOMIS location reference data.")
+    }
+  }
+}

--- a/src/main/resources/spreadsheets/nomis-locations.csv
+++ b/src/main/resources/spreadsheets/nomis-locations.csv
@@ -1,0 +1,3374 @@
+AGY_LOC_ID,DESCRIPTION,LONG_DESCRIPTION,AGENCY_LOCATION_TYPE,ACTIVE_FLAG
+LDM011,Tulse Hill,Tulse Hill,COMM,Y
+LDM087,Havering Mags Court Probation Office,Havering Mags Court Probation Office,COMM,Y
+MUDSLY,The Maudsley Hospital,The Maudsley Hospital,HSHOSP,Y
+DPP007,Newtown Probation Office,Newtown Probation Office,COMM,Y
+THA044,Milton Keynes Probation Office,Milton Keynes Probation Office,COMM,Y
+MWALES,Mid Wales Hospital,Mid Wales Hospital,HSHOSP,Y
+NBR001,Northumbria Head Office,Northumbria Head Office,COMM,Y
+DPP004,Haverfordwest Probation Office,Haverfordwest Probation Office,COMM,Y
+DBS004,Chesterfield Probation Office,Chesterfield Probation Office,COMM,Y
+NBR020,Hendon Probation Office,Hendon Probation Office,COMM,Y
+MRS058,Wirral PPO Unit,Wirral PPO Unit,COMM,Y
+CYWING,Cygnet Wing,Cygnet Wing,HSHOSP,Y
+SWS011,Bridgend Probation Office,Bridgend Probation Office,COMM,Y
+NHS002,Mansfield Probation Office,Mansfield Probation Office,COMM,Y
+DBS005,Chesterfield MC Liaison Unit,Chesterfield MC Liaison Unit,COMM,Y
+WWSY01,LEAMINGTON SPA YOT,LEAMINGTON SPA YOT,YOT,Y
+MRS050,North Liverpool Community Justice Centre,North Liverpool Community Justice Centre,COMM,Y
+RVNTON,Rivington Unit,Rivington Unit,HSHOSP,Y
+MCG049,Wigan Magistrates Court Probation Office,Wigan Magistrates Court Probation Office,COMM,Y
+LCSY02,Blackburn YOT,Blackburn YOT,YOT,Y
+MLW027,Birmingham MC Liaison Unit,Birmingham MC Liaison Unit,COMM,Y
+DPDALE,Deepdale Ward,Deepdale Ward,HSHOSP,Y
+HASTNG,The Hastings Clinic,The Hastings Clinic,HSHOSP,Y
+LCSY01,Accrington YOT,Accrington YOT,YOT,Y
+MCG003,Oldham (Rochdale Rd) Probation Office,Oldham (Rochdale Rd) Probation Office,COMM,Y
+WTS007,Wiltshire MAPPA Co-ordination Unit,Wiltshire MAPPA Co-ordination Unit,COMM,Y
+THA029,St Leonard's Hostel,St Leonard's Hostel,APPR,Y
+WINTON,Winterton Hospital,Winterton Hospital,HSHOSP,Y
+ESX006,Thurrock Probation Office,Thurrock Probation Office,COMM,Y
+HUNTHO,"Huntercombe, Stafford Hosp","Huntercombe, Stafford Hosp",HSHOSP,Y
+NBRAP4,St Christopher's House Bail Hostel,St Christopher's House Bail Hostel,APPR,Y
+STEPRO,Stevenage Probation,Stevenage Probation,COMM,Y
+DUR018,Chester-le-Street Probation Office,Chester-le-Street Probation Office,COMM,Y
+MRS055,Knowsley DRR,Knowsley DRR,COMM,Y
+706931,Plymouth Probation Centre,Plymouth Probation Centre,COMM,N
+415468,Barnstable Probation Centre,Barnstable Probation Centre,COMM,N
+478335,Dorset Probation Service Head Office,Dorset Probation Service Head Office,COMM,N
+LEEDYC,Leeds Youth Court,Leeds Youth Court,CRT,N
+LEICYC,Leicester Youth Court,Leicester Youth Court,CRT,N
+LEWSYC,Lewes Youth Court,Lewes Youth Court,CRT,Y
+LEYLYC,South Ribble Youth Court,South Ribble Youth Court,CRT,Y
+LINCYC,Lincoln Youth Court,Lincoln Youth Court,CRT,Y
+LVRHYC,Liverpool Youth Court,Liverpool Youth Court,CRT,N
+LLDUYC,Llandudno Youth Court,Llandudno Youth Court,CRT,Y
+LLNLYC,Llanelli Youth Court,Llanelli Youth Court,CRT,Y
+LLNGYC,Llangefni Youth Court,Llangefni Youth Court,CRT,Y
+LLWYYC,Llwynypia Youth Court,Llwynypia Youth Court,CRT,Y
+LGHBYC,Loughborough Youth Court,Loughborough Youth Court,CRT,Y
+LOUTYC,Louth Youth Court,Louth Youth Court,CRT,Y
+LWSTYC,Lowestoft Youth Court,Lowestoft Youth Court,CRT,Y
+LUTNYC,Luton Youth Court,Luton Youth Court,CRT,N
+MACCYC,Macclesfield Youth Court,Macclesfield Youth Court,CRT,Y
+MDNHYC,East Berkshire YC Maidenhead Court House,East Berkshire YC Maidenhead Court House,CRT,N
+MDSTYC,Maidstone Youth Court,Maidstone Youth Court,CRT,Y
+MNCHYC,Manchester City Youth Court,Manchester City Youth Court,CRT,N
+MNSFYC,Mansfield Youth Court,Mansfield Youth Court,CRT,Y
+MRGTYC,Margate Youth Court,Margate Youth Court,CRT,Y
+MRKDYC,Market Drayton Youth Court,Market Drayton Youth Court,CRT,Y
+MLTNYC,Melton Mowbray Youth Court,Melton Mowbray Youth Court,CRT,Y
+MRTHYC,Merthyr Tydfil Youth Court,Merthyr Tydfil Youth Court,CRT,N
+MDDLYC,Middlesbrough Youth Court,Middlesbrough Youth Court,CRT,Y
+MLTKYC,Milton Keynes Youth Court,Milton Keynes Youth Court,CRT,N
+MINEYC,Minehead Youth Court,Minehead Youth Court,CRT,Y
+MOLDYC,Mold Youth Court,Mold Youth Court,CRT,Y
+NEATYC,Neath Youth Court,Neath Youth Court,CRT,Y
+LYNDYC,New Forest Youth Court,New Forest Youth Court,CRT,Y
+NWRKYC,Newark Youth Court,Newark Youth Court,CRT,Y
+NWCSYC,Newcastle upon Tyne Youth Court,Newcastle upon Tyne Youth Court,CRT,Y
+NWCLYC,N Staffs Youth Court - Newcastle,North Staffordshire Youth Court - Newcastle under Lyme,CRT,Y
+NWTAYC,Newton Abbot Youth Court,Newton Abbot Youth Court,CRT,Y
+NWAYYC,Newton Aycliffe Youth Court,Newton Aycliffe Youth Court,CRT,Y
+CHSTYC,NE Derby/Dales Youth Crt (Chesterfield),North East Derbyshire and Dales Family Youth Court (Chesterfield),CRT,Y
+CROMYC,North Norfolk Youth Court,North Norfolk Youth Court,CRT,Y
+STHPYC,North Sefton Youth Court,North Sefton Youth Court,CRT,Y
+NRTSYC,North Shields Youth Court,North Shields Youth Court,CRT,Y
+NORAYC,Northallerton Youth Court,Northallerton Youth Court,CRT,Y
+NRTHYC,Northampton Youth Court,Northampton Youth Court,CRT,Y
+NRTWYC,Northwich Youth Court,Northwich Youth Court,CRT,Y
+NORWYC,Norwich Youth Court,Norwich Youth Court,CRT,N
+NOTTYC,Nottingham Youth Court,Nottingham Youth Court,CRT,N
+NUNTYC,Nuneaton Youth Court,Nuneaton Youth Court,CRT,N
+WARLYC,Oldbury Youth Court,Oldbury Youth Court,CRT,Y
+OLDHYC,Oldham Youth Court,Oldham Youth Court,CRT,Y
+ORMKYC,Ormskirk Youth Court,Ormskirk Youth Court,CRT,Y
+OSWSYC,Oswestry Youth Court,Oswestry Youth Court,CRT,Y
+OXFRYC,Oxford Youth Court,Oxford Youth Court,CRT,N
+PENRYC,Eden Youth Court,Eden Youth Court,CRT,Y
+PENZYC,Penzance Youth Court,Penzance Youth Court,CRT,Y
+PBORYC,Peterborough Youth Court,Peterborough Youth Court,CRT,Y
+PTRLYC,Peterlee Youth Court,Peterlee Youth Court,CRT,Y
+PLYMYC,Plymouth Youth Court,Plymouth Youth Court,CRT,N
+PONTYC,Pontefract Youth Court,Pontefract Youth Court,CRT,Y
+POOLYC,Poole Youth Court,Poole Youth Court,CRT,Y
+PRTTYC,Port Talbot Youth Court,Port Talbot Youth Court,CRT,Y
+PRSTYC,Prestatyn Youth Court,Prestatyn Youth Court,CRT,Y
+PRESYC,Preston Youth Court,Preston Youth Court,CRT,N
+PWLLYC,Pwllheli Youth Court,Pwllheli Youth Court,CRT,Y
+ROSSYC,Rawtenstall Youth Court,Rawtenstall Youth Court,CRT,Y
+READYC,Reading and West Berkshire YC,Reading and West Berkshire Youth Court,CRT,N
+RDBRYC,Redbridge Youth Court,Redbridge Youth Court,CRT,Y
+RDHLYC,Redhill Youth Court,Redhill Youth Court,CRT,Y
+REEDYC,Reedley Youth Court,Reedley Youth Court,CRT,Y
+RETFYC,Retford Youth Court,Retford Youth Court,CRT,Y
+ALI,ALBANY (HMP),HMP ALBANY,INST,N
+RCHTYC,Richmond-upon-Thames Youth Court,Richmond-upon-Thames Youth Court,CRT,Y
+ROCHYC,Rochdale Youth Court,Rochdale Youth Court,CRT,Y
+ROTHYC,Rotherham Youth Court,Rotherham Youth Court,CRT,Y
+RGBYYC,Rugby Youth Court,Rugby Youth Court,CRT,Y
+SALSYC,Salisbury Youth Court,Salisbury Youth Court,CRT,Y
+SCBNYC,Scarborough Youth Court,Scarborough Youth Court,CRT,N
+SCUNYC,Scunthorpe Youth Court,Scunthorpe Youth Court,CRT,Y
+SLBYYC,Selby Youth Court,Selby Youth Court,CRT,Y
+SEVNYC,Sevenoaks Youth Court,Sevenoaks Youth Court,CRT,Y
+SHEFYC,Sheffield Youth Court,Sheffield Youth Court,CRT,N
+SHREYC,Shrewsbury Youth Court,Shrewsbury Youth Court,CRT,Y
+SITTYC,Sittingbourne Youth Court,Sittingbourne Youth Court,CRT,Y
+SKEGYC,Skegness Youth Court,Skegness Youth Court,CRT,Y
+SKIPYC,Skipton Youth Court,Skipton Youth Court,CRT,Y
+SLEAYC,Sleaford Youth Court,Sleaford Youth Court,CRT,Y
+SOLIYC,Solihull Youth Court,Solihull Youth Court,CRT,Y
+BDLNYC,SE Northumberland Magistrates' Court,South East Northumberland Magistrates' Court,CRT,N
+THETYC,South Norfolk Youth Court,South Norfolk Youth Court,CRT,Y
+BOOTYC,South Sefton Youth Court,South Sefton Youth Court,CRT,Y
+STHMYC,South Shields Youth Court,South Shields Youth Court,CRT,Y
+LUDLYC,South Shropshire Youth Court,South Shropshire Youth Court,CRT,Y
+WRCSYC,South Worcestershire Youth Court,South Worcestershire Youth Court,CRT,Y
+SOUTYC,Southampton Youth Court,Southampton Youth Court,CRT,N
+STHSYC,Southend-on-Sea Youth Court,Southend-on-Sea Youth Court,CRT,Y
+DRBYYC,Southern Derbyshire Youth Court (Derby),Southern Derbyshire Youth Court (Derby),CRT,Y
+ILKSYC,S.Derbyshire Youth Court (Ilkeston),Southern Derbyshire Youth Court (Ilkeston),CRT,Y
+SPALYC,Spalding Youth Court,Spalding Youth Court,CRT,Y
+STALYC,St. Albans Youth Court,St. Albans Youth Court,CRT,Y
+STHEYC,St. Helens Youth Court,St. Helens Youth Court,CRT,Y
+STAFYC,C and SW Staffs Youth Court - Stafford,C and SW Staffordshire Youth Court - Stafford,CRT,Y
+STAIYC,Staines Youth Court,Staines Youth Court,CRT,Y
+STEVYC,Stevenage Youth Court,Stevenage Youth Court,CRT,Y
+STOCYC,Stockport Youth Court,Stockport Youth Court,CRT,N
+STOKYC,N Staffs Youth Court - Fenton,North Staffordshire Youth Court - Fenton,CRT,Y
+STRAYC,Stratford Youth Court,Stratford Youth Court,CRT,N
+SUDBYC,Sudbury Youth Court,Sudbury Youth Court,CRT,Y
+SUNDYC,Sunderland Youth Court,Sunderland Youth Court,CRT,Y
+STTCYC,Sutton Coldfield Youth Court,Sutton Coldfield Youth Court,CRT,N
+SUTTYC,Sutton Youth Court,Sutton Youth Court,CRT,N
+SWNDYC,Swansea Youth Court,Swansea Youth Court,CRT,Y
+SWINYC,Swindon Youth Court,Swindon Youth Court,CRT,N
+ASHTYC,Tameside Youth Court,Tameside Youth Court,CRT,Y
+TAMWYC,SE Staffs Youth Court - Tamworth,SE Staffordshire Youth Court - Tamworth,CRT,Y
+TAUNYC,Taunton Youth Court,Taunton Youth Court,CRT,Y
+TELFYC,Telford & Bridgnorth Youth Court,Telford & Bridgnorth Youth Court,CRT,Y
+TTTNYC,Tottenham Youth Court,Tottenham Youth Court,CRT,Y
+SALEYC,Trafford Youth Court,Trafford Youth Court,CRT,Y
+TRURYC,Truro Youth Court,Truro Youth Court,CRT,Y
+HXHMYC,Tynedale Magistrates' Court,Tynedale Magistrates' Court,CRT,Y
+UXBRYC,Uxbridge Youth Court,Uxbridge Youth Court,CRT,N
+WAKFYC,Wakefield Youth Court,Wakefield Youth Court,CRT,Y
+WLSSYC,Walsall Youth Court,Walsall Youth Court,CRT,Y
+WLTFYC,Waltham Forest Youth Court,Waltham Forest Youth Court,CRT,Y
+WARRYC,Warrington Youth Court,Warrington Youth Court,CRT,N
+WELBYC,Wellinbgborough Youth Court,Wellinbgborough Youth Court,CRT,N
+WELLYC,Wells Youth Court,Wells Youth Court,CRT,Y
+WLSHYC,Welshpool Youth Court,Welshpool Youth Court,CRT,Y
+WBRMYC,West Bromwich Youth Court,West Bromwich Youth Court,CRT,Y
+KNGSYC,West Norfolk Youth Court,West Norfolk Youth Court,CRT,Y
+WSPMYC,Weston-super-Mare Youth Court,Weston-super-Mare Youth Court,CRT,Y
+WEYMYC,Weymouth Youth Court,Weymouth Youth Court,CRT,Y
+WHTHYC,Whitehaven Youth Court,Whitehaven Youth Court,CRT,Y
+WIDNYC,Widnes Youth Court,Widnes Youth Court,CRT,Y
+WIGNYC,Wigan Youth Court,Wigan Youth Court,CRT,Y
+WMBLYC,Wimbledon Youth Court,Wimbledon Youth Court,CRT,N
+BRKNYC,Wirral Youth Court,Wirral Youth Court,CRT,Y
+WISBYC,Fenland Youth Court,Fenland Youth Court,CRT,Y
+WITHYC,Witham Youth Court,Witham Youth Court,CRT,Y
+WKNGYC,Woking Youth Court,Woking Youth Court,CRT,Y
+WLVRYC,Wolverhampton Youth Court,Wolverhampton Youth Court,CRT,N
+WRKTYC,West Allerdale and Keswick YC,West Allerdale and Keswick Youth Court,CRT,Y
+WORKYC,Worksop Youth Court,Worksop Youth Court,CRT,Y
+WORTYC,Worthing Youth Court,Worthing Youth Court,CRT,Y
+WREXYC,Wrexham Youth Court,Wrexham Youth Court,CRT,Y
+WYCBYC,Wycombe Youth Court,Wycombe Youth Court,CRT,Y
+YATEYC,Yate Youth Court,Yate Youth Court,CRT,Y
+YEOVYC,Yeovil Youth Court,Yeovil Youth Court,CRT,Y
+YORKYC,York Youth Court,York Youth Court,CRT,Y
+ASP007,Bristol Probation Centre,Bristol Probation Centre,COMM,Y
+NBRAP2,Cuthbert House Bail Hostel,Cuthbert House Bail Hostel,APPR,Y
+GWT004,EBBW VALE Probation Centre,EBBW VALE Probation Centre,COMM,Y
+NTS021,Kettering YOT,Kettering YOT,YOT,Y
+604936,Bristol Probation Centre,Bristol Probation Centre,COMM,N
+754134,WESTON-SUPER-MARE Probation Centre,WESTON-SUPER-MARE Probation Centre,COMM,N
+TOWERS,Towers Hospital,Towers Hospital,HSHOSP,Y
+THA039,Banbury Mags Court Probation Office,Banbury Mags Court Probation Office,COMM,Y
+358149,"Knowle Park, Bristol Probation Centre","Knowle Park, Bristol Probation Centre",COMM,N
+MLWAP1,Bilston Approved Premises,Bilston Approved Premises,APPR,Y
+BASDON,Basildon Hospital,Basildon Hospital,HSHOSP,Y
+461848,Bridgewater Probation Centre,Bridgewater Probation Centre,COMM,N
+TSPNY,"The Spinney, Manchester","The Spinney, Manchester",HSHOSP,Y
+486314,Luton Probation Office,Luton Probation Office,COMM,N
+CBS008,Gloucester House Probation Office,Gloucester House Probation Office,COMM,N
+345012,Luton MC Liaison Office,Luton Magistrates' Court Liaison Office,COMM,N
+MLWY11,Selly Oak YOT,Selly Oak YOT,YOT,Y
+YSS015,South Yorkshire Head Office,South Yorkshire Head Office,COMM,Y
+LNS003,Grantham Probation Office,Grantham Probation Office,COMM,Y
+YSW016,Bradford DRR Team,Bradford DRR Team,COMM,Y
+THA009,High Wycombe Probation Office,High Wycombe Probation Office,COMM,Y
+SSX022,Brighton Mags Crt Probation Office,Brighton Magistrates Court Probation Office,COMM,Y
+PENDRD,Pendered ICU,Pendered ICU,HSHOSP,Y
+MLWY01,W Mids Youth Offending Services Head Off,West Midlands Youth Offending Services Head Office,YOT,Y
+STPHSE,Stephenson House,Stephenson House,HSHOSP,Y
+DENBAR,Dene Barton Rehabilitation Unit,Dene Barton Rehabilitation Unit,HSHOSP,Y
+DRHY04,Darlington YOT,Darlington YOT,YOT,Y
+289660,Cambridge Probation Office,Cambridge Probation Office,COMM,N
+DCPY01,East Devon YOT,East Devon YOT,YOT,Y
+WYTHEN,Wythenshaw Hospital,Wythenshaw Hospital,HSHOSP,Y
+SWS010,Swansea Crown Court Liaison Unit,Swansea Crown Court Liaison Unit,COMM,Y
+NBR031,Gateshead Mags Court Probation Office,Gateshead Mags Court Probation Office,COMM,Y
+611336,Warrington Probation Office,Warrington Probation Office,COMM,N
+NBR010,Hexham Probation Office,Hexham Probation Office,COMM,Y
+HBS017,Scunthorpe DIT/PPO,Scunthorpe DIT/PPO,COMM,Y
+261118,Chester Probation Office,Chester Probation Office,COMM,N
+LDM052,HESTIA Battersea,HESTIA Battersea,COMM,Y
+STCATH,St. Catherine's Hosp (Doncaster),St. Catherine's Hosp (Doncaster),HSHOSP,Y
+HPSY05,Wessex YOT (Isle of Wight),Wessex YOT (Isle of Wight),YOT,Y
+DBSAP1,Burdett Lodge Approved Premises,Burdett Lodge Approved Premises,APPR,Y
+STMCHL,St Michael's Hospital,St Michael's Hospital,HSHOSP,Y
+CMBY01,Cumbria YOT North Division,Cumbria YOT North Division,YOT,Y
+DBS015,Southern Derbyshire MC Liaison Unit,Southern Derbyshire MC Liaison Unit,COMM,Y
+BDS003,Bedford Probation Office,Bedford Probation Office,COMM,Y
+MRS003,Bootle Office,Bootle Office,COMM,Y
+NBR026,Court Services Team,Court Services Team,COMM,Y
+YSN002,Scarborough Probation Office,Scarborough Probation Office,COMM,N
+CYGENT,Cygnet Clinic,Cygnet Clinic,HSHOSP,Y
+YSN023,Scarborough Probation Office,Scarborough Probation Office,COMM,Y
+NBR042,Northumbria ETE Unit,Northumbria ETE Unit,COMM,Y
+HRRWMC,Harrow MC,Harrow Magistrates' Court,CRT,N
+HVNTMC,Havant Magistrates Court,Havant Magistrates Court,CRT,N
+HNDNMC,Hendon MC,Hendon Magistrates' Court,CRT,Y
+HXHMMC,Hexham MC,Hexham Magistrates' Court,CRT,Y
+HUYTMC,Huyton MC,Huyton Magistrates' Court,CRT,Y
+KENDMC,Kendal Magistrates Court,Kendal Magistrates Court,CRT,Y
+LUDLMC,Ludlow MC,Ludlow Magistrates' Court,CRT,Y
+NWRKMC,Newark MC,Newark Magistrates' Court,CRT,Y
+NWTNMC,Newton MC,Newton Magistrates' Court,CRT,Y
+OKHMMC,Oakham MC,Oakham Magistrates' Court,CRT,Y
+OLDHMC,Oldham MC,Oldham Magistrates' Court,CRT,N
+OXFRMC,Oxford MC,Oxford Magistrates' Court,CRT,Y
+SLOUMC,Slough Magistrates Court,Slough Magistrates Court,CRT,Y
+STROMC,Stroud MC,Stroud Magistrates' Court,CRT,Y
+SUTTMC,Sutton MC,Sutton Magistrates' Court,CRT,N
+THMSMC,Thames MC,Thames Magistrates' Court,CRT,Y
+TOTSMC,Totnes MC,Totnes Magistrates' Court,CRT,Y
+WARLMC,Sandwell Magistrates Court,Sandwell Magistrates Court,CRT,Y
+WHITMC,Whitby MC,Whitby Magistrates' Court,CRT,Y
+WIDNMC,Widnes MC,Widnes Magistrates' Court,CRT,Y
+WITHMC,Witham MC,Witham Magistrates' Court,CRT,Y
+WITNMC,Witney MC,Witney Magistrates' Court,CRT,Y
+WKNGMC,Woking MC,Woking Magistrates' Court,CRT,Y
+YEOVMC,Yeovil MC,Yeovil Magistrates' Court,CRT,Y
+ALNWMC,Alnwick MC,Alnwick Magistrates' Court,CRT,Y
+ANDVMC,Andover MC,Andover Magistrates' Court,CRT,Y
+ASHFMC,Ashford MC,Ashford Magistrates' Court,CRT,Y
+BDFRMC,Bedford MC,Bedford Magistrates' Court,CRT,Y
+BINGMC,Bingley MC,Bingley Magistrates' Court,CRT,Y
+BLAYMC,Blaydon MC,Blaydon Magistrates' Court,CRT,Y
+BRSTMC,Bristol MC,Bristol Magistrates' Court,CRT,Y
+BURNMC,Burnley and Pendle Magistrates Court,Burnley and Pendle Magistrates Court,CRT,Y
+CANNMC,C and SW Staffs MC - Cannock,C and SW Staffordshire Magistrates Court - Cannock,CRT,Y
+CRDFMC,Cardiff MC,Cardiff Magistrates' Court,CRT,Y
+CHTHMC,Chatham MC,Chatham Magistrates' Court,CRT,N
+CHESMC,Chester MC,Chester Magistrates' Court,CRT,Y
+CHRLMC,Chorley MC,Chorley Magistrates' Court,CRT,Y
+CNSTMC,Consett MC,Consett Magistrates' Court,CRT,Y
+CRAWMC,Crawley MC,Crawley Magistrates' Court,CRT,Y
+CRYDMC,Croydon MC,Croydon Magistrates' Court,CRT,Y
+CWMBMC,Cwmbran MC,Cwmbran Magistrates' Court,CRT,Y
+DNBGMC,Denbigh MC,Denbigh Magistrates' Court,CRT,Y
+DEVZMC,Devizes MC,Devizes Magistrates' Court,CRT,Y
+DORKMC,Dorking MC,Dorking Magistrates' Court,CRT,Y
+EVSHMC,Evesham MC,Evesham Magistrates' Court,CRT,N
+FARHMC,Fareham MC,Fareham Magistrates' Court,CRT,N
+FELTMC,Feltham MC,Feltham Magistrates' Court,CRT,Y
+GLOSMC,Glossop MC,Glossop Magistrates' Court,CRT,Y
+GRIMMC,Grimsby MC,Grimsby Magistrates' Court,CRT,Y
+HLFXMC,Halifax MC,Halifax Magistrates' Court,CRT,Y
+HRWCMC,Harwich MC,Harwich Magistrates' Court,CRT,Y
+HNTNMC,Honiton MC,Honiton Magistrates' Court,CRT,Y
+HRSHMC,Horsham MC,Horsham Magistrates' Court,CRT,Y
+IPSWMC,Ipswich MC,Ipswich Magistrates' Court,CRT,Y
+LEYLMC,South Ribble MC,South Ribble Magistrates Court,CRT,Y
+LINCMC,Lincoln MC,Lincoln Magistrates' Court,CRT,Y
+MRGTMC,Margate MC,Margate Magistrates' Court,CRT,Y
+NWBRMC,West Berkshire MC,West Berkshire MC,CRT,Y
+NWPRMC,Newport (I.O.W.) Mag Court,Newport (I.O.W.) Mag Court,CRT,Y
+NORWMC,Norwich MC,Norwich Magistrates' Court,CRT,Y
+PENRMC,Eden Magistrates Court,Eden Magistrates Court,CRT,Y
+PRESMC,Preston MC,Preston Magistrates' Court,CRT,Y
+READMC,Reading MC,Reading Magistrates' Court,CRT,Y
+RDHLMC,Redhill MC,Redhill Magistrates' Court,CRT,Y
+REEDMC,Reedley MC,Reedley Magistrates' Court,CRT,Y
+RETFMC,Retford MC,Retford Magistrates' Court,CRT,Y
+RHNDMC,Rhondda MC,Rhondda Magistrates' Court,CRT,N
+RMFRMC,Romford MC,Romford Magistrates' Court,CRT,Y
+RUGLMC,Rugeley MC,Rugeley Magistrates' Court,CRT,N
+RUNCMC,Runcorn MC,Runcorn Magistrates' Court,CRT,Y
+RUTLMC,Rutland MC,Rutland Magistrates' Court,CRT,N
+SLFRMC,Salford MC,Salford Magistrates' Court,CRT,N
+SKIPMC,Skipton MC,Skipton Magistrates' Court,CRT,Y
+STAIMC,Staines MC,Staines Magistrates' Court,CRT,Y
+SUDBMC,Sudbury MC,Sudbury Magistrates' Court,CRT,Y
+SWINMC,Swindon MC,Swindon Magistrates' Court,CRT,Y
+TAUNMC,Taunton MC,Taunton Magistrates' Court,CRT,Y
+TELFMC,Telford MC,Telford Magistrates' Court,CRT,Y
+LDM003,City of London Mags Crt Probation Office,City of London Mags Crt Probation Office,COMM,Y
+HBS008,Kingston upon Hull Probation Office,Kingston upon Hull Probation Office,COMM,Y
+LDM112,Wimbledon Mags Court Probation Office,Wimbledon Mags Court Probation Office,COMM,Y
+CHTONT,"Chesterton Unit, Hollins Park Hospital","Chesterton Unit, Hollins Park Hospital",HSHOSP,Y
+SSX002,Chichester Probation Office,Chichester Probation Office,COMM,Y
+LDM014,Kelley House Probation Hostel,Kelley House Probation Hostel,APPR,Y
+CBS007,Peterborough Probation Office,Peterborough Probation Office,COMM,Y
+ANESLY,Annesley Park Hosp RSU,Annesley Park Hosp RSU,HSHOSP,Y
+YSW011,LEEDS CROWN COURT Liaison Unit,LEEDS CROWN COURT Liaison Unit,COMM,Y
+GCSAP1,Ryecroft Approved Premises,Ryecroft Approved Premises,APPR,Y
+WWSAP2,Nuneaton Approved Premises,Nuneaton Approved Premises,APPR,Y
+WSN006,Dolgellau Probation Office,Dolgellau Probation Office,COMM,Y
+CAPIO,Capio Nightingale Hospital (Liverpool),Capio Nightingale Hospital (Liverpool),HSHOSP,Y
+THA006,Aylesbury Crown Court Probation Office,Aylesbury Crown Court Probation Office,COMM,Y
+NBRY02,N Tyneside YOT,N Tyneside YOT,YOT,Y
+DCP011,Plymouth Probation Office,Plymouth Probation Office,COMM,Y
+NBR023,Sunderland Community Punishment Office,Sunderland Community Punishment Office,COMM,Y
+LTS003,Hinckley Probation Office,Hinckley Probation Office,COMM,Y
+KNT002,Ashford Probation Office,Ashford Probation Office,COMM,N
+WTSY01,Swindon YOT,Swindon YOT,YOT,Y
+HFS003,St Albans NPS Centre,Mid Herts Probation Centre,COMM,Y
+MRSAP2,Merseybank Hostel,Merseybank Hostel,APPR,Y
+NHSAP3,Trent House Approved Premises,Trent House Approved Premises,APPR,Y
+MCG036,Manchester Crown Court Probation Office,Manchester Crown Court Probation Office,COMM,Y
+NHS021,Newark CS Office,Newark CS Office,COMM,Y
+HARPER,Harperbury Hospital,Harperbury Hospital,HSHOSP,Y
+DBS010,Ilkeston Probation Office,Ilkeston Probation Office,COMM,Y
+CHS007,Winsford Probation Office,Winsford Probation Office,COMM,Y
+TES001,Teesside Head Office,Teesside Head Office,COMM,Y
+LDM088,New Addington,New Addington,COMM,Y
+YSW007,HUDDERSFIELD Probation Office,HUDDERSFIELD Probation Office,COMM,Y
+DOROTH,Dorothy Pattison Hospital,Dorothy Pattison Hospital,HSHOSP,Y
+NBR008,Gateshead Prob Off and S.of Tyne Ops Un,Gateshead Prob Off and S.of Tyne Ops Un,COMM,Y
+SSX009,Eastbourne Unpaid Work Office,Eastbourne Unpaid Work Office,COMM,Y
+ASP016,New Bridewell Prolific Offender Unit,New Bridewell Prolific Offender Unit,COMM,Y
+DRS003,Bournemouth Probation Centre,Bournemouth Probation Centre,COMM,Y
+LCS009,Chorley Probation Office,Chorley Probation Office,COMM,Y
+STEDS,St Edward's Hospital (Leek),St Edward's Hospital (Leek),HSHOSP,Y
+MCG034,Manchester Unpaid Work Office/ CMU,Manchester Unpaid Work Office/ CMU,COMM,Y
+SLOUCT,Slough County Court,Slough County Court,CRT,Y
+STHSCT,South Shields County Court,South Shields County Court,CRT,Y
+STHMCT,Southampton County Court,Southampton County Court,CRT,Y
+STHNCT,Southend County Court,Southend County Court,CRT,Y
+STHPCT,Southport County Court,Southport County Court,CRT,N
+STALCT,St. Albans County Court,St. Albans County Court,CRT,Y
+STHECT,St. Helens County Court,St. Helens County Court,CRT,Y
+STAFCT,Stafford County Court,Stafford County Court,CRT,Y
+STAICT,Staines County Court,Staines County Court,CRT,Y
+STOCCT,Stockport County Court,Stockport County Court,CRT,Y
+STOKCT,Stoke-on-Trent County Court,Stoke-on-Trent County Court,CRT,Y
+STOUCT,Stourbridge County Court,Stourbridge County Court,CRT,Y
+STRFCT,Stratford-upon-Avon County Court,Stratford-upon-Avon County Court,CRT,Y
+SUNDCT,Sunderland County Court,Sunderland County Court,CRT,Y
+SWNSCT,Swansea County Court,Swansea County Court,CRT,Y
+SWINCT,Swindon County Court,Swindon County Court,CRT,Y
+TAMSCT,Tameside County Court,Tameside County Court,CRT,Y
+TAMWCT,Tamworth County Court,Tamworth County Court,CRT,Y
+TAUNCT,Taunton County Court,Taunton County Court,CRT,Y
+TELFCT,Telford County Court,Telford County Court,CRT,Y
+THANCT,Thanet County Court,Thanet County Court,CRT,Y
+CITYCT,The Mayor's &City of London County Court,The Mayor's and City of London County Court,CRT,Y
+TORQCT,Torquay and Newton Abbot County Court,Torquay and Newton Abbot County Court,CRT,Y
+TRWBCT,Trowbridge County Court,Trowbridge County Court,CRT,Y
+TRURCT,Truro County Court,Truro County Court,CRT,Y
+TUNWCT,Tunbridge Wells County Court,Tunbridge Wells County Court,CRT,Y
+UXBRCT,Uxbridge County Court,Uxbridge County Court,CRT,Y
+WAKFCT,Wakefield County Court,Wakefield County Court,CRT,Y
+WALSCT,Walsall County Court,Walsall County Court,CRT,Y
+WNDSCT,Wandsworth County Court,Wandsworth County Court,CRT,Y
+WRRNCT,Warrington County Court,Warrington County Court,CRT,Y
+WRWCCT,Warwick County Court,Warwick County Court,CRT,Y
+WATFCT,Watford County Court,Watford County Court,CRT,Y
+WELBCT,Wellingborough County Court,Wellingborough County Court,CRT,Y
+WLSHCT,Welshpool and Newtown County Court,Welshpool and Newtown County Court,CRT,Y
+WLONCT,West London County Court,West London County Court,CRT,Y
+WSPMCT,Weston-super-Mare County Court,Weston-super-Mare County Court,CRT,Y
+WEYMCT,Weymouth County Court,Weymouth County Court,CRT,Y
+WHTHCT,Whitehaven County Court,Whitehaven County Court,CRT,Y
+WIGNCT,Wigan County Court,Wigan County Court,CRT,Y
+WILSCT,Willesden County Court,Willesden County Court,CRT,Y
+WNCHCT,Winchester County Court,Winchester County Court,CRT,Y
+WLVRCT,Wolverhampton County Court,Wolverhampton County Court,CRT,Y
+WOOLCT,Woolwich County Court,Woolwich County Court,CRT,Y
+WRCSCT,Worcester County Court,Worcester County Court,CRT,Y
+WRKTCT,WORKINGTON COUNTY COURT,WORKINGTON COUNTY COURT,CRT,Y
+WORKCT,Worksop County Court,Worksop County Court,CRT,Y
+WORTCT,Worthing County Court,Worthing County Court,CRT,Y
+WREXCT,Wrexham County Court,Wrexham County Court,CRT,Y
+YEOVCT,Yeovil County Court & Probation Office,Yeovil County Court & Probation Office,CRT,Y
+YORKCT,York County Court,York County Court,CRT,Y
+ABDRYC,Aberdare Youth Court,Aberdare Youth Court,CRT,Y
+ABRYYC,Aberystwyth Youth Court,Aberystwyth Youth Court,CRT,Y
+ACCRYC,Accrington Youth Court,Accrington Youth Court,CRT,Y
+ACTNYC,Acton Youth Court,Acton Youth Court,CRT,Y
+WLSAYC,Aldridge Youth Court,Aldridge Youth Court,CRT,Y
+ALNWYC,Alnwick Youth Court,Alnwick Youth Court,CRT,Y
+ALTNYC,Alton Youth Court,Alton Youth Court,CRT,Y
+AMRSYC,Amersham Youth Court,Amersham Youth Court,CRT,Y
+AMMNYC,Ammanford Youth Court,Ammanford Youth Court,CRT,Y
+ANDVYC,Andover Youth Court,Andover Youth Court,CRT,Y
+AYLSYC,Aylesbury Youth Court,Aylesbury Youth Court,CRT,Y
+BNBBYC,Banbury Youth Court,Banbury Youth Court,CRT,Y
+BARKYC,Barking Youth Court,Barking Youth Court,CRT,Y
+BRNTYC,Barnet Youth Court,Barnet Youth Court,CRT,Y
+BRNSYC,Barnsley Youth Court,Barnsley Youth Court,CRT,N
+BNSTYC,Barnstaple Youth Court,Barnstaple Youth Court,CRT,Y
+AKI,ACKLINGTON (HMP),HMP ACKLINGTON,INST,N
+BRRWYC,Furness and District Youth Court,Furness and District Youth Court,CRT,Y
+BRRYYC,"Vale of Glamorgan Youth Court, Barry","Vale of Glamorgan Youth Court, Barry",CRT,Y
+BSLDYC,Basildon Youth Court,Basildon Youth Court,CRT,N
+BSNGYC,Basingstoke Youth Court,Basingstoke Youth Court,CRT,Y
+BATHYC,Bath Youth Court,Bath Youth Court,CRT,N
+DEWSYC,Batley and Dewsbury Youth Court,Batley and Dewsbury Youth Court,CRT,Y
+BDFRYC,Bedford Youth Court,Bedford Youth Court,CRT,Y
+BRWKYC,Berwick-upon-Tweed Youth Court,Berwick-upon-Tweed Youth Court,CRT,Y
+BEVRYC,Beverley Youth Court,Beverley Youth Court,CRT,Y
+BEXLYC,Bexley Youth Court,Bexley Youth Court,CRT,N
+BICSYC,Bicester Youth Court,Bicester Youth Court,CRT,Y
+BRMSYC,Birmingham Youth Court,Birmingham Youth Court,CRT,N
+297587,Weymouth Probation Centre,Weymouth Probation Centre,COMM,N
+231809,POOLE Probation Centre,POOLE Probation Centre,COMM,N
+MCG067,Canaervon Street DTTO/Intensive Cont Ser,Canaervon Street DTTO/Intensive Cont Ser,COMM,Y
+STF044,Stoke-on-Trent City Probation Centre,Stoke-on-Trent City Probation Centre,COMM,Y
+NTS002,Northampton Probation Office,Northamptonshire Probation Office,COMM,Y
+STF011,Cannock Probation Centre,Cannock Probation Centre,COMM,Y
+696575,BOURNEMOUTH Probation Centre,BOURNEMOUTH Probation Centre,COMM,N
+LTSY02,Thurmaston YOT,Thurmaston YOT,YOT,Y
+LDM070,Middlesex Guildhall,Middlesex Guildhall,COMM,Y
+STF031,Wharflane House Bail Hostel,Wharflane House Bail Hostel,APPR,Y
+MLWY15,Walsall YOT,Walsall YOT,YOT,Y
+NBR003,Former Employment Exchange,Ashington Probation Centre,COMM,Y
+MCG015,Oldham (Bridge St) Probation Office,Oldham (Bridge St) Probation Office,COMM,Y
+BDS002,Bedfordshire Programmes Unit,Bedfordshire Programmes Unit,COMM,Y
+CHTONF,Chesterfield & N Derbys Royal Hospital,Chesterfield & N Derbys Royal Hospital,HSHOSP,Y
+NHSAP2,Astral Grove,Astral Grove,APPR,Y
+PENN,Penn Hospital,Penn Hospital,HSHOSP,Y
+THA014,Oxford Probation Office,Oxford Probation Office,COMM,Y
+MLW008,Harborne Probation Office,Harborne Probation Office,COMM,Y
+LDM001,Blackfriars Crown Court Probation Office,Blackfriars Crown Court Probation Office,COMM,Y
+LTS004,Leicester CJDT Bowling Green Street,Leicester Criminal Justice Drugs Team Bowling Green Street,COMM,Y
+THA037,Bracknell Probation Office,Bracknell Probation Office,COMM,Y
+HBSY01,Hull YOT,Hull YOT,YOT,Y
+DCPAP3,Prospect House Approved Premises,Prospect House Approved Premises,APPR,Y
+WATLOW,Waterlow Unit,Waterlow Unit,HSHOSP,Y
+WATHWD,Wathwood Hospital RSU,Wathwood Hospital RSU,HSHOSP,Y
+BDS015,Victims Liason Unit,Victims Liason Unit,COMM,Y
+MLW003,Birmingham Homeless Offenders Unit,Birmingham Homeless Offenders Unit,COMM,Y
+MRS051,North Liverpool Probation Centre,North Liverpool Probation Centre,COMM,Y
+489355,Harlow Probation Office,Harlow Probation Office,COMM,N
+638730,Essex Head Office,Essex Head Office,COMM,N
+CHS002,CREWE Probation Office,CREWE Probation Office,COMM,N
+MCG014,Grt Man Prob Progs and Development Unit,Grt Man Prob Progs and Development Unit,COMM,Y
+TES006,Middlesbrough Progrs and Drug Res Unit,Middlesbrough Progrs and Drug Res Unit,COMM,Y
+659471,Gloucester Probation Centre,Gloucester Probation Centre,COMM,N
+BISHYC,Bishop Auckland Youth Court,Bishop Auckland Youth Court,CRT,Y
+BLKBYC,"Blackburn, Darwen and Ribble Valley YC","Blackburn, Darwen and Ribble Valley Youth Court",CRT,Y
+BLKPYC,Fylde Coast at Blackpool Youth Court,Fylde Coast at Blackpool Youth Court,CRT,Y
+BLKWYC,Blackwood Youth Court,Blackwood Youth Court,CRT,N
+BALNYC,Blandford Forum Youth Court,Blandford Forum Youth Court,CRT,Y
+BLAYYC,Blaydon Youth Court,Blaydon Youth Court,CRT,Y
+BODMYC,Bodmin Youth Court,Bodmin Youth Court,CRT,Y
+BOLTYC,Bolton Youth Court,Bolton Youth Court,CRT,Y
+BOSTYC,Boston Youth Court,Boston Youth Court,CRT,Y
+BORNYC,Bourne Youth Court,Bourne Youth Court,CRT,Y
+BRADYC,Bradford Youth Court,Bradford Youth Court,CRT,N
+BRECYC,Brecon Youth Court,Brecon Youth Court,CRT,Y
+BRENYC,Brent Youth Court,Brent Youth Court,CRT,Y
+BRTFYC,Brentford Youth Court,Brentford Youth Court,CRT,Y
+BRIDYC,Bridgend Youth Court,Bridgend Youth Court,CRT,N
+BRDWYC,Bridgwater Youth Court,Bridgwater Youth Court,CRT,Y
+BRDLYC,Bridlington Youth Court,Bridlington Youth Court,CRT,Y
+BRGJYC,Brighton Youth Court,Brighton Youth Court,CRT,Y
+BRSTYC,Bristol Youth Court,Bristol Youth Court,CRT,N
+BROMYC,Bromley Youth Court,Bromley Youth Court,CRT,N
+RDDTYC,Bromsgrove and Redditch Youth Court,Bromsgrove and Redditch Youth Court,CRT,Y
+BURNYC,Burnley and Pendle Youth Court,Burnley and Pendle Youth Court,CRT,Y
+BURTYC,SE Staffs Youth Court - Burton,South East Staffordshire Youth Court - Burton,CRT,Y
+BRSEYC,Bury St. Edmunds Youth Court,Bury St. Edmunds Youth Court,CRT,Y
+BURYYC,Bury Youth Court,Bury Youth Court,CRT,Y
+CRNHYC,Caernarfon Youth Court,Caernarfon Youth Court,CRT,Y
+HLFXYC,Calderdale Youth Court,Calderdale Youth Court,CRT,Y
+CMBRYC,Camborne Youth Court,Camborne Youth Court,CRT,Y
+CAMBYC,Cambridge Youth Court,Cambridge Youth Court,CRT,N
+CANNYC,C and SW Staffs Youth Court - Cannock,C and SW Staffs Youth Court - Cannock,CRT,Y
+CANTYC,Canterbury Youth Court,Canterbury Youth Court,CRT,N
+CRDFYC,Cardiff Youth Court,Cardiff Youth Court,CRT,N
+CRDGYC,Cardigan Youth Court,Cardigan Youth Court,CRT,Y
+CARLYC,Carlisle and District Youth Court,Carlisle and District Youth Court,CRT,Y
+CARMYC,Carmarthen Youth Court,Carmarthen Youth Court,CRT,Y
+SWFFYC,Central Norfolk Youth Court,Central Norfolk Youth Court,CRT,Y
+CHTHYC,Chatham Youth Court,Chatham Youth Court,CRT,Y
+CHELYC,Cheltenham Youth Court,Cheltenham Youth Court,CRT,Y
+CHSHYC,Cheshunt Youth Court,Cheshunt Youth Court,CRT,Y
+CHESYC,Chester Youth Court,Chester Youth Court,CRT,N
+CHCHYC,Chichester Youth Court,Chichester Youth Court,CRT,Y
+CHPPYC,Chippenham Youth Court,Chippenham Youth Court,CRT,Y
+CHRLYC,Chorley Youth Court,Chorley Youth Court,CRT,Y
+SLFRYC,City of Salford Youth Court,City of Salford Youth Court,CRT,Y
+COLVYC,Coalville Youth Court,Coalville Youth Court,CRT,Y
+CNSTYC,Consett Youth Court,Consett Youth Court,CRT,Y
+CVNTYC,Coventry Youth Court,Coventry Youth Court,CRT,N
+CRAWYC,Crawley Youth Court,Crawley Youth Court,CRT,Y
+CREWYC,Crewe Youth Court,Crewe Youth Court,CRT,N
+CRYDYC,Croydon Youth Court,Croydon Youth Court,CRT,N
+CWMBYC,Cwmbran Youth Court,Cwmbran Youth Court,CRT,Y
+DARLYC,Darlington Youth Court,Darlington Youth Court,CRT,Y
+DRTFYC,Dartford Youth Court,Dartford Youth Court,CRT,Y
+DNBGYC,Denbigh Youth Court,Denbigh Youth Court,CRT,Y
+DIDCYC,Didcot Youth Court,Didcot Youth Court,CRT,Y
+DOLGYC,Dolgellau Youth Court,Dolgellau Youth Court,CRT,Y
+DONCYC,Doncaster Youth Court,Doncaster Youth Court,CRT,Y
+DUDLYC,Dudley Youth Court,Dudley Youth Court,CRT,Y
+DURHYC,Durham Youth Court,Durham Youth Court,CRT,Y
+EASBYC,Eastbourne Youth Court,Eastbourne Youth Court,CRT,Y
+ELYMYC,Ely Youth Court,Ely Youth Court,CRT,Y
+EXETYC,Exeter Youth Court,Exeter Youth Court,CRT,Y
+FARHYC,Fareham Youth Court,Fareham Youth Court,CRT,Y
+FLTWYC,Fylde Coast at Fleetwood Youth Court,Fylde Coast at Fleetwood Youth Court,CRT,Y
+FLKSYC,Folkestone Youth Court,Folkestone Youth Court,CRT,Y
+FRMEYC,Frome Youth Court,Frome Youth Court,CRT,Y
+GLOCYC,Gloucester Youth Court,Gloucester Youth Court,CRT,Y
+GOOLYC,Goole Youth Court,Goole Youth Court,CRT,Y
+GOSFYC,Gosforth Youth Court,Gosforth Youth Court,CRT,Y
+GRNTYC,Grantham Youth Court,Grantham Youth Court,CRT,Y
+GRYSYC,Grays Youth Court,Grays Youth Court,CRT,Y
+GRTYYC,Great Yarmouth Youth Court,Great Yarmouth Youth Court,CRT,Y
+GRIMYC,Grimsby Youth Court,Grimsby Youth Court,CRT,N
+GLDFYC,Guildford Youth Court,Guildford Youth Court,CRT,Y
+HALEYC,Halesowen Youth Court,Halesowen Youth Court,CRT,Y
+HRLWYC,Harlow Youth Court,Harlow Youth Court,CRT,Y
+HRRGYC,Harrogate Youth Court,Harrogate Youth Court,CRT,N
+HRRWYC,Harrow Youth Court,Harrow Youth Court,CRT,Y
+HRTLYC,Hartlepool Youth Court,Hartlepool Youth Court,CRT,Y
+HRWCYC,Harwich Youth Court,Harwich Youth Court,CRT,Y
+HSTNYC,Hastings Youth Court,Hastings Youth Court,CRT,Y
+HVRFYC,Haverfordwest Youth Court,Haverfordwest Youth Court,CRT,Y
+RMFRYC,Havering Youth Court,Havering Youth Court,CRT,Y
+HYWHYC,Haywards Heath Youth Court,Haywards Heath Youth Court,CRT,Y
+HMLHYC,Hemel Hempstead Youth Court,Hemel Hempstead Youth Court,CRT,Y
+HNDNYC,Hendon Youth Court,Hendon Youth Court,CRT,Y
+HERFYC,Hereford Youth Court,Hereford Youth Court,CRT,Y
+BUXTYC,High Peak Youth Court (Buxton),High Peak Youth Court (Buxton),CRT,Y
+GLOSYC,High Peak Youth Court (Glossop),High Peak Youth Court (Glossop),CRT,Y
+HGHGYC,Highgate Youth Court,Highgate Youth Court,CRT,Y
+HNCKYC,Hinckley Youth Court,Hinckley Youth Court,CRT,Y
+HLYHYC,Holyhead Youth Court,Holyhead Youth Court,CRT,Y
+HRSHYC,Horsham Youth Court,Horsham Youth Court,CRT,Y
+HOGHYC,Houghton-le-Spring Youth Court,Houghton-le-Spring Youth Court,CRT,Y
+HUDRYC,Huddersfield Youth Court,Huddersfield Youth Court,CRT,Y
+KNGHYC,Hull Youth Court,Hull Youth Court,CRT,N
+HUNTYC,Huntingdon Youth Court,Huntingdon Youth Court,CRT,N
+THMSYC,Inner London Youth Courts Centre 1,Inner London Youth Courts Centre 1,CRT,Y
+CMBGYC,Inner London Youth Courts Centre 2,Inner London Youth Courts Centre 2,CRT,Y
+WLONYC,Inner London Youth Courts Centre 3,Inner London Youth Courts Centre 3,CRT,Y
+STHLYC,Inner London Youth Courts Centre 4,Inner London Youth Courts Centre 4,CRT,Y
+IPSWYC,Ipswich Youth Court,Ipswich Youth Court,CRT,N
+NWPRYC,Isle of Wight Youth Court,Isle of Wight Youth Court,CRT,Y
+BINGYC,Keighley Youth Court,Keighley Youth Court,CRT,Y
+KENDYC,Kendal Youth Court,Kendal Youth Court,CRT,Y
+KTTRYC,Kettering Youth Court,Kettering Youth Court,CRT,Y
+KIDDYC,Kidderminster Youth Court,Kidderminster Youth Court,CRT,Y
+KNGTYC,Kingston-upon-Thames Youth Court,Kingston-upon-Thames Youth Court,CRT,Y
+HUYTYC,Knowlsey Youth Court,Knowlsey Youth Court,CRT,Y
+LANCYC,Lancaster Youth Court,Lancaster Youth Court,CRT,Y
+LEAMYC,Leamington Spa Youth Court,Leamington Spa Youth Court,CRT,N
+STHSCC,Southend Crown Court,Southend Crown Court,CRT,Y
+ELYMC,Ely MC,Ely Magistrates' Court,CRT,Y
+BATHMC,Bath MC,Bath Magistrates' Court,CRT,Y
+BURYMC,Bury MC,Bury Magistrates' Court,CRT,Y
+MOLDMC,Mold MC,Mold Magistrates' Court,CRT,Y
+SALEMC,Sale MC,Sale Magistrates' Court,CRT,Y
+YATEMC,Yate MC,Yate Magistrates' Court,CRT,Y
+YORKMC,York MC,York Magistrates' Court,CRT,Y
+ACTNMC,Acton MC,Acton Magistrates' Court,CRT,Y
+ALTNMC,Alton MC,Alton Magistrates' Court,CRT,Y
+BRRYMC,"Vale of Glamorgan MC, Barry","Vale of Glamorgan Magistrate Court, Barry",CRT,Y
+BRENMC,Willesden MC,Willesden Magistrates Court,CRT,Y
+CRBYMC,Corby MC,Corby Magistrates' Court,CRT,Y
+CREWMC,Crewe MC,Crewe Magistrates' Court,CRT,Y
+DOVRMC,Dover MC,Dover Magistrates' Court,CRT,Y
+EPSMMC,Epsom MC,Epsom Magistrates' Court,CRT,N
+FLNTMC,Flint (Bodhyfryd) Mag Court,Flint (Bodhyfryd) Mag Court,CRT,Y
+FRMEMC,Frome MC,Frome Magistrates' Court,CRT,Y
+GOOLMC,Goole MC,Goole Magistrates' Court,CRT,Y
+GRYSMC,Grays MC,Grays Magistrates' Court,CRT,Y
+LEEDMC,Leeds MC,Leeds Magistrates' Court,CRT,Y
+LEWSMC,Lewes MC,Lewes Magistrates' Court,CRT,Y
+LOUTMC,Louth MC,Louth Magistrates' Court,CRT,Y
+LUTNMC,Luton MC,Luton Magistrates' Court,CRT,Y
+NEATMC,Neath MC,Neath Magistrates' Court,CRT,Y
+POOLMC,Poole MC,Poole Magistrates' Court,CRT,Y
+RGBYMC,Rugby MC,Rugby Magistrates' Court,CRT,Y
+SLBYMC,Selby MC,Selby Magistrates' Court,CRT,Y
+TNBYMC,Tenby MC,Tenby Magistrates' Court,CRT,Y
+THAMMC,Thame MC,Thame Magistrates' Court,CRT,N
+TRURMC,Truro MC,Truro Magistrates' Court,CRT,Y
+WELLMC,Wells MC,Wells Magistrates' Court,CRT,Y
+WIGNMC,Wigan MC,Wigan Magistrates' Court,CRT,Y
+BNGRMC,Bangor MC,Bangor Magistrates' Court,CRT,N
+BRNTMC,Barnet MC,Barnet Magistrates' Court,CRT,Y
+BEXLMC,Bexley MC,Bexley Magistrates' Court,CRT,Y
+BODMMC,Bodmin MC,Bodmin Magistrates' Court,CRT,Y
+BOLTMC,Bolton MC,Bolton Magistrates' Court,CRT,Y
+BOOTMC,Bootle MC,Bootle Magistrates' Court,CRT,N
+BOSTMC,Boston MC,Boston Magistrates' Court,CRT,Y
+BORNMC,Bourne MC,Bourne Magistrates' Court,CRT,Y
+BRECMC,Brecon MC,Brecon Magistrates' Court,CRT,Y
+BUXTMC,Buxton MC,Buxton Magistrates' Court,CRT,Y
+CROMMC,North Norfolk Magistrates Court,North Norfolk Magistrates Court,CRT,Y
+DIDCMC,Didcot MC,Didcot Magistrates' Court,CRT,Y
+DUDLMC,Dudley MC,Dudley Magistrates' Court,CRT,Y
+DURHMC,Durham MC,Durham Magistrates' Court,CRT,Y
+EALNMC,Ealing MC,Ealing Magistrates' Court,CRT,Y
+EPPNMC,Epping MC,Epping Magistrates' Court,CRT,Y
+EXETMC,Exeter MC,Exeter Magistrates' Court,CRT,Y
+HRLWMC,Harlow MC,Harlow Magistrates' Court,CRT,Y
+NLSNCT,Nelson County Court,Nelson County Court,CRT,Y
+NWRKCT,Newark County Court,Newark County Court,CRT,Y
+NWBRCT,Newbury County Court,Newbury County Court,CRT,Y
+NWCSCT,Newcastle upon Tyne County Court,Newcastle upon Tyne County Court,CRT,Y
+NWPRCT,Newport (I.O.W.) County Court,Newport (I.O.W.) County Court,CRT,Y
+NWPWCT,Newport (South Wales) County Court,Newport (South Wales) County Court,CRT,Y
+NRTSCT,North Shields County Court,North Shields County Court,CRT,Y
+NRTHCT,Northampton County Court,Northampton County Court,CRT,Y
+NRTWCT,Northwich County Court,Northwich County Court,CRT,Y
+NORWCT,Norwich County Court,Norwich County Court,CRT,Y
+NOTTCT,Nottingham County Court,Nottingham County Court,CRT,Y
+NUNTCT,Nuneaton County Court,Nuneaton County Court,CRT,Y
+OLDHCT,Oldham County Court,Oldham County Court,CRT,Y
+OSWSCT,Oswestry County Court,Oswestry County Court,CRT,Y
+OXFDCT,Oxford County Court,Oxford County Court,CRT,Y
+PENRCT,Penrith County Court,Penrith County Court,CRT,Y
+PENZCT,Penzance County Court,Penzance County Court,CRT,Y
+PBORCT,Peterborough County Court,Peterborough County Court,CRT,Y
+PLYMCT,Plymouth County Court,Plymouth County Court,CRT,Y
+PONTCT,Pontefract County Court,Pontefract County Court,CRT,Y
+PNTPCT,Pontypool County Court,Pontypool County Court,CRT,Y
+PNTYCT,Pontypridd County Court,Pontypridd County Court,CRT,Y
+POOLCT,Poole County Court,Poole County Court,CRT,Y
+PRTSCT,Portsmouth County Court,Portsmouth County Court,CRT,Y
+PRESCT,Preston County Court,Preston County Court,CRT,Y
+RWTNCT,Rawtenstall County Court,Rawtenstall County Court,CRT,Y
+READCT,Reading County Court,Reading County Court,CRT,Y
+RDDTCT,Redditch County Court,Redditch County Court,CRT,Y
+REIGCT,Reigate County Court,Reigate County Court,CRT,Y
+RHYLCT,Rhyl County Court,Rhyl County Court,CRT,Y
+RMFRCT,Romford County Court,Romford County Court,CRT,Y
+ROTHCT,Rotherham County Court,Rotherham County Court,CRT,Y
+RGBYCT,Rugby County Court,Rugby County Court,CRT,Y
+RUNCCT,Runcorn County Court,Runcorn County Court,CRT,Y
+SLFRCT,Salford County Court,Salford County Court,CRT,Y
+SALSCT,Salisbury County Court,Salisbury County Court,CRT,Y
+SCRBCT,Scarborough County Court,Scarborough County Court,CRT,Y
+SCUNCT,Scunthorpe County Court,Scunthorpe County Court,CRT,Y
+SHEFCT,Sheffield County Court,Sheffield County Court,CRT,Y
+SHRDCT,Shoreditch County Court,Shoreditch County Court,CRT,Y
+SHRWCT,Shrewsbury County Court,Shrewsbury County Court,CRT,Y
+SKEGCT,Skegness County Court,Skegness County Court,CRT,Y
+SKIPCT,Skipton County Court,Skipton County Court,CRT,Y
+KTI,KENNET (HMP),HMP KENNET,INST,Y
+SCOTCT,Scottish Courts,Scottish Courts,CRT,Y
+NICT,Northen Ireland Courts,Northen Ireland Courts,CRT,Y
+HEI,HEWELL (HMP),HEWELL (HMP),INST,Y
+HPS013,Portsmouth Probation Office,Portsmouth Probation Office,COMM,Y
+HPS018,Totton Probation Office,Totton Probation Office,COMM,Y
+MLW026,Wolverhampton Crown Court Liaison Unit,Wolverhampton Crown Court Liaison Unit,COMM,Y
+ROSEWD,Rosewood House,Rosewood House,HSHOSP,Y
+HPS012,Farnborough Probation Office,Farnborough Probation Office,COMM,Y
+MLWAP4,Elliott House Approved Premsies,Elliott House Approved Premsies,APPR,Y
+DBS011,Matlock Probation Office,Matlock Probation Office,COMM,Y
+SCKTON,Stockton Hall Psychiatric Hospital,Stockton Hall Psychiatric Hospital,HSHOSP,Y
+ASPAP2,Bridge House Approved Premises,Bridge House Approved Premises,APPR,Y
+MLLVEW,NHS Millview Hospital,"Pavilion Ward, Millview Hospital",HSHOSP,Y
+SULLY,Sully Hospital,Sully Hospital,HSHOSP,Y
+CMB001,Cumbria Head Office,Cumbria Head Office,COMM,Y
+HBS011,HULL CC Liaison Unit,HULL CC Liaison Unit,COMM,Y
+HPS043,Fareham Court (Probation),Fareham Court (Probation),COMM,Y
+LCS020,PRESTON CC Liaison Unit,PRESTON CC Liaison Unit,COMM,Y
+LNS005,Skegness Probation Office,Skegness Probation Office,COMM,Y
+LDM041,Camden and Islington NPS,St John Street,COMM,Y
+CHS008,Chester Probation Office,Chester Probation Office,COMM,Y
+HBS016,Grimsby DIT,Grimsby DIT,COMM,Y
+ASPY01,Bath YOT,Bath YOT,COMM,Y
+WWS006,Nuneaton Probation Centre,Nuneaton Probation Centre,COMM,Y
+HOLFRD,Holford House,Holford House,HSHOSP,Y
+ASPAP1,Ashley House Approved Premises,Ashley House Approved Premises,APPR,Y
+KNTY05,West Kent YOT,West Kent YOT,YOT,Y
+SSX015,Lewes Crown Court Liaison Unit,Lewes Crown Court Liaison Unit,COMM,Y
+STPNG,Stepping Hill Hospital,Stepping Hill Hospital,HSHOSP,Y
+STNLAS,St Nicholas Hospital Medium Secure Unit,St Nicholas Hospital Medium Secure Unit,HSHOSP,Y
+MCG011,Cheetham Hill Probation Office,Cheetham Hill Probation Office,COMM,Y
+LCS013,MORECAMBE Probation Office,MORECAMBE Probation Office,COMM,Y
+LLWYMC,Llwynypia MC,Llwynypia Magistrates' Court,CRT,Y
+LWSTMC,Lowestoft MC,Lowestoft Magistrates' Court,CRT,Y
+LYNDMC,Lyndhurst MC,Lyndhurst Magistrates' Court,CRT,Y
+MDSTMC,Maidstone MC,Maidstone Magistrates' Court,CRT,Y
+NRTWMC,Northwich MC,Northwich Magistrates' Court,CRT,Y
+PCKRMC,Pickering MC,Pickering Magistrates' Court,CRT,N
+PRSTMC,Prestatyn MC,Prestatyn Magistrates' Court,CRT,Y
+RDBRMC,Redbridge MC,Redbridge Magistrates' Court,CRT,N
+ROTHMC,Rotherham MC,Rotherham Magistrates' Court,CRT,Y
+SALSMC,Salisbury MC,Salisbury Magistrates' Court,CRT,Y
+SEVNMC,Sevenoaks MC,Sevenoaks Magistrates' Court,CRT,Y
+SHEFMC,Sheffield MC,Sheffield Magistrates' Court,CRT,Y
+SHERMC,Sherborne MC,Sherborne Magistrates' Court,CRT,Y
+STHPMC,Southport MC,Southport Magistrates' Court,CRT,Y
+STALMC,St Albans MC,St Albans Magistrates' Court,CRT,Y
+STHEMC,St Helens MC,St Helens Magistrates' Court,CRT,N
+STEVMC,Stevenage MC,Stevenage Magistrates' Court,CRT,Y
+STOCMC,Stockport MC,Stockport Magistrates' Court,CRT,Y
+STRAMC,Stratford MC,Stratford Magistrates' Court,CRT,Y
+TTTNMC,Tottenham MC,Tottenham Magistrates' Court,CRT,N
+TOWCMC,Towcester MC,Towcester Magistrates' Court,CRT,Y
+WAKFMC,Wakefield MC,Wakefield Magistrates' Court,CRT,Y
+WLSHMC,Welshpool MC,Welshpool Magistrates' Court,CRT,Y
+WMBLMC,Wimbledon MC,Wimbledon Magistrates' Court,CRT,Y
+ACCRMC,Accrington MC,Accrington Magistrates' Court,CRT,Y
+ATHRMC,Atherstone MC,Atherstone Magistrates' Court,CRT,N
+BNSTMC,Barnstaple MC,Barnstaple Magistrates' Court,CRT,Y
+BDLNMC,Bedlington MC,Bedlington Magistrates' Court,CRT,Y
+BRKNMC,Birkenhead MC,Birkenhead Magistrates' Court,CRT,Y
+STHWCC,Southwark Crown Court,Southwark Crown Court,CRT,Y
+STALCC,St. Albans Crown Court,St. Albans Crown Court,CRT,Y
+STAFCC,Stafford Crown Court,Stafford Crown Court,CRT,Y
+STOKCC,Stoke-on-Trent Crown Court,Stoke-on-Trent Crown Court,CRT,Y
+SWANCC,Swansea Crown Court,Swansea Crown Court,CRT,Y
+SWINCC,Swindon Crown Court,Swindon Crown Court,CRT,Y
+TAUNCC,Taunton Crown Court,Taunton Crown Court,CRT,Y
+TEESCC,Teesside Crown Court,Teesside Crown Court,CRT,Y
+TRURCC,Truro Crown Court,Truro Crown Court,CRT,Y
+WARRCC,Warrington Combined Court,Warrington Combined Court,CRT,N
+WRWKCC,Leamington Crown Court,Leamington Crown Court,CRT,Y
+WLSHCC,Welshpool Crown Court,Welshpool Crown Court,CRT,Y
+WEYMCC,Weymouth Crown Court,Weymouth Crown Court,CRT,Y
+WNCHCC,Winchester Crown Court,Winchester Crown Court,CRT,Y
+WLVRCC,Wolverhampton Crown Court,Wolverhampton Crown Court,CRT,Y
+WDGRCC,Wood Green Crown Court,Wood Green Crown Court,CRT,Y
+WOOLCC,Woolwich Crown Court,Woolwich Crown Court,CRT,Y
+WRCSCC,Worcester Crown Court,Worcester Crown Court,CRT,Y
+YORKCC,York Crown Court,York Crown Court,CRT,Y
+ABDRCT,Aberdare County Court,Aberdare County Court,CRT,Y
+ABRYCT,Aberystwyth County Court,Aberystwyth County Court,CRT,Y
+ACCRCT,Accrington County Court,Accrington County Court,CRT,Y
+ALDRCT,Aldershot and Farnham County Court,Aldershot and Farnham County Court,CRT,Y
+ALTRCT,Altrincham County Court,Altrincham County Court,CRT,Y
+ASHFCT,Ashford County Court,Ashford County Court,CRT,Y
+LCS008,Burnley Probation Office,Burnley Probation Office,COMM,Y
+BDS005,Luton Probation Office,Luton Probation Office,COMM,Y
+KNT011,Maidstone Crown Court Probation Office,Maidstone Crown Court Probation Office,COMM,Y
+LCSY09,NSPCC Meadow House Project,NSPCC Meadow House Project,YOT,Y
+THA052,Bicester Probation Office,Bicester Probation Office,COMM,Y
+ASP008,Bristol Crown Court Liaison Office,Bristol Crown Court Liaison Office,COMM,Y
+DPP002,Aberystwyth Probation Office,Aberystwyth Probation Office,COMM,Y
+WMP006,Telford Probation Office,Telford Probation Office,COMM,Y
+WTS001,Wiltshire Head Office,Wiltshire Head Office,COMM,Y
+TORQMC,Torquay MC,Torquay Magistrates' Court,CRT,Y
+WANTMC,Wantage MC,Wantage Magistrates' Court,CRT,Y
+WARHMC,Wareham MC,Wareham Magistrates' Court,CRT,Y
+WATFMC,Watford MC,Watford Magistrates' Court,CRT,Y
+WISBMC,Wisbech MC,Wisbech Magistrates' Court,CRT,Y
+WORKMC,Worksop MC,Worksop Magistrates' Court,CRT,Y
+WREXMC,Wrexham MC,Wrexham Magistrates' Court,CRT,Y
+WYCBMC,Wycombe MC,Wycombe Magistrates' Court,CRT,N
+ABDRMC,Aberdare MC,Aberdare Magistrates' Court,CRT,Y
+AMRSMC,Amersham MC,Amersham Magistrates' Court,CRT,Y
+BRNSMC,Barnsley MC,Barnsley Magistrates' Court,CRT,Y
+BSLDMC,Basildon MC,Basildon Magistrates' Court,CRT,Y
+BELMMC,Belmarsh MC,Belmarsh Magistrates' Court,CRT,Y
+BEVRMC,Beverley MC,Beverley Magistrates' Court,CRT,Y
+BICSMC,Bicester MC,Bicester Magistrates' Court,CRT,Y
+BRADMC,Bradford MC,Bradford Magistrates' Court,CRT,Y
+BRIDMC,Bridgend MC,Bridgend Magistrates' Court,CRT,N
+BRDPMC,Bridport MC,Bridport Magistrates' Court,CRT,Y
+CMBRMC,Camborne MC,Camborne Magistrates' Court,CRT,Y
+CRDGMC,Cardigan MC,Cardigan Magistrates' Court,CRT,Y
+CARLMC,Carlisle and District Magistrates Court,Carlisle and District Magistrates Court,CRT,Y
+CHEPMC,Chepstow MC,Chepstow Magistrates' Court,CRT,N
+CHSHMC,Cheshunt MC,Cheshunt Magistrates' Court,CRT,Y
+COLFMC,Coleford MC,Coleford Magistrates' Court,CRT,Y
+CVNTMC,Coventry MC,Coventry Magistrates' Court,CRT,Y
+DRTFMC,Dartford MC,Dartford Magistrates' Court,CRT,Y
+DAVNMC,Daventry MC,Daventry Magistrates' Court,CRT,Y
+DEWSMC,Dewsbury MC,Dewsbury Magistrates' Court,CRT,Y
+GOSFMC,Gosforth MC,Gosforth Magistrates' Court,CRT,Y
+GOWRMC,Gowerton MC,Gowerton Magistrates' Court,CRT,N
+GRNTMC,Grantham MC,Grantham Magistrates' Court,CRT,Y
+HSTNMC,Hastings MC,Hastings Magistrates' Court,CRT,Y
+HERTMC,Hertford MC,Hertford Magistrates' Court,CRT,N
+HGHGMC,Highgate MC,Highgate Magistrates' Court,CRT,Y
+HNCKMC,Hinckley MC,Hinckley Magistrates' Court,CRT,Y
+HLYHMC,Holyhead MC,Holyhead Magistrates' Court,CRT,Y
+ILKSMC,Ilkeston MC,Ilkeston Magistrates' Court,CRT,Y
+LSKRMC,Liskeard MC,Liskeard Magistrates' Court,CRT,Y
+LLNLMC,Llanelli MC,Llanelli Magistrates' Court,CRT,Y
+MINEMC,Minehead MC,Minehead Magistrates' Court,CRT,Y
+NUNTMC,Nuneaton MC,Nuneaton Magistrates' Court,CRT,N
+ORMKMC,Ormskirk MC,Ormskirk Magistrates' Court,CRT,Y
+OSWSMC,Oswestry MC,Oswestry Magistrates' Court,CRT,Y
+PENZMC,Penzance MC,Penzance Magistrates' Court,CRT,Y
+PTRLMC,Peterlee MC,Peterlee Magistrates' Court,CRT,Y
+PLYMMC,Plymouth MC,Plymouth Magistrates' Court,CRT,Y
+PWLLMC,Pwllheli MC,Pwllheli Magistrates' Court,CRT,Y
+RDDTMC,Redditch MC,Redditch Magistrates' Court,CRT,Y
+RCHMMC,Richmond MC,Richmond Magistrates' Court,CRT,N
+ROCHMC,Rochdale MC,Rochdale Magistrates' Court,CRT,Y
+SKEGMC,Skegness MC,Skegness Magistrates' Court,CRT,Y
+SLEAMC,Sleaford MC,Sleaford Magistrates' Court,CRT,Y
+SOLIMC,Solihull MC,Solihull Magistrates' Court,CRT,Y
+SPALMC,Spalding MC,Spalding Magistrates' Court,CRT,Y
+STAFMC,Stafford Magistrates Court,Stafford Magistrates Court,CRT,Y
+STAMMC,Stamford MC,Stamford Magistrates' Court,CRT,Y
+SWFFMC,Swaffham MC,Swaffham Magistrates' Court,CRT,Y
+TAMWMC,SE Staffs MC - Tamworth,SE Staffordshire Magistrates Court - Tamworth,CRT,Y
+THETMC,Thetford MC,Thetford Magistrates' Court,CRT,Y
+TREDMC,Tredegar MC,Tredegar Magistrates' Court,CRT,N
+UXBRMC,Uxbridge MC,Uxbridge Magistrates' Court,CRT,Y
+WALLMC,Wallasey MC,Wallasey Magistrates' Court,CRT,N
+WETHMC,Wetherby MC,Wetherby Magistrates' Court,CRT,N
+WEYMMC,Weymouth MC,Weymouth Magistrates' Court,CRT,Y
+WMBRMC,Wimborne MC,Wimborne Magistrates' Court,CRT,Y
+WOOLMC,Woolwich MC,Woolwich Magistrates' Court,CRT,Y
+WORTMC,Worthing MC,Worthing Magistrates' Court,CRT,Y
+ALDRMC,Aldershot MC,Aldershot Magistrates' Court,CRT,Y
+AMMNMC,Ammanford MC,Ammanford Magistrates' Court,CRT,Y
+AYLSMC,Aylesbury MC,Aylesbury Magistrates' Court,CRT,Y
+BLKBMC,Blackburn MC,Blackburn Magistrates' Court,CRT,Y
+BLKPMC,Blackpool MC,Blackpool Magistrates' Court,CRT,Y
+BLKWMC,Blackwood MC,Blackwood Magistrates' Court,CRT,N
+BALNMC,Blandford MC,Blandford Magistrates' Court,CRT,Y
+BRAKMC,East Berkshire MC Bracknell Court House,East Berkshire MC Bracknell Court House,CRT,Y
+BRTFMC,Brentford MC,Brentford Magistrates' Court,CRT,N
+CMBLMC,Camberley MC,Camberley Magistrates' Court,CRT,N
+CAMBMC,Cambridge MC,Cambridge Magistrates' Court,CRT,Y
+COLVMC,Coalville MC,Coalville Magistrates' Court,CRT,Y
+DOLGMC,Dolgellau MC,Dolgellau Magistrates' Court,CRT,Y
+DONCMC,Doncaster MC,Doncaster Magistrates' Court,CRT,Y
+DRTWMC,Droitwich MC,Droitwich Magistrates' Court,CRT,N
+EASLMC,Eastleigh MC,Eastleigh Magistrates' Court,CRT,N
+FLTWMC,Fylde Coast at Fleetwood MC,Fylde Coast at Fleetwood Magistrates Court,CRT,Y
+GTSHMC,Gateshead MC,Gateshead Magistrates' Court,CRT,Y
+GRNWMC,Greenwich MC,Greenwich Magistrates' Court,CRT,N
+GLDFMC,Guildford MC,Guildford Magistrates' Court,CRT,Y
+HALEMC,Halesowen MC,Halesowen Magistrates' Court,CRT,Y
+HRRGMC,Harrogate MC,Harrogate Magistrates' Court,CRT,Y
+KTTRMC,Kettering MC,Kettering Magistrates' Court,CRT,Y
+LANCMC,Lancaster MC,Lancaster Magistrates' Court,CRT,Y
+LEICMC,Leicester MC,Leicester Magistrates' Court,CRT,Y
+LLDUMC,Llandudno MC,Llandudno Magistrates' Court,CRT,Y
+LLNGMC,Llangefni MC,Llangefni Magistrates' Court,CRT,Y
+SSX016,Sussex Probation Head Office,Sussex Probation Head Office,COMM,Y
+LDM026,Tower Bridge Mags Court Probation Office,Tower Bridge Mags Court Probation Office,COMM,Y
+NEWHAM,Newham Centre for Mental Health,Newham Centre for Mental Health,HSHOSP,Y
+LCS010,FLEETWOOD Probation Office,FLEETWOOD Probation Office,COMM,Y
+DBSY04,Buxton YOT,Buxton YOT,YOT,Y
+YSWVH3,Ripon House,Ripon House,APPR,Y
+LTS011,Leicester MC Liaison Unit,Leicester MC Liaison Unit,COMM,Y
+NEWSUS,New Sussex Hospital,New Sussex Hospital,HSHOSP,Y
+THA010,High Wycombe Mags Court Probation Off,High Wycombe Mags Court Probation Off,COMM,Y
+YSS011,"Victoria Rd, Barnsley","Victoria Rd, Barnsley",COMM,N
+271206,Liverpool North Probation Office,Liverpool North Probation Office,COMM,N
+SWSAP2,Quay House Probation Hostel,Quay House Probation Hostel,APPR,Y
+MLW042,West Bromwich Court,West Bromwich Court,COMM,Y
+YSS023,"Rookwood Hostel, Rotherham","Rookwood Hostel, Rotherham",APPR,Y
+CMB012,Cumbria DAT South,Cumbria DAT South,COMM,Y
+GODDEN,Godden Green Clinic,Godden Green Clinic,HSHOSP,Y
+NBR037,Northumbria MAPPA Unit,Northumbria MAPPA Unit,COMM,Y
+WATLOO,Waterloo Mannor Independent,Waterloo Mannor Independent,HSHOSP,Y
+285233,Norwich Probation Office,Norwich Probation Office,COMM,N
+439249,Thetford Probation Office,Thetford Probation Office,COMM,N
+KNT007,Faversham Probation Office,Faversham Probation Office,COMM,Y
+DRHY03,Co Durham North Area YOT,Co Durham North Area YOT,YOT,Y
+YSW009,Leeds East Probation Office,Leeds East Probation Office,COMM,Y
+479325,Norfolk Head Office,Norfolk Head Office,COMM,N
+ACI,ALTCOURSE (HMP),HMP ALTCOURSE,INST,Y
+LANRTH,Llanarth Court Psychiatric Hospital,Llanarth Court Psychiatric Hospital,HSHOSP,Y
+SWSY05,Swansea YOT,Swansea YOT,YOT,Y
+KNT012,Thanet Probation KSSCRC,Thanet Probation KSSCRC,COMM,Y
+FSTLDG,Forest Lodge,Forest Lodge,HSHOSP,Y
+ESXY01,SW Essex Youth Offending Team,SW Essex Youth Offending Team,YOT,Y
+CBSAP1,Peterborough Probation Hostel,Peterborough Probation Hostel,APPR,Y
+CHS006,WILMSLOW Probation Office,WILMSLOW Probation Office,COMM,N
+LDM023,208 Lewisham High Street,208 Lewisham High Street,COMM,Y
+727642,NORTHAMPTONSHIRE OFFICES,NORTHAMPTONSHIRE OFFICES,COMM,N
+MRS056,St Helens DIP,St Helens DIP,COMM,Y
+MLW018,Centenary House Probation Centre,Centenary House Probation Centre,COMM,Y
+701109,Wallsend Probation Office,Wallsend Probation Office,COMM,N
+YSS013,"Law Courts, Doncaster","Law Courts, Doncaster",COMM,Y
+LDM032,Katherine Price Hughes,Katherine Price Hughes,COMM,Y
+NBR024,Wallsend Probation Office,Wallsend Probation Office,COMM,Y
+ASPY04,Street YOT,Street YOT,COMM,Y
+MLW028,Birmingham CC Liaison Unit,Birmingham CC Liaison Unit,COMM,Y
+MCG041,Oldham Mags Court Probation Office,Oldham Mags Court Probation Office,COMM,Y
+NBR029,Berwick Probation Office,Berwick Probation Office,COMM,Y
+CMB004,KENDAL COMMUNITY SERVICE Office,KENDAL COMMUNITY SERVICE Office,COMM,Y
+YSS005,"West Bar, Sheffield","West Bar, Sheffield",COMM,Y
+YSW013,Pontefract Probation Office,Pontefract Probation Office,COMM,Y
+NETOWN,"Newtown Hospital, Worcester","Newtown Hospital, Worcester",HSHOSP,Y
+LCSY03,Blackpool YOT,Blackpool YOT,YOT,Y
+THA018,Oxford Bail Hostel,Oxford Bail Hostel,APPR,Y
+CHURCH,Whitchurch Hospital,Whitchurch Hospital,HSHOSP,Y
+LDM149,Richmond Mags Crt Probation Office,Richmond Mags Crt Probation Office,COMM,Y
+MLW041,Smethwick Police Station,Smethwick Police Station,COMM,Y
+MCG027,Ashton-under-Lyne Probation Office,Ashton-under-Lyne Probation Office,COMM,Y
+YSS020,"Main St, Rotherham","Main St, Rotherham",COMM,Y
+BEDY02,Ashburnham Road Youth Offending Service,Ashburnham Road Youth Offending Service,YOT,Y
+WSNY01,Mold YOT,Mold YOT,YOT,Y
+LDM067,Mitre House Probation Office,Mitre House,COMM,Y
+MLW031,West Bromwich Probation Office,West Bromwich Probation Office,COMM,Y
+LINCCT,Lincoln County Court,Lincoln County Court,CRT,Y
+LVRPCT,Liverpool County Court,Liverpool Civil and Family Court,CRT,Y
+LLNLCT,Llanelli County Court,Llanelli County Court,CRT,Y
+LLNGCT,Llangefni County Court,Llangefni County Court,CRT,Y
+LWSTCT,Lowestoft County Court,Lowestoft County Court,CRT,Y
+LUDLCT,Ludlow County Court,Ludlow County Court,CRT,Y
+LUTNCT,Luton County Court,Luton County Court,CRT,Y
+MCCLCT,Macclesfield County Court,Macclesfield County Court,CRT,Y
+MNCHCT,Manchester County Court,Manchester County Court,CRT,Y
+MNSFCT,Mansfield County Court,Mansfield County Court,CRT,Y
+MDWYCT,Medway County Court,Medway County Court,CRT,Y
+MLTNCT,Melton Mowbray County Court,Melton Mowbray County Court,CRT,Y
+MRTHCT,Merthyr Tydfil County Court,Merthyr Tydfil County Court,CRT,Y
+MDDLCT,Middlesbrough County Court,Middlesbrough County Court,CRT,Y
+MDSTCT,Maidstone County Court,Maidstone County Court,CRT,Y
+MLTKCT,Milton Keynes County Court,Milton Keynes County Court,CRT,Y
+MOLDCT,Mold County Court,Mold County Court,CRT,Y
+MRPTCT,Morpeth and Berwick County Court,Morpeth and Berwick County Court,CRT,Y
+NEATCT,Neath and Port Talbot County Court,Neath and Port Talbot County Court,CRT,Y
+IOWICC,Newport (I.O.W.) Crown Court,Newport (I.O.W.) Crown Court,CRT,Y
+NRTHCC,Northampton Crown Court,Northampton Crown Court,CRT,Y
+NORWCC,Norwich Crown Court,Norwich Crown Court,CRT,Y
+NOTTCC,Nottingham Crown Court,Nottingham Crown Court,CRT,Y
+OXFDCC,Oxford Crown Court,Oxford Crown Court,CRT,Y
+PBORCC,Peterborough Crown Court,Peterborough Crown Court,CRT,Y
+PLYMCC,Plymouth Crown Court,Plymouth Crown Court,CRT,Y
+PRTSCC,Portsmouth Crown Court,Portsmouth Crown Court,CRT,Y
+PRESCC,Preston Crown Court,Preston Crown Court,CRT,Y
+READCC,Reading Crown Court,Reading Crown Court,CRT,Y
+SALSCC,Salisbury Crown Court,Salisbury Crown Court,CRT,Y
+SHEFCC,Sheffield Crown Court,Sheffield Crown Court,CRT,Y
+SHRWCC,Shrewsbury Crown Court,Shrewsbury Crown Court,CRT,Y
+SNARCC,Snaresbrook Crown Court,Snaresbrook Crown Court,CRT,Y
+SOUTCC,Southampton Crown Court,Southampton Crown Court,CRT,Y
+218434,Havant Probation Office,Havant Probation Office,COMM,Y
+282160,Farnborough Probation Office,Farnborough Probation Office,COMM,N
+648804,Fareham Probation Office,Fareham Probation Office,COMM,Y
+495531,Andover Probation Office,Andover Probation Office,COMM,N
+670812,Aldershot Probation Office,Aldershot Probation Office,COMM,N
+SWS001,South Wales Probation Head Office,South Wales Probation Head Office,COMM,Y
+613487,Basingstoke Probation Office,Basingstoke Probation Office,COMM,N
+456740,Southampton Probation Office,Southampton Probation Office,COMM,Y
+GWT003,CWMBRAN Accredited Programmes Centre,CWMBRAN Accredited Programmes Centre,COMM,Y
+LDM129,Hendon Mags Court Probation Office,Hendon Mags Court Probation Office,COMM,Y
+508946,Hereford Probation Centre,Hereford Probation Centre,COMM,N
+THA038,Aylesbury Probation Office,Aylesbury Probation Office,COMM,Y
+DCP013,West Cornwall Prolific Offender Unit,West Cornwall Prolific Offender Unit,COMM,Y
+NBRY06,Wearside YOT,Wearside YOT,YOT,Y
+LTS006,Leics Probation Ctr – Cobden Street,Leicester Probation Centre - Cobden Street,COMM,Y
+PRNCSM,Princess Marina Hospital,Princess Marina Hospital,HSHOSP,Y
+ASP017,Staple Hill Police St. Prolific Off Unit,Staple Hill Police Station Prolific Offender Unit,COMM,Y
+CHS004,Runcorn Probation Office,Runcorn Probation Office,COMM,Y
+NBR014,Newcastle City Probation Centre,Newcastle City Probation Centre,COMM,Y
+673866,Redditch Probation Centre,Redditch Probation Centre,COMM,N
+LDM176,Harrow Police Station,Harrow Police Station,COMM,Y
+KNT005,Medway Probation Office,Medway Probation Office,COMM,Y
+LDM030,Harpenden House,Harpenden House,COMM,Y
+398396,Hertfordshire Head Office,Hertfordshire Head Office,COMM,N
+NHS018,Nottingham Aftercare/ Inreach Team,Nottingham Aftercare/ Inreach Team,COMM,Y
+SUTONS,Suttons Manor,Suttons Manor,HSHOSP,Y
+321117,St Albans Crown Court Probation Office,St Albans Crown Court Probation Office,COMM,N
+DRS011,Community Alcohol Team,Community Alcohol Team,COMM,Y
+CMB003,CARLISLE Probation Office,CARLISLE Probation Office,COMM,Y
+DRS007,Poole CRC,Poole CRC,COMM,Y
+NFK004,King's Lynn Probation Office,King's Lynn Probation Office,COMM,Y
+HPSY06,Wessex YOT ISSP,Wessex YOT ISSP,YOT,Y
+WRXHAM,Wrexham Maelor,Wrexham Maelor,HSHOSP,Y
+DCPY02,Plymouth YOT,Plymouth YOT,YOT,Y
+WTS005,Swindon Probation,Swindon Probation,COMM,Y
+WCHHOS,West Cheshire Hospital,West Cheshire Hospital,HSHOSP,Y
+NHS010,Nottingham City Prob. Office Derby Rd,Nottingham City Probation Office Derby Rd,COMM,Y
+GWT008,NEWPORT DRT Unit,NEWPORT DRT Unit,COMM,Y
+LDM136,Lordship Lane,Lordship Lane,COMM,Y
+MLW017,Halesowen Probation Centre,Halesowen Probation Centre,COMM,Y
+691966,Folkestone Probation Unit,Folkestone Probation Unit,COMM,N
+PKWOOD,"Parkwood Unit, Blackpool Victoria Hosp","Parkwood Unit, Blackpool Victoria Hosp",HSHOSP,Y
+CAHILL,Cane Hill Forensic Mental Health Unit,Cane Hill Forensic Mental Health Unit,HSHOSP,Y
+MCG047,Tameside Magistrates Court Probation Off,Tameside Magistrates Court Probation Off,COMM,Y
+672024,Maidstone Probation Unit,Maidstone Probation Unit,COMM,N
+325320,Gravesend Probation Unit,Gravesend Probation Unit,COMM,N
+321982,Thanet Probation Unit,Thanet Probation Unit,COMM,N
+724648,Sheerness Probation Office,Sheerness Probation Office,COMM,N
+HPS033,Winchester Combined Courts Centre (Prob),Winchester Combined Courts Centre (Probation),COMM,Y
+714662,Sittingbourne Probation Office,Sittingbourne Probation Office,COMM,N
+360920,Dover Probation Unit,Dover Probation Unit,COMM,N
+ASP021,Yeovil Police Station Prolific Off Unit,Yeovil Police Station Prolific Offender Unit,COMM,Y
+NHS013,Nottingham Prolific Offender Unit,Nottingham Prolific Offender Unit Police HQ,COMM,Y
+MCG033,Greater Manchester Head Office,Greater Manchester Head Office,COMM,Y
+267869,Ashford Probation Unit,Ashford Probation Unit,COMM,N
+327732,Kent Head Office,Kent Head Office,COMM,N
+LDM141,Hillingdon Probation,Hillingdon Probation,COMM,Y
+GCS008,Coleford MC Liaison Unit,Coleford MC Liaison Unit,COMM,Y
+LDM101,Sutton Probation Office,Sutton,COMM,Y
+721844,NELSON Probation Office,NELSON Probation Office,COMM,N
+AYLSCT,Aylesbury County Court,Aylesbury County Court,CRT,Y
+BNBRCT,Banbury County Court,Banbury County Court,CRT,N
+BRNTCT,Barnet County Court,Barnet County Court,CRT,Y
+BRNSCT,Barnsley County Court,Barnsley County Court,CRT,Y
+BNSTCT,Barnstaple County Court,Barnstaple County Court,CRT,Y
+BRRWCT,Barrow-in-Furness County Court,Barrow-in-Furness County Court,CRT,Y
+BSLDCT,Basildon County Court,Basildon County Court,CRT,Y
+BSNGCT,Basingstoke County Court,Basingstoke County Court,CRT,Y
+BATHCT,Bath County Court,Bath County Court,CRT,Y
+BDFRCT,Bedford County Court,Bedford County Court,CRT,Y
+BRKNCT,Birkenhead County Court,Birkenhead County Court,CRT,Y
+BRMNCT,Birmingham Civil Justice Centre,Birmingham Civil Justice Centre,CRT,Y
+BISHCT,Bishop Auckland,Bishop Auckland,CRT,Y
+BLKBCT,Blackburn County Court,Blackburn County Court,CRT,Y
+BLKPCT,Blackpool County Court,Blackpool County Court,CRT,Y
+BLKWCT,Blackwood County Court,Blackwood County Court,CRT,Y
+BODMCT,Bodmin County Court,Bodmin County Court,CRT,Y
+BOLTCT,Bolton County Court,Bolton County Court,CRT,Y
+BOSTCT,Boston County Court,Boston County Court,CRT,Y
+BRNMCT,Bournemouth County Court,Bournemouth County Court,CRT,Y
+BOWCT,Bow County Court,Bow County Court,CRT,Y
+BRADCT,Bradford County Court,Bradford County Court,CRT,Y
+BRCKCT,Brecknock County Court,Brecknock County Court,CRT,Y
+BRTFCT,Brentford County Court,Brentford County Court,CRT,Y
+BRIDCT,Bridgend County Court,Bridgend County Court,CRT,Y
+BRGHCT,Brighton County Court,Brighton County Court,CRT,Y
+BRSTCT,Bristol County Court,Bristol County Court,CRT,Y
+BRMLCT,Bromley County Court,Bromley County Court,CRT,Y
+BURNCT,Burnley County Court,Burnley County Court,CRT,Y
+BRTNCT,Burton-upon-Trent County Court,Burton-upon-Trent County Court,CRT,Y
+BURYCT,Bury County Court,Bury County Court,CRT,Y
+BRSECT,Bury St. Edmunds County Court,Bury St. Edmunds County Court,CRT,Y
+BUXTCT,Buxton County Court,Buxton County Court,CRT,Y
+CRNRCT,Caernarfon County Court,Caernarfon County Court,CRT,Y
+CAMBCT,Cambridge County Court,Cambridge County Court,CRT,Y
+CANTCT,Canterbury County Court,Canterbury County Court,CRT,Y
+CRDFCT,Cardiff County Court,Cardiff County Court,CRT,Y
+CARLCT,Carlisle County Court,Carlisle County Court,CRT,Y
+CARMCT,Carmarthen County Court,Carmarthen County Court,CRT,Y
+LONDCT,Central London County Court,Central London County Court,CRT,Y
+CHLMCT,Chelmsford County Court,Chelmsford County Court,CRT,Y
+CHELCT,Cheltenham County Court,Cheltenham County Court,CRT,Y
+CHESCT,Chester County Court,Chester County Court,CRT,Y
+CHSTCT,Chesterfield County Court,Chesterfield County Court,CRT,Y
+CHCHCT,Chichester County Court,Chichester County Court,CRT,Y
+CHRLCT,Chorley County Court,Chorley County Court,CRT,Y
+CLRKCT,Clerkenwell County Court,Clerkenwell County Court,CRT,Y
+CLCHCT,Colchester County Court,Colchester County Court,CRT,Y
+CNSTCT,Consett County Court,Consett County Court,CRT,Y
+CNWYCT,Conwy and Colwyn County Court,Conwy and Colwyn County Court,CRT,Y
+CVNTCT,Coventry County Court,Coventry County Court,CRT,Y
+CREWCT,Crewe County Court,Crewe County Court,CRT,Y
+CRYDCT,Croydon County Court,Croydon County Court,CRT,Y
+DARLCT,Darlington County Court,Darlington County Court,CRT,Y
+DRTFCT,Dartford County Court,Dartford County Court,CRT,Y
+DRBYCT,Derby County Court,Derby County Court,CRT,Y
+DEWSCT,Dewsbury County Court,Dewsbury County Court,CRT,Y
+DONCCT,Doncaster County Court,Doncaster County Court,CRT,Y
+DUDLCT,Dudley County Court,Dudley County Court,CRT,Y
+DURHCT,Durham County Court,Durham County Court,CRT,Y
+EASBCT,Eastbourne County Court,Eastbourne County Court,CRT,Y
+EDMNCT,Edmonton County Court,Edmonton County Court,CRT,Y
+EPSMCT,Epsom County Court,Epsom County Court,CRT,Y
+EVSHCT,Evesham County Court,Evesham County Court,CRT,Y
+EXETCT,Exeter County Court,Exeter County Court,CRT,Y
+GTSHCT,Gateshead County Court,Gateshead County Court,CRT,Y
+GLOCCT,Gloucester County Court,Gloucester County Court,CRT,Y
+GRNTCT,Grantham County Court,Grantham County Court,CRT,Y
+GRVSCT,Gravesend County Court,Gravesend County Court,CRT,Y
+GRIMCT,Great Grimsby County Court,Great Grimsby County Court,CRT,Y
+GLDFCT,Guildford County Court,Guildford County Court,CRT,Y
+HLFXCT,Halifax County Court,Halifax County Court,CRT,Y
+HRLWCT,Harlow County Court,Harlow County Court,CRT,Y
+HRRGCT,Harrogate County Court,Harrogate County Court,CRT,Y
+HRTLCT,Hartlepool County Court,Hartlepool County Court,CRT,Y
+HSTNCT,Hastings County Court,Hastings County Court,CRT,Y
+HVRFCT,Haverfordwest County Court,Haverfordwest County Court,CRT,Y
+HYWHCT,Haywards Heath County Court,Haywards Heath County Court,CRT,Y
+HRFRCT,Hereford County Court,Hereford County Court,CRT,Y
+HERTCT,Hertford County Court,Hertford County Court,CRT,Y
+HWYCCT,High Wycombe County Court,High Wycombe County Court,CRT,Y
+HTCHCT,Hitchin County Court,Hitchin County Court,CRT,Y
+HRSHCT,Horsham County Court,Horsham County Court,CRT,Y
+HUDRCT,Huddersfield County Court,Huddersfield County Court,CRT,Y
+HUNTCT,Huntingdon County Court,Huntingdon County Court,CRT,Y
+ILFDCT,Ilford County Court,Ilford County Court,CRT,Y
+IPSWCT,Ipswich County Court,Ipswich County Court,CRT,Y
+KGHLCT,Keighley County Court,Keighley County Court,CRT,Y
+KENDCT,Kendal County Court,Kendal County Court,CRT,Y
+KTTRCT,Kettering County Court,Kettering County Court,CRT,Y
+KDDRCT,Kidderminster County Court,Kidderminster County Court,CRT,Y
+KNGSCT,King's Lynn County Court,King's Lynn County Court,CRT,Y
+KNGHCT,Kingston-upon-Hull County Court,Kingston-upon-Hull County Court,CRT,Y
+KNGTCT,Kingston-upon-Thames County Court,Kingston-upon-Thames County Court,CRT,Y
+LMBTCT,Lambeth County Court,Lambeth County Court,CRT,Y
+LANCCT,Lancaster County Court,Lancaster County Court,CRT,Y
+LEEDCT,Leeds County Court,Leeds County Court,CRT,Y
+LEICCT,Leicester County Court,Leicester County Court,CRT,Y
+LEIGCT,Leigh County Court,Leigh County Court,CRT,Y
+LEWSCT,Lewes County Court,Lewes County Court,CRT,Y
+BOWSMC,Bow Street MC,Bow Street Magistrates' Court,CRT,Y
+BRDWMC,Bridgwater MC,Bridgwater Magistrates' Court,CRT,Y
+CAERMC,Caerphilly MC,Caerphilly Magistrates' Court,CRT,Y
+CANTMC,Canterbury MC,Canterbury Magistrates' Court,CRT,Y
+CARMMC,Carmarthen MC,Carmarthen Magistrates' Court,CRT,Y
+CASTMC,Castleford MC,Castleford Magistrates' Court,CRT,Y
+CHLMMC,Chelmsford MC,Chelmsford Magistrates' Court,CRT,Y
+CHELMC,Cheltenham MC,Cheltenham Magistrates' Court,CRT,Y
+CHCHMC,Chichester MC,Chichester Magistrates' Court,CRT,Y
+CULLMC,Cullompton MC,Cullompton Magistrates' Court,CRT,Y
+DARLMC,Darlington MC,Darlington Magistrates' Court,CRT,Y
+DORCMC,Dorchester MC,Dorchester Magistrates' Court,CRT,N
+EASBMC,Eastbourne MC,Eastbourne Magistrates' Court,CRT,Y
+FLKSMC,Folkestone MC,Folkestone Magistrates' Court,CRT,Y
+GLOCMC,Gloucester MC,Gloucester Magistrates' Court,CRT,Y
+HRTLMC,Hartlepool MC,Hartlepool Magistrates' Court,CRT,Y
+HRNCMC,Horncastle MC,Horncastle Magistrates' Court,CRT,N
+HUNTMC,Huntingdon MC,Huntingdon Magistrates' Court,CRT,Y
+LAUNMC,Launceston MC,Launceston Magistrates' Court,CRT,Y
+LLNDMC,Llandovery MC,Llandovery Magistrates' Court,CRT,N
+MDNHMC,East Berkshire MC Maidenhead Court House,East Berkshire MC Maidenhead Court House,CRT,N
+MNCHMC,Manchester MC,Manchester Magistrates' Court,CRT,Y
+MILDMC,Mildenhall MC,Mildenhall Magistrates' Court,CRT,Y
+OKHEMC,Okehampton MC,Okehampton Magistrates' Court,CRT,Y
+PONTMC,Pontefract MC,Pontefract Magistrates' Court,CRT,Y
+PRTSMC,Portsmouth MC,Portsmouth Magistrates' Court,CRT,Y
+ROSSMC,Rossendale MC,Rossendale Magistrates' Court,CRT,Y
+SCUNMC,Scunthorpe MC,Scunthorpe Magistrates' Court,CRT,Y
+SHREMC,Shrewsbury MC,Shrewsbury Magistrates' Court,CRT,Y
+SUNDMC,Sunderland MC,Sunderland Magistrates' Court,CRT,Y
+TEWKMC,Tewkesbury MC,Tewkesbury Magistrates' Court,CRT,N
+TRWBMC,Trowbridge MC,Trowbridge Magistrates' Court,CRT,N
+WHTCMC,Whitchurch MC,Whitchurch Magistrates' Court,CRT,N
+WHTHMC,Whitehaven MC,Whitehaven Magistrates' Court,CRT,Y
+WRKTMC,West Allerdale and Keswick Mag. Court,West Allerdale and Keswick Magistrates Court,CRT,N
+ABGVMC,Abergavenny MC,Abergavenny Magistrates' Court,CRT,Y
+ABTYMC,Abertillery MC,Abertillery Magistrates' Court,CRT,Y
+ABRYMC,Aberystwyth MC,Aberystwyth Magistrates' Court,CRT,Y
+BSNGMC,Basingstoke MC,Basingstoke Magistrates' Court,CRT,Y
+BRNMMC,Bournemouth MC,Bournemouth Magistrates' Court,CRT,Y
+BRDLMC,Bridlington MC,Bridlington Magistrates' Court,CRT,Y
+CIRNMC,Cirencester MC,Cirencester Magistrates' Court,CRT,Y
+GSBRMC,Guisborough MC,Guisborough Magistrates' Court,CRT,Y
+KNGSMC,West Norfolk Magistrates Court,West Norfolk Magistrates Court,CRT,N
+LLNTMC,Llantrisant MC,Llantrisant Magistrates' Court,CRT,Y
+LNGSMC,Long Sutton MC,Long Sutton Magistrates' Court,CRT,N
+MCHYMC,Machynlleth MC,Machynlleth Magistrates' Court,CRT,N
+NRTHMC,Northampton MC,Northampton Magistrates' Court,CRT,Y
+PRTTMC,Port Talbot Magistrates Court,Port Talbot Magistrates Court,CRT,Y
+STOUMC,Stourbridge MC,Stourbridge Magistrates' Court,CRT,N
+WLONMC,Hammersmith MC,Hammersmith Magistrates Court,CRT,Y
+FLAXMC,Flax Bourton MC,Flax Bourton Magistrates' Court,CRT,N
+GNSBMC,Gainsborough MC,Gainsborough Magistrates' Court,CRT,Y
+HUDRMC,Huddersfield MC,Huddersfield Magistrates' Court,CRT,Y
+LGHBMC,Loughborough MC,Loughborough Magistrates' Court,CRT,Y
+NWTAMC,Newton Abbot MC,Newton Abbot Magistrates' Court,CRT,Y
+PBORMC,Peterborough MC,Peterborough Magistrates' Court,CRT,Y
+TWRBMC,Tower Bridge MC,Tower Bridge Magistrates' Court,CRT,Y
+HVRFMC,Haverfordwest MC,Haverfordwest Magistrates' Court,CRT,Y
+MDDLMC,Middlesbrough MC,Middlesbrough Magistrates' Court,CRT,Y
+MLTKMC,Milton Keynes MC,Milton Keynes Magistrates' Court,CRT,Y
+NRTSMC,North Shields Magistrates Court,North Shields Magistrates Court,CRT,Y
+NORAMC,Northallerton MC,Northallerton Magistrates' Court,CRT,Y
+SITTMC,Sittingbourne MC,Sittingbourne Magistrates' Court,CRT,Y
+WBRMMC,West Bromwich MC,West Bromwich Magistrates' Court,CRT,Y
+WLVRMC,Wolverhampton MC,Wolverhampton Magistrates' Court,CRT,Y
+YSTRMC,Ystradgynlais MC,Ystradgynlais Magistrates' Court,CRT,Y
+CITYMC,City of London (Queen Victoria St) MC,City of London (Queen Victoria Street) Magistrates' Court,CRT,Y
+GRTYMC,Great Yarmouth MC,Great Yarmouth Magistrates' Court,CRT,Y
+HYWHMC,Haywards Heath MC,Haywards Heath Magistrates' Court,CRT,Y
+KIDDMC,Kidderminster (Comberton Place) MC,Kidderminster  Magistrates' Court,CRT,Y
+LEAMMC,Leamington Spa MC,Leamington Spa Magistrates' Court,CRT,N
+MRKDMC,Market Drayton MC,Market Drayton Magistrate Crt,CRT,Y
+MLTNMC,"Melton, Belvoir and Rutland MC","Melton Mowbray, Belvoir and Rutland Magistrates Court",CRT,Y
+MRTHMC,Merthyr Tydfil MC,Merthyr Tydfil Magistrate Crt,CRT,Y
+STOKMC,North Staffordshire MC - Fenton,North Staffordshire Magistrates Court - Fenton,CRT,Y
+WLTFMC,Waltham Forest MC,Waltham Forest Magistrates' Court,CRT,Y
+WELBMC,Wellingborough MC,Wellingborough Magistrates' Court,CRT,Y
+BISHMC,Bishop Auckland MC,Bishop Auckland Magistrates' Court,CRT,Y
+BRSEMC,Bury St Edmunds MC,Bury St Edmunds Magistrates' Court,CRT,Y
+HMLHMC,Hemel Hempstead MC,Hemel Hempstead Magistrates' Court,CRT,Y
+HGHBMC,Highbury Corner MC,Highbury Corner Magistrates' Court,CRT,N
+HRSFMC,Horseferry Road MC,Horseferry Rd Magistrates Crt,CRT,Y
+SCILMC,Isles of Scilly MC,Isles of Scilly Magistrates' Court,CRT,Y
+NWAYMC,Newton Aycliffe MC,Newton Aycliffe Magistrates' Court,CRT,Y
+STHSMC,Southend on Sea MC,Southend on Sea Magistrates' Court,CRT,Y
+CMBGMC,Camberwell Green MC,Camberwell Green Magistrates' Court,CRT,N
+STTCMC,Sutton Coldfield MC,Sutton Coldfield Magistrates' Court,CRT,N
+BRRWMC,Furness and District Magistrates Court,Furness and District Magistrates Court,CRT,N
+BURTMC,SE Staffs MC - Burton,South East Staffordshire Magistrates Court - Burton,CRT,Y
+CHSLMC,Chester le Street MC,Chester le Street Magistrates' Court,CRT,N
+LLNWMC,Llandrindod Wells MC,Llandrindod Wells Magistrates' Court,CRT,Y
+MRKTMC,Market Harborough MC,Market Harborough Magistrates' Court,CRT,Y
+WSPMMC,Weston Super Mare MC,Weston Super Mare Magistrates' Court,CRT,N
+BRWKMC,Berwick upon Tweed MC,Berwick upon Tweed Magistrates' Court,CRT,Y
+HOGHMC,Houghton le Spring MC,Houghton le Spring Magistrates' Court,CRT,Y
+KNGHMC,Kingston-upon-Hull Magistrates Court,Kingston-upon-Hull Magistrates Court,CRT,Y
+WLSAMC,Walsall (Aldridge) MC,Walsall Magistrates' Court,CRT,Y
+BNBBMC,Banbury (Bridge Street) MC,Banbury (Bridge Street) Magistrates' Court,CRT,N
+LVRDMC,Liverpool Magistrates Court,Liverpool Magistrates' Court,CRT,Y
+NWCSMC,Newcastle-Upon-Tyne MC,Newcastle-Upon-Tyne Magistrates' Court,CRT,N
+STRFMC,Stratford upon Avon MC,Stratford upon Avon Magistrates' Court,CRT,N
+KNGTMC,Kingston upon Thames MC,Kingston upon Thames Magistrates' Court,CRT,N
+NWCLMC,SE Staffs MC - Burton,North Staffs MC - Newcastle,CRT,Y
+RCHTMC,Richmond upon Thames MC,Richmond upon Thames Magistrates' Court,CRT,Y
+BARKMC,Barking (East Street) MC,Barking (East Street) Magistrates' Court,CRT,Y
+BROMMC,Bromley (London Road) MC,Bromley (London Road) Magistrates' Court,CRT,Y
+COLCMC,"Colchester (County Court, South Way)","Colchester (County Court, South Way)",CRT,N
+ILCFMC,ILCFPC (Wells Street) MC,ILCFPC Wells Street (Inner London Family Proceedings Court),CRT,Y
+NWPPMC,Newport (Pentonville) MC,Newport Magistrates' Court,CRT,N
+SWNGMC,Swansea (Grove Place) MC,Swansea (Grove Place) Magistrates' Court,CRT,Y
+WRCSMC,Worcester (Castle St) MC,Worcester (Castle St) Magistrates' Court,CRT,Y
+BRGJMC,Brighton (John Street) MC,Brighton (John Street) Magistrates' Court,CRT,N
+COLTMC,Colchester (Town Hall) MC,Colchester (Town Hall) Magistrates' Court,CRT,N
+DRBYMC,Derby (St Mary's Gate) MC,Derby Magistrates' Court,CRT,Y
+HERFMC,Hereford (Bath Street) MC,Hereford Magistrates' Court,CRT,Y
+NWPCMC,Newport (South Wales) Mag Court,Newport (South Wales) Mag Court,CRT,N
+SCBNMC,Scarborough (Northway) MC,Scarborough (Northway) Magistrates' Court,CRT,N
+STHBMC,South Western (Balham) MC,South Western (Balham) Magistrates' Court,CRT,Y
+MACCMC,Macclesfield (Hibel Rd) MC,Macclesfield Magistrates Court,CRT,Y
+MNSFMC,Mansfield (Rosemary St) MC,Mansfield Magistrates' Court,CRT,Y
+SWNDMC,Swansea (Dynevor Place) MC,Swansea (Dynevor Place) Magistrates' Court,CRT,N
+BRGEMC,Brighton Magistrates Court (Edward St),Brighton Magistrates Court (Edward St),CRT,Y
+CRNHMC,Caernarfon Magistrates Court,Caernarfon Magistrates Court,CRT,Y
+CHPPMC,Chippenham (Pewsham Way) MC,Chippenham Magistrates' Court,CRT,Y
+PNTCMC,Pontypridd (Court House) MC,Pontypridd Magistrates' Court,CRT,Y
+STHMMC,South Shields (Millbank) MC,South Shields (Millbank) Magistrates' Court,CRT,Y
+SOUTMC,Southampton (WH) Magistrates Court,Southampton Magistrates' Court,CRT,Y
+LVRHMC,Liverpool (Hatton Garden) MC,Liverpool Magistrates' Court,CRT,N
+PNTUMC,Pontypridd (Union Street) MC,Pontypridd Magistrates' Court,CRT,N
+WLSSMC,Walsall (Stafford Street) MC,Walsall Magistrates' Court,CRT,Y
+CHSTMC,Chesterfield (Tapton Lane) MC,North East Derbyshire & Dales Magistrates' Court,CRT,Y
+NOTTMC,Nottingham (Carrington St) MC,Nottingham Magistrates' Court,CRT,Y
+WARRMC,Warrington Magistrates Court,Warrington Magistrates Court,CRT,Y
+BRMCMC,Birmingham (Corporation St) MC,Birmingham (Corporation St) Magistrates' Court,CRT,Y
+ASHTMC,Tameside MC,Tameside Magistrate Court,CRT,Y
+BRMSMC,Birmingham (Steelehouse Lane) MC,Birmingham (Steelhouse Lane) Magistrates' Court,CRT,N
+STHLMC,Lavender Hill MC,Lavender Hill Magistrates Court,CRT,Y
+BNBCMC,Banbury (County Court Parsons Street) MC,"Banbury (County Court, Parson's Street) Magistrates' Court",CRT,N
+LVRCMC,Liverpool (Crown & Jerome Bldgs) MC,Liverpool Magistrates' Court,CRT,N
+MRYLMC,Marylebone (185 Marylebone Rd) MC,Marylebone Magistrates' Court,CRT,Y
+BARNMC,Barking (North Street) MC,Barking (North Street) Magistrates' Court,CRT,N
+BRMWMC,Birmingham (Newton Street) MC,Birmingham (Newton Street) Magistrates' Court,CRT,N
+BRDGMC,Bridgnorth MC,Bridgnorth Magistrates' Court,CRT,N
+CHSBMC,Chesterfield (Brimington Rd) MC,Chesterfield (Brimington Rd) Magistrates' Court,CRT,N
+CHSWMC,Chesterfield (West Bars) MC,Chesterfield (West Bars) Magistrates' Court,CRT,N
+DRBBMC,Derby (Bold Lane) MC,Derby (Bold Lane) Magistrates' Court,CRT,N
+DRBDMC,Derby (Derwent St) MC,Derby (Derwent Street) Magistrates' Court,CRT,N
+DRBSMC,Derby (Swadlincote) MC,Derby (Swadlincote) Magistrates' Court,CRT,N
+CAISMC,Caistor MC,Caistor Magistrates' Court,CRT,N
+COLSMC,Colchester (Stanwell House) MC,Colchester (Stanwell House) Magistrates' Court,CRT,N
+AYLSCC,Aylesbury Crown Court,Aylesbury Crown Court,CRT,Y
+BNSTCC,Barnstaple Crown Court,Barnstaple Crown Court,CRT,Y
+BRRWCC,Barrow-in-Furness Crown Court,Barrow-in-Furness Crown Court,CRT,Y
+BSLDCC,Basildon Crown Court,Basildon Crown Court,CRT,Y
+BRMNCC,Birmingham Crown Court,Birmingham Crown Court,CRT,Y
+BLCKCC,Blackfriars Crown Court,Blackfriars Crown Court,CRT,N
+BOLTCC,Bolton Crown Court,Bolton Crown Court,CRT,Y
+BRNMCC,Bournemouth Crown Court,Bournemouth Crown Court,CRT,Y
+BRADCC,Bradford Crown Court,Bradford Crown Court,CRT,Y
+BRSTCC,Bristol Crown Court,Bristol Crown Court,CRT,Y
+BURNCC,Burnley Crown Court,Burnley Crown Court,CRT,Y
+BRSECC,Bury St. Edmunds Crown Court,Bury St. Edmunds Crown Court,CRT,Y
+CRNRCC,Caernarfon Crown Court,Caernarfon Crown Court,CRT,Y
+CAMBCC,Cambridge Crown Court,Cambridge Crown Court,CRT,Y
+CANTCC,Canterbury Crown Court,Canterbury Crown Court,CRT,Y
+CRDFCC,Cardiff Crown Court,Cardiff Crown Court,CRT,Y
+CARLCC,Carlisle Crown Court,Carlisle Crown Court,CRT,Y
+CARMCC,Carmarthen Crown Court,Carmarthen Crown Court,CRT,Y
+CNTRCC,Central Criminal Court,Central Criminal Court,CRT,Y
+CHLMCC,Chelmsford Crown Court,Chelmsford Crown Court,CRT,Y
+CHESCC,Chester Crown Court,Chester Crown Court,CRT,Y
+CHCHCC,Chichester Crown Court,Chichester Crown Court,CRT,N
+CVNTCC,Coventry Crown Court,Coventry Crown Court,CRT,Y
+CRYDCC,Croydon Crown Court,Croydon Crown Court,CRT,Y
+DRBYCC,Derby Crown Court,Derby Crown Court,CRT,Y
+DOLGCC,Dolgellau Crown Court,Dolgellau Crown Court,CRT,Y
+DONCCC,Doncaster Crown Court,Doncaster Crown Court,CRT,Y
+DORCCC,Dorchester Crown Court,Dorchester Crown Court,CRT,Y
+DURHCC,Durham Crown Court,Durham Crown Court,CRT,Y
+EXETCC,Exeter Crown Court,Exeter Crown Court,CRT,Y
+GLOCCC,Gloucester Crown Court,Gloucester Crown Court,CRT,Y
+GRIMCC,Great Grimsby Crown Court,Great Grimsby Crown Court,CRT,Y
+GLDFCC,Guildford Crown Court,Guildford Crown Court,CRT,Y
+HRRWCC,Harrow Crown Court,Harrow Crown Court,CRT,Y
+HVRFCC,Haverfordwest Crown Court,Haverfordwest Crown Court,CRT,Y
+HERFCC,Hereford Crown Court,Hereford Crown Court,CRT,Y
+INNRCC,Inner London Sessions House Crown Court,Inner London Sessions House Crown Court,CRT,Y
+IPSWCC,Ipswich Crown Court,Ipswich Crown Court,CRT,Y
+ISLWCC,Isleworth Crown Court,Isleworth Crown Court,CRT,Y
+KNGSCC,King's Lynn Crown Court,King's Lynn Crown Court,CRT,Y
+KNGHCC,Kingston-upon-Hull Combined Court Centre,Kingston-upon-Hull,CRT,N
+KNGTCC,Kingston upon Thames Crown Court,Kingston upon Thames Crown Court,CRT,Y
+KNUTCC,Knutsford Crown Court,Knutsford Crown Court,CRT,Y
+LANCCC,Lancaster Crown Court,Lancaster Crown Court,CRT,Y
+LEEDCC,Leeds Crown Court,Leeds Crown Court,CRT,Y
+LEICCC,Leicester Crown Court,Leicester Crown Court,CRT,Y
+LEWSCC,Lewes Crown Court,Lewes Crown Court,CRT,Y
+LINCCC,Lincoln Crown Court,Lincoln Crown Court,CRT,Y
+LVRPCC,Liverpool Crown Court,Liverpool Crown Court,CRT,Y
+LUTNCC,Luton Crown Court,Luton Crown Court,CRT,Y
+MDSTCC,Maidstone Crown Court,Maidstone Crown Court,CRT,Y
+MNCCCC,Manchester Crown Court (Crown Square),Manchester Crown Court (Crown Square),CRT,Y
+MNCMCC,Manchester Crown Court (Minshull Street),Manchester Crown Court (Minshull Street),CRT,Y
+MRTHCC,Merthyr Tydfil Crown Court,Merthyr Tydfil Crown Court,CRT,Y
+MDDLCC,Middlesex Guildhall Crown Court,Middlesex Guildhall Crown Court,CRT,Y
+MOLDCC,Mold Crown Court,Mold Crown Court,CRT,Y
+NWCSCC,Newcastle Upon Tyne Crown Court Moothall,Newcastle Upon Tyne Crown Court Moothall,CRT,Y
+NWPRCC,Newport (South Wales) Crown Court,Newport (South Wales) Crown Court,CRT,Y
+THA048,Banbury Probation Office,Banbury Probation Office,COMM,Y
+YSN014,York Admin & Training,York Admin & Training,COMM,Y
+MCG065,Tameside DIP (CJIT),Tameside DIP (CJIT),COMM,Y
+NBR039,Gosforth Probation Office,Newcastle North Probation Office,COMM,Y
+NEWTON,Newton Lodge,Newton Lodge,HSHOSP,Y
+MLW024,Wolverhampton Probation Centre,Wolverhampton Probation Centre,COMM,Y
+LTSAP2,Kirk Lodge Approved Premises,Kirk Lodge Approved Premises,APPR,Y
+SWSY01,Cardiff YOT,Cardiff YOT,YOT,Y
+LDM094,Croydon Crown Court,Croydon Crown Court,COMM,Y
+NBRAP3,Ozanam House Probation Hostel,Ozanam House Probation Hostel,APPR,Y
+MRS011,Waterloo Office,Waterloo Office,COMM,Y
+LTSAP1,Howard House Approved Premises,Howard House Approved Premises,APPR,Y
+HPS003,Winchester Probation Office,Winchester Probation Office,COMM,Y
+MCG046,Stockport  Mags Court Probation Office,Stockport  Mags Court Probation Office,COMM,Y
+PRNCSW,Princess of Wales Hospital,Princess of Wales Hospital,HSHOSP,Y
+NMANCH,North Manchester General Hospital,North Manchester General Hospital,HSHOSP,Y
+MLWAP2,Carpenter House Approved Premises,Carpenter House Approved Premises,APPR,Y
+LAMBTH,Lambeth Health Care,Lambeth Health Care,HSHOSP,Y
+HBSY03,Scunthorpe YOT,Scunthorpe YOT,YOT,Y
+FARMFD,Farmfield Hospital,Farmfield Hospital,HSHOSP,Y
+ASP019,Taunton Police Station Prolific Off Unit,Taunton Police Station Prolific Offender Unit,COMM,Y
+DBS012,Buxton Probation Office,Buxton Probation Office,COMM,Y
+TALYGN,Talygarn Mental Health Unit,Talygarn Mental Health Unit,HSHOSP,Y
+654545,COLLEGE HOUSE,COLLEGE HOUSE,COMM,N
+679724,SWAN HOUSE,SWAN HOUSE,COMM,N
+410576,WHITE ROSE COURT,WHITE ROSE COURT,COMM,N
+KNTY04,Folkstone YOT,Folkstone YOT,YOT,Y
+LCS007,Blackpool Avroe Crescent,Blackpool Avroe Crescent,COMM,Y
+CMB007,Penrith Communty Service Office,Penrith Communty Service Office,COMM,Y
+754990,Littlehampton Probation Office,Littlehampton Probation Office,COMM,N
+656872,Hastings PUBLIC PROBATION TEAM,PUBLIC PROBATION TEAM,COMM,N
+317696,THE COURT HOUSE,THE COURT HOUSE,COMM,N
+519749,WORTHING PROBATION OFFICE,WORTHING PROBATION OFFICE,COMM,N
+502904,Crawley Probation Office,Crawley Probation Office,COMM,N
+588054,BRIGHTON Probation Office,BRIGHTON Probation Office,COMM,N
+488812,Eastbourne Probation Office,Eastbourne Probation Office,COMM,N
+577363,Sussex HEAD OFFICE,Sussex HEAD OFFICE,COMM,N
+311857,CHICHESTER Probation Office,CHICHESTER Probation Office,COMM,N
+MLLBRK,Millbrook Mental Health Unit,Millbrook Mental Health Unit,HSHOSP,Y
+BDS014,Healthlink,Healthlink,COMM,Y
+MLW016,Erdington Probation Centre,Erdington Probation Centre,COMM,Y
+MLWY04,Coventry YOT,Coventry Youth Offending Service,YOT,Y
+KNGSWY,Kingsway ICU,Kingsway ICU,HSHOSP,Y
+CYTWKE,Cygnet Hospital at Wyke,Cygnet Hospital at Wyke,HSHOSP,Y
+DELHPK,Delph Park Nursing Home,Delph Park Nursing Home,HSHOSP,Y
+MIDSTG,Middleton St George Hosp,Middleton St George Hosp,HSHOSP,Y
+NFK006,Thetford Probation Office,Thetford Probation Office,COMM,Y
+HNTMAD,Huntercombe Maidenhead Hospital,Huntercombe Maidenhead Hospital,HSHOSP,Y
+YSN011,York Crown Court Probation Office,York Crown Court Probation Office,COMM,Y
+MCG004,Bradshaw House Approved Premises,Bradshaw House Approved Premises,APPR,Y
+YSWVH1,Cardigan House,Cardigan House,APPR,Y
+761287,MAGISTRATES COURT,Sutton Coldfield Magistrates' Court Probation Office,COMM,N
+HFS004,South & West Herts Probation Centre,South & West Herts Probation Centre,COMM,Y
+STF013,Stafford Interventions Unit,Stafford Interventions Unit,COMM,Y
+HPS036,Barclays House Unit,Barclays House Unit,COMM,Y
+STCADS,St Cadoc's,St Cadoc's,HSHOSP,Y
+LDM123,Feltham Probation Office,Feltham Probation Office,COMM,Y
+MLW021,Smethwick Probation Centre,Smethwick Probation Centre,COMM,Y
+MLWY13,Highgate Deritend YOT,Highgate Deritend YOT,YOT,Y
+YSS028,Town Moor Bail Hostel,Town Moor Bail Hostel,APPR,Y
+LDM059,Hestia Streatham,Hestia Streatham,COMM,Y
+507626,Wolverhampton Probation Centre,Wolverhampton Probation Centre,COMM,N
+LNS015,Lincolnshire MAPPP,Lincolnshire MAPPP,COMM,Y
+796120,Erdington Probation Centre,Erdington Probation Centre,COMM,N
+HERGST,Hergest Psychiatric Unit,Hergest Psychiatric Unit,HSHOSP,Y
+KEMPLE,"Kemple View Psychiatric Serv., Blackburn","Kemple View Psychiatric Services, Blackburn",HSHOSP,Y
+HORTON,Horton Hospital,Horton Hospital,HSHOSP,Y
+LDM066,Great Peter Street,Great Peter Street,COMM,N
+778998,West Bromwich Probation Office,West Bromwich Probation Office,COMM,N
+KENETH,Kenneth Day Unit,Kenneth Day Unit,HSHOSP,Y
+LDM144,Wood Green Crown Court Probation Office,Wood Green Crown Court Probation Office,COMM,Y
+494537,Wiltshire Head Office,Wiltshire Head Office,COMM,N
+ASP009,Taunton Probation Centre,Taunton Probation Centre,COMM,Y
+562263,Salisbury Probation Centre,Salisbury Probation Centre,COMM,N
+DCPY04,Truro YOT,Truro YOT,YOT,Y
+605663,Swindon Probation Centre,Swindon Probation Centre,COMM,N
+358093,COURTS OF JUSTICE,COURTS OF JUSTICE,COMM,N
+YSN004,Southview Approved Premises,Southview Approved Premises,APPR,Y
+LTS009,Wigston Probation Office,Wigston Probation Office,COMM,Y
+DPP005,Llanelli Probation Office,Llanelli Probation Office,COMM,Y
+NFK010,Thetford Unpaid Work Unit,Thetford Unpaid Work Unit,COMM,Y
+389497,KINGSTON AND RICHMOND PROBATIO,KINGSTON AND RICHMOND PROBATION Service,COMM,N
+CAMLDG,Camlet Lodge Regional Secure Unit,Camlet Lodge Regional Secure Unit,HSHOSP,Y
+NBR007,Northumbria Training Centre,Northumbria Training Centre,COMM,Y
+KNT004,Canterbury Crown Court Probation Office,Canterbury Crown Court Probation Office,COMM,Y
+ASP023,Quadeast,Quadeast,COMM,Y
+CRCHIL,Churchill Clinic,Churchill Clinic,HSHOSP,Y
+MCG052,Wigan YOT,Wigan YOT,YOT,Y
+MCG057,Withington Road Approved Premises,Withington Road Approved Premises,APPR,Y
+781940,Croydon Probation Office,Croydon Probation Office,COMM,N
+MLWY14,Birmingham Youth Court,Birmingham Youth Court,YOT,Y
+STF008,Newcastle-under-Lyme Probation Centre,Newcastle-under-Lyme Probation Centre,COMM,Y
+NFK008,Norfolk DRR Team,Norfolk DRR Team,COMM,Y
+THA045,Milton Keynes - Stony Stratford Prob Off,Milton Keynes - Stony Stratford Prob Off,COMM,Y
+WDHVEN,Woodhaven Hospital,Woodhaven Hospital,HSHOSP,Y
+NBR004,Northumberland County Probation Office,Northumberland County Probation Office,COMM,Y
+KHT025,Tunbridge Wells Office,Tunbridge Wells Office,COMM,Y
+705109,Enfield Probation Office,Enfield Probation Office,COMM,N
+NHS008,Worksop Probation & CS Office,Worksop Probation & CS Office,COMM,Y
+QPARK,Queen's Park Hospital,Queen's Park Hospital,HSHOSP,Y
+513247,Tottenham Probation Office,Tottenham Probation Office,COMM,N
+YSW003,Bradford City Courts Probation Office,Bradford City Courts Probation Office,COMM,Y
+LCS004,Blackburn Probation Centre,Blackburn Probation Centre,COMM,Y
+542705,Hounslow Probation Office,Hounslow Probation Office,COMM,N
+WEXHAM,Wexham Park Hospital,Wexham Park Hospital,HSHOSP,Y
+355242,Hendon Probation Office,Hendon Probation Office,COMM,N
+221707,HARROW PROBATION OFFICE,HARROW PROBATION OFFICE,COMM,N
+KNT014,Sittingbourne Probation Office,Sittingbourne Probation Office,COMM,N
+629111,WILLESDEN PROBATION OFFICE,WILLESDEN PROBATION OFFICE,COMM,N
+770452,LEELAND HOUSE,LEELAND HOUSE,COMM,N
+685588,Balham High Road Probation Office,Balham High Road Probation Office,COMM,N
+WWS002,LEAMINGTON SPA Probation Office,LEAMINGTON SPA Probation Office,COMM,Y
+BARROW,Barrow Hospital,Barrow Hospital,HSHOSP,Y
+TRAFFD,Trafford General Hospital,Trafford General Hospital,HSHOSP,Y
+THA015,Cowley Probation Office,Cowley Probation Office,COMM,Y
+KENSTN,Kensington PICU,Kensington PICU,HSHOSP,Y
+LDM027,Balham High Road,Balham High Road,COMM,Y
+WWS007,Warwickshire Victim Liaison Unit,Warwickshire Victim Liaison Unit,COMM,Y
+THA051,Reading MC Probation Liaison Unit,Reading MC Probation Liaison Unit,COMM,Y
+WWS003,Rugby Probation Office,Rugby Probation Office,COMM,Y
+WARHAM,Warlingham Park Hospital,Warlingham Park Hospital,HSHOSP,Y
+DONRYL,Doncaster Royal Infirmary,Doncaster Royal Infirmary,HSHOSP,Y
+LDM078,Oaklands(NELPS Probation Centre),Oaklands(NELPS Probation Centre),COMM,Y
+STANSD,St Ann's (Dorset),St Ann's (Dorset),HSHOSP,Y
+WWSAP1,LEAMINGTON SPA Approved Premises,LEAMINGTON SPA Approved Premises,APPR,Y
+LTS010,Leicester Friar Lane Office,Leicester Friar Lane Office,COMM,Y
+WTS002,CHIPPENHAM Probation Centre,CHIPPENHAM Probation Centre,COMM,Y
+MLW009,Birmingham Supporting People Unit,Birmingham Supporting People Unit,COMM,Y
+STF032,Staitheford House Probation & Bail Host.,Staitheford House Probation & Bail Host.,APPR,Y
+689073,Bradford CITY Probation Unit,Bradford CITY Probation Unit,COMM,N
+LCS001,Lancashire Head Office,Lancashire Head Office,COMM,Y
+NHS005,Newark Probation Office,Newark Probation Office,COMM,Y
+440419,HUDDERSFIELD Probation Centre,HUDDERSFIELD Probation Centre,COMM,N
+BRADEN,Branden Unit,Branden Unit,HSHOSP,Y
+HBS015,Hull DIT,Hull DIT,COMM,Y
+ASPAP3,Brigstocke Road Approved Premises,Brigstocke Road Approved Premises,APPR,Y
+NBR028,Houghton - le -Spring Probation Office,Houghton - le -Spring Probation Office,COMM,Y
+MLW032,Birmingham Admin Unit,Birmingham Admin Unit,COMM,Y
+THA049,Didcot Mags Court Probation Office,Didcot Mags Court Probation Office,COMM,Y
+THA027,East Berkshire Mags Court Probation Off,East Berkshire Mags Court Probation Off,COMM,Y
+CMBY02,Cumbria YOT West Division,Cumbria YOT West Division,YOT,Y
+HAZLWD,Hazelwood House,Hazelwood House,HSHOSP,Y
+LTS015,SHARP,SHARP,COMM,Y
+LCSAP1,Highfield House Approved Premises,Highfield House Approved Premises,APPR,Y
+KNT021,Canterbury Probation Office,Canterbury Probation Office,COMM,Y
+302265,NEWPORT Probation Centre,NEWPORT Probation Centre,COMM,N
+NBR021,Pennywell Probation Office,Pennywell Probation Office,COMM,Y
+ARNOLD,Arnold Lodge,Arnold Lodge,HSHOSP,Y
+LTS001,Leicestershire Head Office,Leicestershire Head Office,COMM,Y
+CHSY02,Macclesfield YOT,Macclesfield YOT,YOT,Y
+YSS030,"Bentley, Doncaster","Bentley, Doncaster",COMM,Y
+THA002,Thames Valley Head Office,Thames Valley Head Office,COMM,Y
+DCP006,Cornwall Divisional Head Office,Cornwall Divisional Head Office,COMM,Y
+MCHAEL,Michael Carlisle Centre,Michael Carlisle Centre,HSHOSP,Y
+MLW006,Sparkbrook Probation Centre,Sparkbrook Probation Centre,COMM,Y
+HPS021,Havant Probation Office,Havant Probation Office,COMM,Y
+BRLAND,Broadlands Clinic,Broadlands Clinic,HSHOSP,Y
+YSS027,Rotherham Magistrates Court,Rotherham Magistrates Court,COMM,Y
+EHAMHS,East Ham Memorial Hospital,East Ham Memorial Hospital,HSHOSP,Y
+LDM004,Dorset Close Probation Office,Dorset Close,COMM,Y
+544685,Pontypridd Probation Centre,Pontypridd Probation Centre,COMM,N
+SSX001,Worthing Probation Office,Worthing Probation Office,COMM,Y
+244525,South Wales HO & Bridgend Probation,South Wales HO & Bridgend Probation,COMM,N
+795760,DTTO NOTTINGHILL GATE,DTTO NOTTINGHILL GATE,COMM,N
+514947,Bow Probation Office,Bow Probation Office,COMM,N
+635419,EAST HILL - WANDSWORTH Probation Office,EAST HILL - WANDSWORTH Probation Office,COMM,N
+430750,LEWISHAM Probation Office,LEWISHAM Probation Office,COMM,N
+275314,St John Street Probation Office,St John Street Probation Office,COMM,N
+724559,Woolwich Probation Office,Woolwich Probation Office,COMM,N
+266718,REED HOUSE Probation Office,REED HOUSE Probation Office,COMM,N
+LNGLEY,The Longley Centre,The Longley Centre,HSHOSP,Y
+647602,HARPENDEN HOUSE Probation Office,HARPENDEN HOUSE Probation Office,COMM,N
+614932,Camberwell Probation Centre,Camberwell Probation Centre,COMM,N
+703230,DORSET CLOSE Probation Office,DORSET CLOSE Probation Office,COMM,N
+249378,Bethnal Green Probation Office,Bethnal Green Probation Office,COMM,N
+456872,HACKNEY Probation Office,HACKNEY Probation Office,COMM,N
+615733,SHEPHERDS BUSH Probation Office,SHEPHERDS BUSH Probation Office,COMM,N
+234498,Stockwell Probation Office,Stockwell Probation Office,COMM,N
+462072,London Head Office,London Head Office,COMM,N
+384377,WALTHAMSTOW Probation Office,WALTHAMSTOW Probation Office,COMM,N
+506555,Wimbeldon Probation Office,Wimbeldon Probation Office,COMM,N
+326241,Sutton Probation Office,Sutton Probation Office,COMM,N
+693103,Kingston & Richmond Probation Office,Kingston & Richmond Probation Office,COMM,N
+MLW023,Wolverhampton Programmes Unit,Wolverhampton Programmes Unit,COMM,Y
+KNTY07,Medway Area YOT,Medway Area YOT,YOT,Y
+LCSY06,Fleetwood YOT,Fleetwood YOT,YOT,Y
+HBS004,Goole Probation Office,Goole Probation Office,COMM,Y
+MCG059,Salford Mags Court Probation Office,Salford Mags Court Probation Office,COMM,Y
+NHS007,Nottingham C S Office & Workshop,Nottingham C S Office & Workshop,COMM,Y
+LDM054,Court of Appeal Probation Office,Court of Appeal Probation Office,COMM,Y
+DBS003,Bolsover Probation Office,Bolsover Probation Office,COMM,N
+NBR043,Sunderland Accredited Programmes Unit,Sunderland Accredited Programmes Unit,COMM,Y
+MCG009,Hyde Probation Office,Hyde Probation Office,COMM,Y
+NBR005,Blaydon Probation Office,Blaydon Probation Office,COMM,Y
+349940,LEICESTERSHIRE OFFICES,LEICESTERSHIRE OFFICES,COMM,N
+DBSY03,Chesterfield YOT,Chesterfield YOT,YOT,Y
+GLDLDG,Guild Lodge,Guild Lodge,HSHOSP,Y
+LDM068,Great Dover Street,Great Dover Street,COMM,Y
+NBRY03,Newcastle YOT,Newcastle YOT,YOT,Y
+STANSL,St Ann's ( Tottenham),St Ann's ( Tottenham),HSHOSP,Y
+TESY02,South Tees YOT,South Tees YOT,YOT,Y
+GCS006,Gloucester Courts Liaison Unit,Gloucester Courts Liaison Unit,COMM,Y
+MCG013,Longsight Probation Office,Longsight Probation Office,COMM,Y
+GRGMAC,George Mackenzie House ( Fulbourn),George Mackenzie House ( Fulbourn),HSHOSP,Y
+NHS003,Masfield Probation Office Sherwood Court,Masfield Probation Office Sherwood Court,COMM,Y
+MLW013,Coventry Probation Centre,Coventry Probation Centre,COMM,Y
+MRS012,South Knowsley Probation Centre,South Knowsley Probation Centre,COMM,Y
+YSW015,Bradford Fraternal House Prob Office,Bradford Fraternal House Prob Office,COMM,Y
+MLW038,Printing Hse St,Printing Hse St,COMM,Y
+RAMTON,Rampton Hospital,Rampton Hospital,HSHOSP,Y
+WWS004,STRATFORD-UPON-AVON Probation Office,STRATFORD-UPON-AVON Probation Office,COMM,Y
+739917,LINCOLN Probation Office,LINCOLN Probation Office,COMM,N
+HPS027,Hampshire Head Office,Hampshire Head Office,COMM,Y
+STCLEM,St Clements (Ipswich),St Clements (Ipswich),HSHOSP,Y
+LDM072,Havering PO,Havering PO,COMM,N
+HPS007,Alton Probation Office,Alton Probation Office,COMM,Y
+TGRANG,The Grange (Norwich),The Grange (Norwich),HSHOSP,Y
+655772,LOUTH Probation Office,LOUTH Probation Office,COMM,N
+HPS052,Southampton Crown Court (Probation),Southampton Crown Court (Probation),COMM,Y
+HPS046,New Forest Magistrates Court (Probation),New Forest Magistrates Court (Probation),COMM,Y
+LCSY04,Burnley YOT,Burnley YOT,YOT,Y
+BDS008,Bedford MC Liaison Office,Bedford MC Liaison Office,COMM,Y
+NBR006,Newcastle East Probation Office,Newcastle East Probation Office,COMM,Y
+THRNFD,Thornford Park (Blenheim House),Thornford Park (Blenheim House),HSHOSP,Y
+ASHWTH,Ashworth Hospital,Ashworth Hospital,HSHOSP,Y
+DBSY02,Ilkeston YOT,Ilkeston YOT,YOT,Y
+LDM147,Wandle Road,Wandle Road,COMM,Y
+MRS015,Liverpool Crown Court Liaison Unit,Liverpool Crown Court Liaison Unit,COMM,Y
+ASP015,Bath Prolific Offender Unit,Bath Prolific Offender Unit,COMM,Y
+642637,Slough Probation Office,Slough Probation Office,COMM,N
+555383,Reading Probation Office 1,Reading Probation Office 1,COMM,N
+645808,Reading Probation Office 2,Reading Probation Office 2,COMM,N
+DCPAP2,Meneghy House Approved Premises,Meneghy House Approved Premises,APPR,Y
+MCG064,Manchester Mags New Court Probation Off,Manchester Mags New Court Probation Off,COMM,Y
+CHS009,Macclesfield Probation Office -Brunswick,Macclesfield Probation Office -Brunswick,COMM,Y
+DRS005,Bournemouth CC Liaison Office,Bournemouth CC Liaison Office,COMM,Y
+DBS001,Derbyshire Probation Headquarters,Derbyshire Probation Headquarters,COMM,Y
+BROWYN,Bro Gerwyn Unit,Bro Gerwyn Unit,HSHOSP,Y
+CMB010,Carlisle Community Service Office,Carlisle Community Service Office,COMM,Y
+WTSY02,Melksham YOT,Melksham YOT,YOT,Y
+NFK001,Norfolk Head Office,Norfolk Head Office,COMM,Y
+MRS018,St Helens Probation Centre,St Helens Probation Centre,COMM,Y
+WLSGRV,Walsgrave Hospital,Walsgrave Hospital,HSHOSP,Y
+LDM051,88 Clapham Road,88 Clapham Road,COMM,Y
+LNSY03,Lincolnshire YOT West,Lincolnshire YOT West,YOT,Y
+LDM110,Kingston Mags Court Probation Office,Kingston Mags Court Probation Office,COMM,Y
+KNT013,Sheerness Probation Office,Sheerness Probation Office,COMM,Y
+GCS004,Gloucester Probation Centre,Gloucester Probation Centre,COMM,Y
+776185,High Wycombe Probation Office,High Wycombe Probation Office,COMM,N
+HELLIN,Hellingly Hospital,Hellingly Hospital,HSHOSP,Y
+NHS009,Notts County Substance Misuse Team,Nottinghamshire County Substance Misuse Team,COMM,Y
+NBR035,South Tyneside Mags Court Probation Off,South Tyneside Mags Court Probation Off,COMM,Y
+MRS007,Kirkdale Probation Office,Kirkdale Probation Office,COMM,Y
+TINDAL,"The Tindal Centre, Buckinghamshire","The Tindal Centre, Buckinghamshire",HSHOSP,Y
+705670,Oxford City Probation Office,Oxford City Probation Office,COMM,N
+YSS001,"Norfolk Park Hostel, Sheffield","Norfolk Park Hostel, Sheffield",APPR,Y
+YSN001,York Probation Office,York Probation Office,COMM,Y
+CNCOED,Cefn Coed Hospital,Cefn Coed Hospital,HSHOSP,Y
+RSHANT,Royal S. Hampshire Hosp(Mayflowers Ward),Royal South Hampshire Hospital (Mayflowers Ward),HSHOSP,Y
+WSTMOR,Westmorland General Hospital,Westmorland General Hospital,HSHOSP,Y
+CMB013,Cumbria DAT North,Cumbria DAT North,COMM,Y
+NBR033,Newcastle Mags Court Probation Office,Newcastle Mags Court Probation Office,COMM,Y
+MCG022,Grt Man Training and Staff Devel Unit,Grt Man Training and Staff Devel Unit,COMM,Y
+STANDW,St Andrew's Hospital (Northants),St Andrew's Hospital (Northants),HSHOSP,Y
+LDM019,Woolwich Crown Court Probation Office,Woolwich Crown Court Probation Office,COMM,Y
+LDM099,Croydon CRC,Croydon,COMM,Y
+SPRFLD,"Springfield Hospital, London","Springfield Hospital, London",HSHOSP,Y
+CBS004,Huntingdon Probation Office,Huntingdon Probation Office,COMM,Y
+SSX012,Brighton Probation Office,Brighton Probation Office,COMM,Y
+EGLAM,East Glamorgan General Hospital,East Glamorgan General Hospital,HSHOSP,Y
+SFKAP1,Lightfoot House Approved Premises,Lightfoot House Approved Premises,APPR,Y
+YSWY01,West Yorks Com Justice Interven Proj Off,West Yorks Com Justice Interven Proj Off,COMM,Y
+NHS014,Nottinghamshire MAPPP Unit,Nottinghamshire MAPPP Unit,COMM,Y
+LNS001,Lincolnshire Head Office,Lincolnshire Head Office,COMM,Y
+ASYHSE,Ashley House,Ashley House,HSHOSP,Y
+LNDHSE,Linden House (York),Linden House (York),HSHOSP,Y
+MAYFLR,Mayflower Hospital,Mayflower Hospital,HSHOSP,Y
+EDENFD,Edenfield Centre,Edenfield Centre,HSHOSP,Y
+DBS013,Derbyshire MAPPA Co-ordination Unit,Derbyshire MAPPA Co-ordination Unit,COMM,Y
+NBR041,Northumbria Sex Offender Programme Team,Northumbria Sex Offender Programme Team,COMM,Y
+FORSTN,The Forston Clinic,The Forston Clinic,HSHOSP,Y
+WOTTON,Wotton Lawn Hospital,Wotton Lawn Hospital,HSHOSP,Y
+GDMAYE,Goodmayes Hospital,Goodmayes Hospital,HSHOSP,Y
+SSX020,Lewes Probation Office,Lewes Probation Office,COMM,Y
+NRTHGT,Northgate Hospital,Northgate Hospital,HSHOSP,Y
+GWT006,NEWPORT Probation Centre,NEWPORT Probation Centre,COMM,Y
+STJOHN,St John's House,St John's House,HSHOSP,Y
+MCG070,Wigan Criminal Justice Team,Wigan Criminal Justice Team,COMM,Y
+OLDMAN,Old Manor Hospital,Old Manor Hospital,HSHOSP,Y
+DCP009,Exeter Probation Office,Exeter Probation Office,COMM,Y
+MANHOS,Maindiff Court Hospital,Maindiff Court Hospital,HSHOSP,Y
+YSW001,West Yorkshire Head Office,West Yorkshire Head Office,COMM,Y
+MLW004,Birmingham Probation Centre,Birmingham Probation Centre,COMM,Y
+LCS011,Lancaster Probation Office,Lancaster Probation Office,COMM,Y
+GCS005,Stroud Probation Office,Stroud Probation Office,COMM,Y
+WARFRD,Warneford Hospital,Warneford Hospital,HSHOSP,Y
+MCG001,Chorlton Approved Premises,Chorlton Approved Premises,APPR,Y
+GCS003,CIRENCESTER Courts Liaison Unit,CIRENCESTER Courts Liaison Unit,COMM,Y
+THA017,Oxford Probation Hostel,Oxford Probation Hostel,APPR,Y
+TRENIT,Trent Unit,Trent Unit,HSHOSP,Y
+CHS005,Warrington Probation Office,Warrington Probation Office,COMM,Y
+NBR015,Newcastle Law Courts Probation Office,Newcastle Law Courts Probation Office,COMM,Y
+DUR014,Durham Head Office,Durham Head Office,COMM,Y
+STF042,North Staffordshire MDO Unit,North Staffordshire Mentally Disordered Offenders Unit,COMM,Y
+YSW002,Bradford CROWN COURT Liaison Unit,Bradford CROWN COURT Liaison Unit,COMM,Y
+DPP006,Llandrindod Wells Probation Office,Llandrindod Wells Probation Office,COMM,Y
+CHSY03,Warrington YOT,Warrington YOT,YOT,Y
+MCG040,Stretford Probation Office,Stretford Probation Office,COMM,Y
+STLUKE,St Luke's Hospital,St Luke's Hospital,HSHOSP,Y
+NHSY03,Newark YOT,Newark YOT,YOT,Y
+HPS020,Dickson House Approved Premises,Dickson House Approved Premises,APPR,Y
+NHSY01,Nottingham City YOT,Nottingham City YOT,YOT,Y
+STF004,Burton-upon-Trent Probation Centre,Burton-upon-Trent Probation Centre,COMM,Y
+379153,ORPINGTON PROBATION CENTRE,ORPINGTON PROBATION CENTRE,COMM,N
+LTS007,Loughborough Probation Office,Loughborough Probation Office,COMM,Y
+CHS001,Cheshire Head Office,Cheshire Head Office,COMM,Y
+NHWKYC,North Warwickshire Youth Court,North Warwickshire Youth Court,CRT,Y
+735096,Bexleyheath Probation Office,Bexleyheath Probation Office,COMM,N
+ASP011,Yeovil Probation Centre,Yeovil Probation Centre,COMM,Y
+STF007,Longton Probation Office,Longton Probation Office,COMM,N
+MRS023,Liverpool Magistrates Court Liaison Unit,Liverpool Magistrates Court Liaison Unit,COMM,Y
+TES008,Teeside Crown Crt Probation Liaison Unit,Teeside Crown Crt Probation Liaison Unit,COMM,Y
+634809,UXBRIDGE Probation Office,UXBRIDGE Probation Office,COMM,N
+332572,WEMBLEY PROBATION OFFICE,WEMBLEY PROBATION OFFICE,COMM,N
+261129,STRATFORD Probation Office,STRATFORD Probation Office,COMM,N
+474052,Romford Probation Office,Romford Probation Office,COMM,Y
+508510,Ilford Probation Centre,Ilford Probation Centre,COMM,N
+591295,CROYDON CC Probation Office,CROYDON Crown Court Probation Office,COMM,N
+ASI,ASHFIELD (HMP),HMP & YOI ASHFIELD,INST,Y
+AWI,ASHWELL (HMP),HMP ASHWELL,INST,N
+AGI,ASKHAM GRANGE (HMP & YOI),HMP & YOI ASKHAM GRANGE,INST,Y
+AYI,AYLESBURY (HMP),HMP AYLESBURY,INST,Y
+BFI,BEDFORD (HMP),HMP BEDFORD,INST,Y
+BAI,BELMARSH (HMP),HMP BELMARSH,INST,Y
+BMI,BIRMINGHAM (HMP),HMP BIRMINGHAM,INST,Y
+BTI,BLAKENHURST (HMP),HMP BLAKENHURST,INST,N
+BHI,BLANTYRE HOUSE (HMP),HMP BLANTYRE HOUSE,INST,N
+BDI,BLUNDESTON (HMP),HMP BLUNDESTON,INST,N
+BSI,BRINSFORD (HMP),HMP BRINSFORD,INST,Y
+BLI,BRISTOL (HMP),HMP BRISTOL,INST,Y
+BXI,BRIXTON (HMP),HMP BRIXTON,INST,Y
+BKI,BROCKHILL (HMP & YOI),HMP & YOI BROCKHILL,INST,N
+BZI,BRONZEFIELD (HMP),HMP BRONZEFIELD,INST,Y
+BCI,BUCKLEY HALL (HMP),HMP BUCKLEY HALL,INST,Y
+BNI,BULLINGDON (HMP),HMP BULLINGDON,INST,Y
+BUI,BULLWOOD HALL (HMP),HMP BULLWOOD HALL,INST,N
+CHI,CAMP HILL (HMP),HMP CAMPHILL,INST,N
+CYI,CANTERBURY (HMP),HMP CANTERBURY,INST,N
+CFI,CARDIFF (HMP),HMP CARDIFF,INST,Y
+CSI,CASTINGTON (HMP & YOI),HMP & YOI CASTINGTON,INST,N
+CWI,CHANNINGS WOOD (HMP),HMP CHANNINGS WOOD,INST,Y
+CDI,CHELMSFORD (HMP),HMP CHELMSFORD,INST,Y
+CLI,COLDINGLEY (HMP),HMP COLDINGLEY,INST,Y
+CKI,COOKHAM WOOD (HMP),HMP COOKHAM WOOD,INST,Y
+DAI,DARTMOOR (HMP),HMP DARTMOOR,INST,Y
+DTI,DEERBOLT (HMPYOI),HMYOI DEERBOLT,INST,Y
+DNI,DONCASTER (HMP),HMP DONCASTER,INST,Y
+DRI,DORCHESTER (HMP),HMP DORCHESTER,INST,N
+DGI,DOVEGATE (HMP),HMP DOVEGATE,INST,Y
+DVI,Dover Immigration Removal Centre,IMMIGRATION REMOVAL CENTRE DOVER,INST,N
+DWI,DOWNVIEW (HMP),HMP DOWNVIEW,INST,Y
+DHI,DRAKE HALL (HMP & YOI),HMP & YOI DRAKE HALL,INST,Y
+DMI,DURHAM (HMP),HMP DURHAM,INST,Y
+ESI,EAST SUTTON PARK (HMP & YOI),HMP & YOI EAST SUTTON PK,INST,Y
+LANGHT,LANGLEY HOUSE TRUST,LANGLEY HOUSE TRUST,OUT,Y
+EWI,EASTWOOD PARK (HMP),HMP EASTWOOD PARK,INST,Y
+NEI,EDMUNDS HILL (HMP),HMP EDMUNDS HILL,INST,N
+EYI,ELMLEY (HMP),HMP ELMLEY,INST,Y
+EEI,ERLESTOKE (HMP),HMP ERLESTOKE,INST,Y
+EVI,EVERTHORPE (HMP),HMP EVERTHORPE,INST,N
+EXI,EXETER (HMP),HMP EXETER,INST,Y
+FSI,FEATHERSTONE (HMP),HMP FEATHERSTONE,INST,Y
+FMI,FELTHAM (HMP & YOI),HMP & YOI FELTHAM,INST,Y
+FDI,FORD (HMP),HMP FORD,INST,Y
+FBI,FOREST BANK (HMP & YOI),HMP & YOI FOREST BANK,INST,Y
+FHI,FOSTON HALL (HMP),HMP FOSTON HALL,INST,Y
+FKI,FRANKLAND (HMP),HMP FRANKLAND,INST,Y
+FNI,FULL SUTTON (HMP),HMP FULL SUTTON,INST,Y
+GHI,GARTH (HMP),HMP GARTH,INST,Y
+GTI,GARTREE (HMP),HMP GARTREE,INST,Y
+GPI,GLEN PARVA (HMPYOI & RC),HMYOI & RC GLEN PARVA,INST,N
+GLI,GLOUCESTER (HMP),HMP GLOUCESTER,INST,N
+GNI,GRENDON (HMP),HMP GRENDON,INST,Y
+GMI,GUYS MARSH (HMP),HMP GUYS MARSH,INST,Y
+HRI,Haslar Immigration Removal Centre,IMMIGRATION REMOVAL CENTRE HASLAR,INST,N
+HVI,HAVERIGG (HMP),HMP HAVERIGG,INST,Y
+HGI,HEWELL GRANGE (HMP),HMP HEWELL GRANGE,INST,N
+HOI,HIGH DOWN (HMP),HMP HIGH DOWN,INST,Y
+HPI,HIGHPOINT (HMP),HMP HIGHPOINT,INST,Y
+HII,HINDLEY (HMP & YOI),HMP & YOI HINDLEY,INST,Y
+HBI,HOLLESLEY BAY (HMP),HMP HOLLESLEY BAY,INST,Y
+HYI,HOLLOWAY (HMP),HMP HOLLOWAY,INST,N
+HHI,HOLME HOUSE (HMP),HMP HOLME HOUSE,INST,Y
+HLI,HULL (HMP),HMP HULL,INST,Y
+HCI,HUNTERCOMBE (HMP),HMP HUNTERCOMBE,INST,Y
+PTI,KINGSTON (HMP),HMP KINGSTON/PORTS,INST,N
+KMI,KIRKHAM (HMP),HMP KIRKHAM,INST,Y
+KVI,KIRKLEVINGTON GRANGE (HMP),HMP KIRKLEVINGTON GRANGE,INST,Y
+LAI,LANCASTER CASTLE (HMP),HMP LANCASTER CASTLE,INST,N
+LFI,LANCASTER FARMS (HMP),HMP LANCASTER FARMS,INST,Y
+LMI,LATCHMERE HOUSE (HMP),HMP LATCHMERE HOUSE,INST,N
+LEI,LEEDS (HMP),HMP LEEDS,INST,Y
+LCI,LEICESTER (HMP),HMP LEICESTER,INST,Y
+LWI,LEWES (HMP),HMP LEWES,INST,Y
+LYI,LEYHILL (HMP),HMP LEYHILL,INST,Y
+LII,LINCOLN (HMP),HMP LINCOLN,INST,Y
+LHI,LINDHOLME (HMP),HMP LINDHOLME,INST,Y
+LTI,LITTLEHEY (HMP),HMP LITTLEHEY,INST,Y
+LPI,LIVERPOOL (HMP),HMP LIVERPOOL,INST,Y
+LLI,LONG LARTIN (HMP),HMP LONG LARTIN,INST,Y
+LNI,LOW NEWTON (HMP),HMP LOW NEWTON,INST,Y
+LGI,LOWDHAM GRANGE (HMP),HMP LOWDHAM GRANGE,INST,Y
+MSI,MAIDSTONE (HMP),HMP MAIDSTONE,INST,Y
+MRI,MANCHESTER (HMP),HMP MANCHESTER,INST,Y
+MDI,MOORLAND (HMP & YOI),HMP & YOI MOORLAND,INST,Y
+HDI,HATFIELD (HMP & YOI),HMP & YOI HATFIELD,INST,Y
+MHI,MORTON HALL IMMIGRATION REMOVAL CENTRE,IMMIGRATION REMOVAL CENTRE MORTON HALL,INST,Y
+NHI,NEW HALL (HMP),HMP NEW HALL,INST,Y
+NSI,NORTH SEA CAMP (HMP),HMP NORTH SEA CAMP,INST,Y
+NNI,NORTHALLERTON (HMP),HMYOI NORTHALLERTON,INST,N
+NWI,NORWICH (HMP & YOI),HMP & YOI NORWICH,INST,Y
+NMI,NOTTINGHAM (HMP),HMP NOTTINGHAM,INST,Y
+ONI,ONLEY (HMP),HMP ONLEY,INST,Y
+PRI,PARC (HMP),HMP PARC,INST,Y
+PKI,PARKHURST (HMP),HMP PARKHURST,INST,N
+PVI,PENTONVILLE (HMP),HMP PENTONVILLE,INST,Y
+PDI,PORTLAND (HMPYOI),HMYOI PORTLAND,INST,Y
+UPI,PRESCOED (HMP & YOI),HMP & YOI PRESCOED,INST,Y
+PNI,PRESTON (HMP),HMP PRESTON,INST,Y
+RNI,RANBY (HMP),HMP RANBY,INST,Y
+RDI,READING (HMP & YOI),HMP & YOI READING,INST,N
+RSI,RISLEY (HMP),HMP RISLEY,INST,Y
+RCI,ROCHESTER (HMP & YOI),HMP & YOI ROCHESTER,INST,Y
+RHI,RYE HILL (HMP),HMP RYE HILL,INST,Y
+SDI,SEND (HMP),HMP SEND,INST,Y
+SMI,SHEPTON MALLET (HMP),HMP SHEPTON MALLET,INST,N
+SYI,SHREWSBURY (HMP),HMP SHREWSBURY,INST,N
+SFI,STAFFORD (HMP),HMP STAFFORD,INST,Y
+EHI,STANDFORD HILL (HMP),HMP STANDFORD HILL,INST,Y
+SKI,STOCKEN (HMP),HMP STOCKEN,INST,Y
+SHI,STOKE HEATH (HMPYOI),HMYOI STOKE HEATH,INST,Y
+STI,STYAL (HMP & YOI),HMP & YOI STYAL,INST,Y
+SUI,SUDBURY (HMP & YOI),HMP & YOI  SUDBURY,INST,Y
+SLI,SWALESIDE (HMP),HMP SWALESIDE,INST,Y
+SWI,SWANSEA (HMP),HMP SWANSEA,INST,Y
+SNI,SWINFEN HALL (HMP),HMP SWINFEN HALL,INST,Y
+MTI,THE MOUNT (HMP),HMP THE MOUNT,INST,Y
+VEI,THE VERNE (HMP),HMP THE VERNE,INST,Y
+WAI,THE WEARE (HMP),HMP THE WEARE,INST,N
+TCI,THORN CROSS (HMPYOI),HMYOI THORN CROSS,INST,Y
+UKI,USK (HMP),HMP USK & PRESCOED,INST,Y
+WDI,WAKEFIELD (HMP),HMP WAKEFIELD,INST,Y
+WWI,WANDSWORTH (HMP),HMP WANDSWORTH,INST,Y
+WII,WARREN HILL (HMP),HMP WARREN HILL,INST,Y
+WLI,WAYLAND (HMP),HMP WAYLAND,INST,Y
+WEI,WEALSTUN (HMP),HMP WEALSTUN,INST,Y
+WBI,WELLINGBOROUGH (HMP),HMP WELLINGBOROUGH,INST,N
+WNI,WERRINGTON (HMPYOI),HMYOI WERRINGTON,INST,Y
+WYI,WETHERBY (HMPYOI),HMYOI WETHERBY,INST,Y
+WTI,WHATTON (HMP),HMP WHATTON,INST,Y
+WRI,WHITEMOOR (HMP),HMP WHITEMOOR,INST,Y
+WCI,WINCHESTER (HMP),HMP WINCHESTER,INST,Y
+WOI,WOLDS (HMP),HMP THE WOLDS,INST,N
+WHI,WOODHILL (HMP),HMP WOODHILL,INST,Y
+WSI,WORMWOOD SCRUBS (HMP),HMP WORMWOOD SCRUBS,INST,Y
+WMI,WYMOTT (HMP),HMP WYMOTT,INST,Y
+RAWTMC,Rawtenstall MC,Rawtenstall Magistrates' Court,CRT,N
+NUNVMC,"Nuneaton, Vicarage St MC",Nuneaton Magistrates' Court,CRT,N
+KCNSMC,"Kings Court, North Shields MC","Kings Court, North Shields, Magistrates' Court",CRT,N
+NLCJMC,North Liverpool Community Justice Centre,North Liverpool Community Justice Centre,CRT,N
+BRMBMC,Birmingham (Bull Street) MC,Birmingham (Bull Street) Magistrates' Court,CRT,N
+SCBCMC,"Scarborough (County Court,Valley Bridge)",Scarborough (Valley Bridge Rd) Magistrates' Court,CRT,N
+CFONMC,Caernarfon (County Court) MC,Caernarfon (County Court),CRT,N
+OUT,OUTSIDE,OUTSIDE JURISDICTION,INST,N
+TRN,TRANSFER,,INST,Y
+512280,Lymington Probation Office,Lymington Probation Office,COMM,N
+516298,Isle of Wight Probation Office,Isle of Wight Probation Office,COMM,N
+LDM071,Riverside House,Riverside House,COMM,Y
+659348,Town Quay Probation Office,Town Quay Probation Office,COMM,N
+306416,Winchester Probation Office,Winchester Probation Office,COMM,N
+341843,Portsmouth Probation Office,Portsmouth Probation Office,COMM,N
+NOU,National Operations Unit,National Operations Unit (PECS),PECS,Y
+G1,London and South East,London and South East PECS Region,PECS,N
+G2,South Wales and The West,South Wales and The West PECS Region,PECS,N
+G3,The North,The North PECS Region,PECS,N
+G4,East,East PECS Region,PECS,N
+G5,Inter Prison Escorts,Inter Prison Escorts,PECS,Y
+FOI,Foreign Prison,FOREIGN PRISON (OUTSIDE ENGLAND & WALES),INST,N
+UNKNWN,UNKNOWN LOCATION,UNKNOWN LOCATION,INST,N
+PBI,PETERBOROUGH (HMP),HMP PETERBOROUGH,INST,Y
+CHINGX,Charing Cross Hospital (PICU),Charing Cross Hospital (PICU),HSHOSP,Y
+NBR019,STAG Accredited Programmes Unit,STAG Accredited Programmes Unit,COMM,Y
+WSNAP1,Plas y Wern,Plas y Wern,APPR,Y
+WESTON,Weston General Hospital,Weston General Hospital,HSHOSP,Y
+ENDEAV,Endeavour Court (HDU),Endeavour Court (HDU),HSHOSP,Y
+NFK007,Norwich Unpaid Work Unit,Norwich Unpaid Work Unit,COMM,Y
+SWSAP1,Mandeville House Bail Hostel,Mandeville House Bail Hostel,APPR,Y
+WMP002,Hereford Probation Office,Hereford Probation Office,COMM,Y
+MCG028,Grt Manchester Probation Programmes Team,Grt Manchester Probation Programmes Team,COMM,Y
+SWSY04,Rhondda YOT,Rhondda YOT,YOT,Y
+DCP007,Truro Probation Office,Truro Probation Office,COMM,Y
+HGHGTE,Highgate Mental Health Centre,Highgate Mental Health Centre,HSHOSP,Y
+ASP012,Bridgwater Probation Centre,Bridgwater Probation Centre,COMM,Y
+ABDALE,"Abbey Dale Court, London","Abbey Dale Court, London",HSHOSP,Y
+ESX005,Harlow Probation Office,Harlow Probation Office,COMM,Y
+HPS054,Basingstoke Probation and CRC Office,Basingstoke Probation and CRC Office,COMM,Y
+BOWDEN,Bowden House,Bowden House,HSHOSP,Y
+YSW005,Dewsbury Probation Office,Dewsbury Probation Office,COMM,Y
+ESX003,Chelmsford Probation Office,Chelmsford Probation Office,COMM,Y
+TESAP2,Nelson House Probation Hostel,Nelson House Probation Hostel,APPR,Y
+LTSY03,Hinckley YOT,Hinckley YOT,YOT,Y
+HERBRT,Herbert Day Hospital,Herbert Day Hospital,HSHOSP,Y
+THA050,Project IRIS (Thames Valley),Project IRIS (Thames Valley),COMM,Y
+LDM039,39 Greenwich High Road,39 Greenwich High Road,COMM,Y
+MRS046,Liverpool Intensive Supervision (LISM),Liverpool Intensive Supervision (LISM),COMM,Y
+DRS006,Dorchester Probation Centre,Dorchester Probation Centre,COMM,Y
+DRS002,Blandford Probation Centre,Blandford Probation Centre,COMM,Y
+BRATON,Bracton Centre,Bracton Centre,HSHOSP,Y
+BIRING,All Saints Hospital,All Saints Hospital,HSHOSP,Y
+MLW044,Walsall Court,Walsall Court,COMM,Y
+LNS011,Lincoln CC Liaison Unit,Lincoln CC Liaison Unit,COMM,Y
+CMBAP1,Bowling Green Approved Premises,Bowling Green Approved Premises,APPR,Y
+KNT006,Dover Probation Office,Dover Probation Office,COMM,Y
+MCG054,Grt Man Hostels Manage Unit/ Cen Admis,Grt Man Hostels Manage Unit/ Cen Admis,APPR,Y
+SSX003,Littlehampton Probation Office,Littlehampton Probation Office,COMM,Y
+GWT009,Caerphilly Probation Office,Caerphilly Probation Office,COMM,Y
+WSN001,North Wales Head Office,North Wales Head Office,COMM,Y
+NBR016,North Shields Probation Office,North Shields Probation Office,COMM,Y
+HBSAP1,Hull Probation and Bail Hostel,Hull Probation and Bail Hostel,APPR,Y
+MRS048,St Helens DRR,St Helens DRR,COMM,Y
+HPSY04,Wessex YOT (SW and Southampton City),Wessex YOT (SW and Southampton City),YOT,Y
+WMP001,West Mercia Head Office,West Mercia Head Office,COMM,Y
+SWS005,Cardiff Probation Office,Cardiff Probation Office,COMM,Y
+LDM006,Stockwell Road,Stockwell Road,COMM,Y
+MCG008,Salford Probation Office,Salford Probation Office,COMM,Y
+NTS005,Corby Probation Office,Corby Probation Office,COMM,Y
+HPS006,Fareham Probation Office,Fareham Probation Office,COMM,Y
+LDM109,Kingston Crown Court Probation Office,Kingston Crown Court Probation Office,COMM,Y
+ESX002,Basildon Probation Office,Basildon Probation Office,COMM,Y
+TOLWTH,Tolworth Hospital,Tolworth Hospital,HSHOSP,Y
+JTSHAW,Janet Shaw Clinic,Janet Shaw Clinic,HSHOSP,Y
+SSX013,Brighton Approved Premises,Brighton Approved Premises,APPR,Y
+SWS006,Cardiff Crown Court Liaison Unit,Cardiff Crown Court Liaison Unit,COMM,Y
+GRENPK,Green Parks House,Green Parks House,HSHOSP,Y
+WMP008,Shrewsbury Probation Office,Shrewsbury Probation Office,COMM,Y
+MLWY05,Solihull YOT,Solihull YOT,YOT,Y
+WSN009,Wrexham Probation Office,Wrexham Probation Office,COMM,Y
+LDM143,Willesden Probation Office,Willesden Probation Office,COMM,Y
+HPS053,Hythe Probation Office,Hythe Probation Office,COMM,Y
+STF001,Hanley Unpaid Work Office,Hanley Unpaid Work Office,COMM,Y
+LCSY05,Chorley YOT,Chorley YOT,YOT,Y
+MLW011,Birmingham Probation Centre - Selly Oak,Selly Oak Probation Centre,COMM,Y
+WWS001,Warwickshire Head Office,Warwickshire Head Office,COMM,Y
+LNS002,Boston Probation Office,Boston Probation Office,COMM,Y
+LDM024,Inner London Crown Crt Probation Office,Inner London Crown Crt Probation Office,COMM,Y
+DRSY02,Bournemouth and Poole YOT,Bournemouth and Poole YOT,YOT,Y
+ASP001,North Somerset Courthouse Probation,North Somerset Courthouse Probation,COMM,Y
+MLW019,Stourbridge Probation Office,Stourbridge Probation Office,COMM,Y
+CALDER,Calderstones Hospital,Calderstones Hospital,HSHOSP,Y
+YSN020,N Yorkshire Public Protection Unit,North Yorkshire Public Protection Unit,COMM,Y
+HPSY02,Wessex YOT (NE and NW),Wessex YOT (NE and NW),YOT,Y
+STF037,Hanley Probation Office,Hanley Probation Office,COMM,N
+YSW006,HALIFAX Probation Office,HALIFAX Probation Office,COMM,Y
+YSN008,North Yorkshire Head Office,North Yorkshire Head Office,COMM,Y
+MCG039,Minshull St Crown Court Probation Office,Minshull St Crown Court Probation Office,COMM,Y
+MCG005,Heywood Community Punishment Office,Heywood Community Punishment Office,COMM,Y
+CENHUL,Central Hull Acute Unit,Central Hull Acute Unit,HSHOSP,Y
+HBS014,Humberside MAPPA Unit,Humberside MAPPA Unit,COMM,Y
+ORCHRD,Orchard Unit (Beds),Orchard Unit (Beds),HSHOSP,Y
+NFK003,Great Yarmouth Probation Office,Great Yarmouth Probation Office,COMM,Y
+CMB002,BARROW-IN-FURNESS Probation Office,BARROW-IN-FURNESS Probation Office,COMM,Y
+NHSAP1,Nottingham Approved Premises Raleigh St,Nottingham Approved Premises Raleigh St,APPR,Y
+TAI,THORP ARCH (HMP),HMP THORP ARCH,INST,N
+RUI,RUDGATE (HMP),HMP RUDGATE,INST,N
+MLW012,Coventry Programmes & ECP Unit,Coventry Programmes & Enhanced Community Punishment Unit,COMM,Y
+MCG024,Bury and Rochdale Probation Office,Bury and Rochdale Probation Office,COMM,Y
+YSWVH2,St John's Hostel,St John's Hostel,APPR,Y
+LDM128,Harrow Probation Office,Harrow Probation Office,COMM,Y
+MRSAP4,Adelaide House Probation/ Bail Hostel,Adelaide House Probation/ Bail Hostel,APPR,Y
+TESY01,Hartlepool YOT,Hartlepool YOT,YOT,Y
+LTS005,Leicester Probation Office,Leicester Probation Office,COMM,Y
+YSS014,"Court House, Barnsley","Court House, Barnsley",COMM,Y
+KNTY02,Sittingbourne YOT,Sittingbourne YOT,YOT,Y
+LDM097,Crosby House,Crosby House,COMM,Y
+MRS057,Liverpool DIP,Liverpool DIP,COMM,Y
+SFK001,Suffolk Head Office and Ipswich Prob Off,Suffolk Head Office and Ipswich Prob Off,COMM,Y
+GRENLN,Green Lane Hospital,Green Lane Hospital,HSHOSP,Y
+YSWAP1,HOLBECK HOUSE Approved Premises,HOLBECK HOUSE Approved Premises,APPR,Y
+DBS007,Derby CC Liaison Unit,Derby CC Liaison Unit,COMM,Y
+MCG062,Bolton Unpaid Work Office,Bolton Unpaid Work Office,COMM,Y
+NBR027,Blyth Probation Office,Blyth Probation Office,COMM,Y
+NFK005,Norwich Probation Office,Norwich Probation Office,COMM,Y
+LECSTR,Leicester General Hospital,Leicester General Hospital,HSHOSP,Y
+LEEMIL,Lee Mill Unit,Lee Mill Unit,HSHOSP,Y
+MLWY08,Pype Hayes YOT,Pype Hayes YOT,YOT,Y
+THA028,Manor Lodge Hostel,Manor Lodge Hostel,APPR,Y
+THA026,Maidenhead Probation Office,Maidenhead Probation Office,COMM,Y
+WSN003,Caernarfon Probation Office,Caernarfon Probation Office,COMM,Y
+DCP008,Barnstable Probation Office,Barnstable Probation Office,COMM,Y
+NBRY05,S Tyneside YOT,S Tyneside YOT,YOT,Y
+DCP004,Penzance Probation Office,Penzance Probation Office,COMM,Y
+MRS052,Liverpool DRR,Liverpool DRR,COMM,Y
+MCG012,Wythenshawe Probation Office,Wythenshawe Probation Office,COMM,Y
+HPS051,Interventions Unpaid Work (South East),Interventions Unpaid Work (South East),COMM,Y
+LDM098,Bexleyheath Probation Office,Bexleyheath Probation Office,COMM,Y
+LYWELL,"Ladywell Unit, Lewisham","Ladywell Unit, Lewisham",HSHOSP,Y
+DCPY03,Torbay YOT,Torbay YOT,YOT,Y
+ABWLEY,Abraham Cowley Unit,Abraham Cowley Unit,HSHOSP,Y
+ESX009,Chelmsford Crown Court Liaison Unit,Chelmsford Crown Court Liaison Unit,COMM,Y
+LDM093,Orpington Probation Office,Orpington Probation Office,COMM,Y
+BETHLM,Bethlem Royal Hospital,Bethlem Royal Hospital,HSHOSP,Y
+ESX007,Southend-on-Sea Probation Office,Southend-on-Sea Probation Office,COMM,Y
+DRSY01,Dorset YOT,Dorset YOT,YOT,Y
+HBS018,East Yorkshire PPO/DIP,East Yorkshire PPO/DIP,COMM,Y
+MRS001,Merseyside Headquarters,Merseyside Headquarters,COMM,Y
+MRSY04,Liverpool North/Central/South YOT,Liverpool North/Central/South YOT,YOT,Y
+LDM121,Enfield Probation Office,Enfield Probation Office,COMM,Y
+THA055,Reading Probation Office,Reading Probation Office,COMM,Y
+CBS002,Cambridge Probation Office,Cambridge Probation Office,COMM,Y
+PTRSON,Paterson Centre for Mental Health,Paterson Centre for Mental Health,HSHOSP,Y
+SHWKMC,South Warwickshire MC,South Warwickshire Magistrates Court,CRT,Y
+MLW005,Saltley Probation Centre,Saltley Probation Centre,COMM,Y
+GLNFLD,Glenfield Hospital (Leicestershire),Glenfield Hospital (Leicestershire),HSHOSP,Y
+DUR003,BISHOP AUCKLAND Probation Office,BISHOP AUCKLAND Probation Office,COMM,Y
+SSX024,Worthing Mags Crt Probation Office,Worthing Magistrates Court Probation Office,COMM,Y
+ESX001,Essex Head Office,Essex Head Office,COMM,Y
+CMB008,Whitehaven Probation Office,Whitehaven Probation Office,COMM,Y
+BEDY01,Luton Youth Offending Team,Luton Youth Offending Team,YOT,Y
+KNT017,Gravesend Probation,Gravesend Probation,COMM,Y
+DUR001,Darlington Probation Office,Darlington Probation Office,COMM,Y
+THA008,Aylesbury YOI,Aylesbury YOI,YOT,Y
+KNT022,MAPPPA Joint Co-ordination Team,MAPPPA Joint Co-ordination Team,COMM,Y
+DCP014,C.A.R.D.,C.A.R.D.,COMM,Y
+BURNLY,Burnley General,Burnley General,HSHOSP,Y
+STLUKM,St Luke's Hospital (Cleveland),St Luke's Hospital (Cleveland),HSHOSP,N
+NFK002,Great Yarmouth Unpaid Work Unit,Great Yarmouth Unpaid Work Unit,COMM,Y
+STF024,Wenger House Probation & Bail Hostel,Wenger House Probation & Bail Hostel,APPR,Y
+FNTAIN,Fountain Way Hospital,Fountain Way Hospital,HSHOSP,Y
+LDM108,"Kingston, 45 High Street","Kingston, 45 High Street",COMM,N
+LDM130,Hendon Probation Office,Hendon Probation Office,COMM,Y
+CBS006,Wisbech Probation Office,Wisbech Probation Office,COMM,Y
+LDM015,West London Mags Court Probation Office,West London Mags Court Probation Office,COMM,Y
+LDM073,Forest Gate CSU,Forest Gate CSU,COMM,Y
+LDM080,Stratford Mags Court Probation Office,Stratford Mags Court Probation Office,COMM,Y
+DUR002,Peterlee Probation Office,Peterlee Probation Office,COMM,Y
+SHANON,Shannon House,Shannon House,HSHOSP,Y
+YSW014,Wakefield Probation Office,Wakefield Probation Office,COMM,Y
+FRANCS,Francis Willis Unit,Francis Willis Unit,HSHOSP,Y
+DUR017,Consett Probation Office,Consett Probation Office,COMM,Y
+STF045,South Staffordshire MDO Unit,South Staffordshire Mentally Disordered Offenders Unit,COMM,Y
+THA046,Milton Keynes Probation & Bail Hostel,Milton Keynes Probation & Bail Hostel,APPR,Y
+LNGFRD,The Langford Centre,The Langford Centre,HSHOSP,Y
+DUR004,Durham Probation Office,Durham Probation Office,COMM,Y
+SUTTON,Sutton Hospital,Sutton Hospital,HSHOSP,Y
+SWSY07,Bridgend YOT,Bridgend YOT,YOT,Y
+TES003,Middlesbrough Probation Centre,Middlesbrough Probation Centre,COMM,Y
+NBR017,North Shields Accredited Programmes Unit,North Shields Accredited Programmes Unit,COMM,Y
+MCG016,ATHERTON PROBATION OFFICE,ATHERTON PROBATION OFFICE,COMM,Y
+ALPHA,Alpha Hospital,Alpha Hospital,HSHOSP,Y
+NHS016,Mansfield  Prolific Offender Unit,Mansfield  Prolific Offender Unit,COMM,Y
+LDM114,Acton Probation Office,Acton Probation Office,COMM,Y
+DRSAP2,The Pines Bail and Probation Hostel,The Pines Bail and Probation Hostel,APPR,Y
+EALING,"Addison Ward, Ealing Hospital","Addison Ward, Ealing Hospital",HSHOSP,Y
+LDM075,Waltham Forest PO,Waltham Forest PO,COMM,Y
+BODMIN,Bodmin Hospital,Bodmin Hospital,HSHOSP,Y
+MRS022,South Sefton MC Liaison Unit,South Sefton MC Liaison Unit,COMM,Y
+YSN009,Selby Probation Office,Selby Probation Office,COMM,Y
+CONTYH,County Hospital,County Hospital,HSHOSP,Y
+LDM135,Lansdowne Road Probation Office,Lansdowne Road Probation Office,COMM,Y
+STF047,NEWCASTLE-UNDER-LYME YOT,NEWCASTLE-UNDER-LYME YOT,YOT,Y
+STMART,St Martin's Hospital,St Martin's Hospital,HSHOSP,Y
+ROWAN,Rowan House,Rowan House,HSHOSP,Y
+SFK002,West Suffolk Probation Centre,West Suffolk Probation Centre,COMM,Y
+HBS012,Scunthorpe Probation Office,Scunthorpe Probation Office,COMM,Y
+KNTY06,Tonbridge YOT,Tonbridge YOT,YOT,Y
+ESXAP1,Basildon Probation Hostel,Basildon Probation Hostel,APPR,Y
+MCG021,Bolton Mags Court Probation Office,Bolton Mags Court Probation Office,COMM,Y
+MARLBR,Marlborough House Regional Secure Unit,Marlborough House Regional Secure Unit,HSHOSP,Y
+HFS002,North Herts Probation Centre,North Herts Probation Centre,COMM,Y
+LDM048,Marsham Street,Marsham Street,COMM,Y
+TESY03,Stockton YOT,Stockton YOT,YOT,Y
+LNS010,Gainsborough Probation Office,Gainsborough Probation Office,COMM,Y
+HPS002,The Grange Approved Premises,The Grange Approved Premises,APPR,Y
+STF030,Bucknall DRR Unit,Bucknall DRR Unit,COMM,Y
+COACD,Court Of Appeal Criminal Division,Court Of Appeal Criminal Division,CRT,Y
+CMART,Courts Martial,Courts Martial,CRT,Y
+GUERNS,Guernsey Courts,Guernsey Courts,CRT,Y
+LORDS,House Of Lords (Appeals),House Of Lords (Appeals),CRT,Y
+IMM,Immigration,Immigration,CRT,Y
+IOM,Isle Of Man Courts,Isle Of Man Courts,CRT,Y
+JERSEY,Jersey Courts,Jersey Courts,CRT,Y
+NA,Court Not Yet Allocated,Court Not Yet Allocated,CRT,N
+ASSIZE,Quarter Session/Assizes,Quarter Session/Assizes,CRT,Y
+RCJ,Royal Courts Of Justice,Royal Courts Of Justice,CRT,Y
+FORGN,Repatriated To This Country,Repatriated To This Country,CRT,Y
+ANI,ALDINGTON (HMP),HMP ALDINGTON,INST,N
+CEI,CLELAND (HMP),HMP CLELAND,INST,N
+NOI,NORTHEYE (HMP),HMP NORTHEYE,INST,N
+PCI,PUCKLECHURCH (HMRC),HMRC PUCKLECHURCH,INST,N
+FII,FINNAMORE (HMYOI),HMYOI FINNAMORE,INST,N
+SPI,SPRING HILL (HMP),HMP SPRING HILL,INST,Y
+CPI,CAMPSFIELD HOUSE (HMYOI),HMYOI CAMPSFIELD HOUSE,INST,N
+OXI,OXFORD (HMP),HMP OXFORD,INST,N
+RLI,ROLLESTONE (HMP),HMP ROLLESTONE,INST,N
+CRI,COLCHESTER (HMYOI),HMYOI COLCHESTER,INST,N
+UNKNCT,Court Not Known,Court Not Known,CRT,Y
+FRMILE,Fairmile Hospital,Fairmile Hospital,HSHOSP,Y
+CHSAP1,Linden Bank Approved Premises,Linden Bank Approved Premises,APPR,Y
+LTS002,Coalville Probation Office,Coalville Probation Office,COMM,Y
+DCP016,Newquay Reporting Office,Newquay Reporting Office,COMM,Y
+LTS014,Leicester CJDT Nelson Street,Leicester Criminal Justice Drugs Team Nelson Street,COMM,Y
+MCG068,The Edge,The Edge,COMM,Y
+HBS001,Beverley HLNY CRC,Beverley HLNY CRC,COMM,Y
+STDAVD,St David's,St David's,HSHOSP,Y
+STF009,Stafford Probation Office,Stafford Probation Office,COMM,Y
+WSN012,Flint Probation Office,Flint Probation Office,COMM,Y
+GCS001,Gloucestershire Head Office,Gloucestershire Head Office,COMM,Y
+LDM038,Cambridge Heath Road,Cambridge Heath Road,COMM,Y
+LNSY02,Lincolnshire YOT South,Lincolnshire YOT South,YOT,Y
+DPP008,Brecon Probation Office,Brecon Probation Office,COMM,Y
+DRS010,CADAS Dorchester,CADAS Dorchester,COMM,Y
+MLWY09,Halescroft YOT,Halescroft YOT,YOT,Y
+MLW014,Dudley ECP Unit,Dudley Enhanced Community Punishment Unit,COMM,Y
+STJAMS,St James Hospital (Portsmouth),St James Hospital (Portsmouth),HSHOSP,Y
+LCS014,NELSON Probation Office,NELSON Probation Office,COMM,Y
+NHS012,"Nottingham Probation Office, Castle Quay","Nottingham Probation Office & Substance Misuse Team, Castle Quay",COMM,Y
+HBS019,Grimsby PPO,Grimsby PPO,COMM,Y
+MRS013,Knowsley/St. Helens CP Office,Knowsley/St. Helens CP Office,COMM,Y
+YSWAP4,Westgate Approved Premises,Westgate Approved Premises,APPR,Y
+KNTAP1,Fleming House Probation & Bail Hostel,Fleming House Probation & Bail Hostel,APPR,Y
+ZZGHI,GHOST HOLDING ESTABLISHMENT,GHOST HOLDING ESTABLISHMENT - DO NOT USE,INST,N
+LDM142,Wembley Probation Office,Wembley Probation Office,COMM,Y
+WSNY02,Bangor YOT,Bangor YOT,YOT,Y
+SFKAP2,The Cottage Approved Premises,The Cottage Approved Premises,APPR,Y
+THA053,Banbury MC,North Oxfordshire Magistrates Court,CRT,Y
+CHSAP2,Bunbury House Approved Premises,Bunbury House Approved Premises,APPR,Y
+STF006,Lichfield Unpaid Work Office,Lichfield Unpaid Work Office,COMM,Y
+STGEOR,St George's Hospital (Morpeth),St George's Hospital (Morpeth),HSHOSP,Y
+RAVNSW,Ravenswood House Medium Secure Unit,Ravenswood House Medium Secure Unit,HSHOSP,Y
+FLORNT,Florence Nightingale Clinic (Chelsea),Florence Nightingale Clinic (Chelsea),HSHOSP,Y
+MRS016,Old Roan,Old Roan,COMM,Y
+STF022,Tamworth Probation Centre,Tamworth Probation Centre,COMM,Y
+ASP006,Weston-super-Mare Probation Centre,Weston-super-Mare Probation Centre,COMM,Y
+HFS005,St Albans Crown Court Probation Office,St Albans Crown Court Probation Office,COMM,Y
+ESX008,Basildon Crown Court Liaison Unit,Basildon Crown Court Liaison Unit,COMM,Y
+TREVOR,Trevor Gibbens Unit,Trevor Gibbens Unit,HSHOSP,Y
+WWSY02,Rugby YOT,Rugby YOT,YOT,Y
+ARDEN,Arden Leigh MSU,Arden Leigh MSU,HSHOSP,Y
+EXTLOC,External Location,External Location,COMM,Y
+MRS059,Sefton PPO Unit,Sefton PPO Unit,COMM,Y
+BDS010,Luton MC Liaison Office,Luton MC Liaison Office,COMM,Y
+TES007,South Bank Middlesborough Prob Centre,South Bank Middlesborough Prob Centre,COMM,Y
+NBR022,Southwick Probation Office,Southwick Probation Office,COMM,Y
+ASP003,"Knowle Park, Bristol Probation Centre","Knowle Park, Bristol Probation Centre",COMM,Y
+RESDIE,Reaside Clinic,Reaside Clinic,HSHOSP,Y
+HPSVLU,Winchester Probation Office,Winchester Probation Office,COMM,Y
+NBRY01,Northumberland YOT,Northumberland YOT,YOT,Y
+YSS004,"Pitsmoor, Sheffield","Pitsmoor, Sheffield",COMM,Y
+SFK006,Lowestoft Probation Office,Lowestoft Probation Office,COMM,Y
+NASBER,Naseberry Court,Naseberry Court,HSHOSP,Y
+LDM037,Ellison House,Ellison House,COMM,Y
+HPS016,Southampton London Road Probation Office,Southampton London Road Probation Office,COMM,Y
+STF039,Chase Prolific Offenders & Stafford PO,Chase Prolific Offenders Unit & Stafford Probation Office,COMM,Y
+MCG053,Wilton Place Approved Premises,Wilton Place Approved Premises,APPR,Y
+MRS025,Merseyside Development Unit,Merseyside Development Unit,COMM,Y
+BDS012,Bedford Probation Hostel,Bedford Probation Hostel,APPR,Y
+CHERRY,Cherry Knowle Hospital,Cherry Knowle Hospital,HSHOSP,Y
+LDM138,Seafield Lodge Probation Hostel,Seafield Lodge Probation Hostel,APPR,Y
+WDLAND,Woodlands Hospital,Woodlands Hospital,HSHOSP,Y
+SWS002,Merthyr Tydfil Probation Office,Merthyr Tydfil Probation Office,COMM,Y
+ASP013,Taunton Crown Court Liaison Unit,Taunton Crown Court Liaison Unit,COMM,Y
+CALNWD,Calnwood Court,Calnwood Court,HSHOSP,Y
+LTS008,Melton Mowbray Probation Office,Melton Mowbray Probation Office,COMM,Y
+HBS005,GRIMSBY Probation Office,GRIMSBY Probation Office,COMM,Y
+GCS010,Gloucestershire Reintegration Service,Gloucestershire Reintegration Service,COMM,N
+TES010,Stockton on Tees Probation Centre,Stockton on Tees Probation Centre,COMM,Y
+SWSY03,Neath Port Talbot YOT,Neath Port Talbot YOT,YOT,Y
+EBORNE,Eastbourne District General Hospital,Eastbourne District General Hospital,HSHOSP,Y
+YSS010,Sheffield Crown Court,Sheffield Crown Court,COMM,Y
+WSN002,Bangor Probation Office,Bangor Probation Office,COMM,Y
+MEABRK,Meadowbrook Hospital,Meadowbrook Hospital,HSHOSP,Y
+CHWICK,Chadwick Lodge,Chadwick Lodge,HSHOSP,Y
+THA025,Newbury Probation Office,Newbury Probation Office,COMM,Y
+GCS011,MAPPA Public Protection Office,MAPPA Public Protection Office,COMM,Y
+LDM118,Ealing Hostel,Ealing Hostel,APPR,Y
+CHSY01,Crewe YOT,Crewe YOT,YOT,Y
+GWT005,NEWPORT Community Punishment Unit,NEWPORT Community Punishment Unit,COMM,Y
+STF014,Leek Probation Office,Leek Probation Office,COMM,Y
+LTLEMR,Littlemore Hospital,Littlemore Hospital,HSHOSP,Y
+BDS009,Crown Court Liaison Office,Crown Court Liaison Office,COMM,Y
+MRSAP3,Southwood Probation Hostel,Southwood Probation Hostel,APPR,Y
+LDM096,Bromley Mags Court Probation Office,Bromley Mags Court Probation Office,COMM,Y
+WITTON,Withington Hospital,Withington Hospital,HSHOSP,Y
+ASPY03,Filton YOT,Filton YOT,COMM,Y
+DBS002,Derbyshire Area Training Unit,Derbyshire Area Training Unit,COMM,Y
+LYNFED,NHS LYNFIELD MOUNT HOSPITAL,NHS LYNFIELD MOUNT HOSPITAL,HSHOSP,Y
+SCCLNC,Scott  Clinic,Scott  Clinic,HSHOSP,Y
+LDM082,Prob Off Redbridge Mags Crt(Barkingside),Prob Off Redbridge Mags Crt(Barkingside),COMM,Y
+DCP002,Camborne Probation Office,Camborne Probation Office,COMM,Y
+YSN006,Northallerton Probation Office,Northallerton Probation Office,COMM,Y
+GCSY01,Gloucester YOT,Gloucester YOT,YOT,Y
+SEYMUR,"Seymour Clinic,","Seymour Clinic,",HSHOSP,Y
+HPSY03,Wessex YOT (SE and Portsmouth City),Wessex YOT (SE and Portsmouth City),YOT,Y
+DBSY01,Derby YOT,Derby YOT,YOT,Y
+DCP001,Devon & Cornwall Head Office,Devon & Cornwall Head Office,COMM,Y
+MRS014,Kirkby Probation Centre,Kirkby Probation Centre,COMM,Y
+MRS008,South Liverpool Probation Centre,South Liverpool Probation Centre,COMM,Y
+KNTY01,East Kent YOT,East Kent YOT,YOT,Y
+DBS008,Derby Probation Centre,Derby Probation Centre,COMM,N
+SHWKYC,South Warwickshire Youth Court,South Warwickshire Youth Court,CRT,Y
+DBS009,Glossop Probation Office,Glossop Probation Office,COMM,Y
+HBSY02,East Yorkshire YOT,East Yorkshire YOT,YOT,Y
+MLW030,Walsall Probation Complex,Walsall Probation Complex,COMM,Y
+DCP003,Liskeard Probation Office,Liskeard Probation Office,COMM,Y
+LDM012,Seymour Place,Seymour Place,COMM,Y
+CMB005,KENDAL Probation Office,KENDAL Probation Office,COMM,Y
+MRINFM,Manchester Royal Infirmary,Manchester Royal Infirmary,HSHOSP,Y
+MCG043,Rochdale Mags Court Probation Office,Rochdale Mags Court Probation Office,COMM,Y
+NBR036,Sunderland Mags Court Probation Office,Sunderland Mags Court Probation Office,COMM,Y
+WMP004,Redditch Probation Office,Redditch Probation Office,COMM,Y
+DCP012,Torquay Probation Office - Abbey Road,Torquay Probation Office - Abbey Road,COMM,Y
+SKEN,South Kensington and Chelsea MH Centre,South Kensington and Chelsea MH Centre,HSHOSP,Y
+MLW001,West Midlands Head Office,West Midlands Head Office,COMM,Y
+NORVIC,NORTH SIDE HOUSE,NORTH SIDE HOUSE,HSHOSP,Y
+BLACKB,Blackberry Hill Hospital,Blackberry Hill Hospital,HSHOSP,Y
+NBR012,Newcastle Sexual Behaviour Unit,Newcastle Sexual Behaviour Unit,COMM,Y
+LCS002,ACCRINGTON Probation Office,ACCRINGTON Probation Office,COMM,Y
+HBS003,BRIDLINGTON Probation Office,BRIDLINGTON Probation Office,COMM,Y
+MLW043,Warley Court,Warley Court,COMM,Y
+WATFRD,Watford General Hospital (Shrodells),Watford General Hospital (Shrodells),HSHOSP,Y
+SPARK,Southpark Lodge,Southpark Lodge,HSHOSP,Y
+RGLAM,Royal Glamorgan Hospital,Royal Glamorgan Hospital,HSHOSP,Y
+WSUITE,Willow Suite ICU,Willow Suite ICU,HSHOSP,Y
+LNS008,Boston Carlton Road Probation Office,Boston Carlton Road Probation Office,COMM,Y
+MCG060,PPU / Visor Unit,PPU / Visor Unit,COMM,Y
+LTS013,Leicester MAPPP Office,Leicester MAPPP Office,COMM,Y
+LNSAP1,Wordsworth House Approved Premises,Wordsworth House Approved Premises,APPR,Y
+TES009,Middlesbrough Community Punishment Unit,Middlesbrough Community Punishment Unit,COMM,Y
+CHS011,CDRP Unit - Probation presence,CDRP Unit - Probation presence,COMM,Y
+KNT008,Kent Community Service Office,Kent Community Service Office,COMM,Y
+WMP007,Accredited Programmes (North),Accredited Programmes (North),COMM,Y
+GUYHOS,Guy's Hospital,Guy's Hospital,HSHOSP,Y
+DPP003,Carmarthen Probation Office,Carmarthen Probation Office,COMM,Y
+LCSAP2,Haworth House Approved Premsies,Haworth House Approved Premsies,APPR,Y
+HPS029,Lymington Probation Office,Lymington Probation Office,COMM,Y
+WTS004,Swindon Progs and Community Service Unit,Swindon Progs and Community Service Unit,COMM,Y
+NHSY02,Nottinghamshire County North YOT,Nottinghamshire County North YOT,YOT,Y
+LCS019,BURNLEY CC Liaison Unit,BURNLEY CC Liaison Unit,COMM,Y
+STF048,LICHFIELD YOT,LICHFIELD YOT,YOT,Y
+YSW010,Leeds West Probation Office,Leeds West Probation Office,COMM,Y
+MLW029,Solihull MC Liaison Unit,Solihull MC Liaison Unit,COMM,Y
+LDM120,Ealing Probation Office,Ealing Probation Office,COMM,Y
+TYWLYN,Ty Llywelyn Medium Secure Unit,Ty Llywelyn Medium Secure Unit,HSHOSP,Y
+MCG018,Ascot House,Ascot House,APPR,Y
+MLW039,Wednesfield Police Station,Wednesfield Police Station,COMM,Y
+YSS012,"Eastern Ave, Sheffield","Eastern Ave, Sheffield",COMM,Y
+GCS012,Drug Intervention Project,Drug Intervention Project,COMM,Y
+MRSY07,Sefton YOT,Sefton YOT,YOT,Y
+DRHY01,Co Durham East Area YOT,Co Durham East Area YOT,YOT,Y
+SWS007,Cardiff MC Liaison Unit,Cardiff MC Liaison Unit,COMM,Y
+LCS018,Human Resources Team & Staff Development,Human Resources Team & Staff Development,COMM,Y
+NBR009,North Of Tyne Operations Unit,North Of Tyne Operations Unit,COMM,Y
+DCP017,Bodmin Reporting Office,Bodmin Reporting Office,COMM,Y
+ASPY02,Bristol YOT,Bristol YOT,COMM,Y
+MRSAP1,Canning House Probation Hostel,Canning House Probation Hostel,APPR,N
+HBSY04,Grimsby YOT,Grimsby YOT,YOT,Y
+NHS019,NACRO Notts Accomodation Project,NACRO Basford House Accomodation Project,APPR,Y
+ASP002,Bath Probation Centre,Bath Probation Centre,COMM,Y
+DBS006,Derby Probation Office,Derby Probation Office,COMM,N
+STF049,STAFFORD YOT,STAFFORD YOT,YOT,Y
+MELBRY,Melbury Lodge,Melbury Lodge,HSHOSP,Y
+STMRYL,St Mary's Hospital (London),St Mary's Hospital (London),HSHOSP,Y
+LNS006,Spalding Probation Office,Spalding Probation Office,COMM,Y
+YSN005,Skipton Probation Office,Skipton Probation Office,COMM,Y
+LDM095,Croydon Magistrates Court,Croydon Magistrates Court,COMM,Y
+LDM139,Southall Probation Office,Southall Probation Office,COMM,Y
+SEVRLS,Severalls Hospital,Severalls Hospital,HSHOSP,Y
+YSS021,"GPD Masborough St, Rotherham","GPD Masborough St, Rotherham",COMM,Y
+LDM018,Reed House Probation Office,Reed House Probation Office,COMM,Y
+MCG037,Manchester Magistrates Probation Office,Manchester Magistrates Probation Office,COMM,Y
+NBRY04,Gateshead YOT,Gateshead YOT,YOT,Y
+GWT001,GWENT Head Office,GWENT Head Office,COMM,Y
+THEDEN,The Dene,The Dene,HSHOSP,Y
+MLW036,Joint Public Protection Unit,Joint Public Protection Unit,COMM,Y
+TES004,Middlesbrough Practioner Training Unit,Middlesbrough Practioner Training Unit,COMM,Y
+YSN012,Westborough,Westborough,COMM,N
+LANDON,Langdon Hospital,Langdon Hospital,HSHOSP,Y
+SEDGLY,Sedgley House,Sedgley House,HSHOSP,Y
+ASPY05,Weston-super-Mare YOT,Weston-super-Mare YOT,COMM,Y
+HNTROE,Huntercombe (Roehampton),Huntercombe (Roehampton),HSHOSP,Y
+DCP015,Public Protection Unit,Public Protection Unit,COMM,Y
+LDM053,"Probation Office, CCC Old Bailey","Probation Office, CCC Old Bailey",COMM,Y
+LDM017,Camden House,Camden House,COMM,Y
+DRS001,Dorset Head Office,Dorset Head Office,COMM,Y
+MRS054,Sefton DRR,Sefton DRR,COMM,Y
+LCS015,Preston Probation Office,Preston Probation Office,COMM,Y
+STF003,Hanley Crown & Mags Courts Liaison Unit,Hanley Crown & Magistrates Courts Liaison Unit,COMM,Y
+HUNTLE,Huntley Centre,Huntley Centre,HSHOSP,Y
+HMRTON,Homerton Hospital,Homerton Hospital,HSHOSP,Y
+HLLVEW,Hillview Lodge,Hillview Lodge,HSHOSP,Y
+MRS021,Wirral Probation Centre,Wirral Probation Centre,COMM,Y
+LDM170,Valentine House,Valentine House,COMM,Y
+PROYAL,Park Royal Centre for Mental Health,Park Royal Centre for Mental Health,HSHOSP,Y
+LDM092,Beckenham Probation Office,Beckenham Probation Office,COMM,Y
+HAMRSM,Hammersmith and Fulham Ment. Health Unit,Hammersmith and Fulham Mental Health Unit,HSHOSP,Y
+SSX021,Hastings Mags Crt Probation Office,Hastings Magistrates Court Probation Office,COMM,Y
+LDM145,Greenwich & Bexley DTTO,Greenwich & Bexley DTTO,COMM,Y
+STF010,Stafford Crown Court Liaison Unit,Stafford Crown Court Liaison Unit,COMM,Y
+DUR009,NEWTON AYCLIFFE Probation Office,NEWTON AYCLIFFE Probation Office,COMM,Y
+ASP004,Bristol Probation Centre,Bristol Probation Centre,COMM,Y
+SWSY06,Vale YOT,Vale YOT,YOT,Y
+NTS010,Northampton CC Liaison Unit,Northampton CC Liaison Unit,COMM,N
+STCLML,St Clements (London),St Clements (London),HSHOSP,Y
+LTS012,Leicester CC Liaison Unit,Leicester CC Liaison Unit,COMM,Y
+GWT007,PONTYPOOL Probation Centre,PONTYPOOL Probation Centre,COMM,Y
+LCSY07,Lancaster YOT,Lancaster YOT,YOT,Y
+LDM106,Kew Probation and Bail Hostel,Kew Probation and Bail Hostel,APPR,Y
+NHSY04,Nottinghamshire County South YOT,Nottinghamshire County South YOT,YOT,Y
+GORDON,Gordon Hospital,Gordon Hospital,HSHOSP,Y
+GLNBRN,Glenbourne Unit,Glenbourne Unit,HSHOSP,Y
+TES002,Hartlepool Probation Centre,Hartlepool Probation Centre,COMM,Y
+MLWY06,Wolverhampton YOT,Wolverhampton YOT,YOT,Y
+LDM111,Sutton Mags Crt Probation Office,Sutton Mags Crt Probation Office,COMM,Y
+BEDY03,Woburn Road Youth Offending Service,Woburn Road Youth Offending Service,YOT,Y
+JHWARD,"John Howard Centre, Hackney MSU","John Howard Centre, Hackney MSU",HSHOSP,Y
+CBS003,Ely Probation Office,Ely Probation Office,COMM,Y
+THA047,Slough Probation Office,Slough Probation Office,COMM,Y
+GARLND,"Garlands Hospital, Cumbria","Garlands Hospital, Cumbria",HSHOSP,Y
+TMSIDE,Tameside Hospital,Tameside Hospital,HSHOSP,Y
+ASP010,Wells Probation Centre,Wells Probation Centre,COMM,Y
+GARDNR,Gardener Unit,Gardener Unit,HSHOSP,Y
+QABETH,Queen Elizabeth Hospital,Queen Elizabeth Hospital,HSHOSP,Y
+SSX007,Crawley Probation Office,Crawley Probation Office,COMM,Y
+CMB011,Cumbria DAT West,Cumbria DAT West,COMM,Y
+NHS001,Nottinghamshire Head Office,Nottinghamshire Head Office,COMM,Y
+HUMBER,Humber Centre for Forensic Psychiatry,Humber Centre for Forensic Psychiatry,HSHOSP,Y
+ASP020,Weston-super-Mare Prolific Off Unit,Weston-super-Mare Prolific Offender Unit,COMM,Y
+MCG061,Atherton MDO,Atherton MDO,COMM,Y
+MCG044,Bolton Probation Office,Bolton Probation Office,COMM,Y
+WSN013,Colwyn Bay Probation Office,Colwyn Bay Probation Office,COMM,Y
+CBS009,Cambridgeshire MAPPP Unit,Cambridgeshire MAPPP Unit,COMM,Y
+WSNY04,Colwyn Bay YOT,Colwyn Bay YOT,YOT,Y
+WTS006,TROWBRIDGE Probation Centre,TROWBRIDGE Probation Centre,COMM,Y
+WSNY03,Wrexham YOT,Wrexham YOT,YOT,Y
+MRS017,North Sefton MC Liaison Unit,North Sefton MC Liaison Unit,COMM,Y
+LDM089,Beckenham Hostel,Beckenham Hostel,APPR,Y
+CHS003,Macclesfield Probation Office,Macclesfield Probation Office,COMM,Y
+ERICS,The Eric Shepherd Unit,The Eric Shepherd Unit,HSHOSP,Y
+NBRAP1,Pennywell House Approved Premises,Pennywell House Approved Premises,APPR,Y
+DRS009,Weymouth Probation Centre,Weymouth Probation Centre,COMM,Y
+LDM133,"Probation Office, Isleworth Crown Court","Probation Office, Isleworth Crown Court",COMM,Y
+ASPAP4,Glogan House Approved Premsies,Glogan House Approved Premsies,APPR,Y
+LTSY01,Leicester YOT,Leicester YOT,YOT,Y
+BDS011,Luton Probation Hostel,Luton Probation Hostel,APPR,Y
+HPS032,Andover Probation Office,Andover Probation Office,COMM,Y
+LDM036,Englefield Road,Englefield Road,COMM,N
+YSW012,LEEDS MAGISTRATES COURT Liaison Unit,LEEDS MAGISTRATES COURT Liaison Unit,COMM,Y
+THA030,Elizabth Fry VAP,Elizabth Fry VAP,APPR,Y
+DCPAP1,Lawson House Approved Premises,Lawson House Approved Premises,APPR,Y
+SSX023,Hastings Probation Office,Hastings Probation Office,COMM,Y
+SMEADH,Southmead Hospital,Southmead Hospital,HSHOSP,Y
+RATHBN,Rathbone Hospital,Rathbone Hospital,HSHOSP,Y
+NBR002,Alnwick Probation Office,Alnwick Probation Office,COMM,Y
+STF028,Staffordshire Probation Head Office,Staffordshire Probation Head Office,COMM,Y
+BDS001,Bedford Head Office,Bedford Head Office,COMM,Y
+MLWAP6,Stonnall Road Approved Premises,Stonnall Road Approved Premises,APPR,Y
+HPS010,Landguard Road Approved Premises,Landguard Road Approved Premises,APPR,Y
+NBR034,North Tyneside Mags Court Probation Off,North Tyneside Mags Court Probation Off,COMM,Y
+LDM085,Snaresbrook Crown Crt Probation Office,Snaresbrook Crown Crt Probation Office,COMM,Y
+RFREE,Royal Free Hospital,Royal Free Hospital,HSHOSP,Y
+GCS007,GLOUCESTER  CC Liaison Unit,GLOUCESTER  CC Liaison Unit,COMM,Y
+MCG048,Trafford Magistrates Court Probation Off,Trafford Magistrates Court Probation Off,COMM,Y
+LCS017,Skelmersdale Probation Office,Skelmersdale Probation Office,COMM,Y
+HFS001,Hertfordshire Head Office,Hertfordshire Head Office,COMM,Y
+CBS005,Cambridgeshire Support Services Unit,Cambridgeshire Support Services Unit,COMM,Y
+PRNCSA,Princess Alexandra Hospital,Princess Alexandra Hospital,HSHOSP,Y
+MLW037,Birmingham Court,Birmingham Court,COMM,Y
+FRMSDE,Fromeside Clinic,Fromeside Clinic,HSHOSP,Y
+MACGEN,Macclesfield District General Hospital,Macclesfield District General Hospital,HSHOSP,Y
+LDM076,Barking and Dagenham Mags Crt Prob Off,Barking and Dagenham Mags Crt Prob Off,COMM,Y
+CASTLE,Castle Hill Unit,Castle Hill Unit,HSHOSP,Y
+MLW040,West Bromwich Police Station,West Bromwich Police Station,COMM,Y
+SWS009,Swansea Probation Office,Swansea Probation Office,COMM,Y
+THA005,Aylesbury Mags Court Probation Office,Aylesbury Mags Court Probation Office,COMM,Y
+MRS060,Knowsley PPO Unit,Knowsley PPO Unit,COMM,Y
+DBS016,Community Punishment Office,Community Punishment Office,COMM,Y
+MRS006,Speke Probation Office,Speke Probation Office,COMM,Y
+HPS017,Isle of Wight Probation Office,Isle of Wight Probation Office,COMM,N
+CMBY03,Cumbria YOT South Division,Cumbria YOT South Division,YOT,Y
+YSS007,"Bennetthorpe, Doncaster","Bennetthorpe, Doncaster",COMM,Y
+DRSAP1,Weston Probation Hostel,Weston Probation Hostel,APPR,Y
+GRYLNG,Graylingwell Hospital,Graylingwell Hospital,HSHOSP,Y
+NEWSAM,The Newsome Centre,The Newsome Centre,HSHOSP,Y
+RUNWEL,Runwell Regional Secure Unit,Runwell Regional Secure Unit,HSHOSP,Y
+MRSY02,Knowsley YOT,Knowsley YOT,YOT,Y
+STMRYN,St Mary's Hospital (IoW),St Mary's Hospital (IoW),HSHOSP,Y
+NTS019,Rose Project - Albion House,Rose Project - Albion House Police Building,COMM,Y
+LDM046,Canadian Avenue,Canadian Avenue,COMM,Y
+MLW033,Dudley Admin Unit,Dudley Admin Unit,COMM,Y
+HPS005,Aldershot Probation Office,Aldershot Probation Office,COMM,Y
+SSX018,Eastbourne Probation Office,Eastbourne Probation Office,COMM,Y
+STF041,Trent Valley Prolific Offenders Unit,Trent Valley Prolific Offenders Unit,COMM,Y
+MCG007,Stockport Probation Office,Stockport Probation Office,COMM,Y
+DPP001,Dyfed-Powys Head Office,Dyfed-Powys Head Office,COMM,Y
+MLWAP5,Jackie Harriett House Approved Premises,Jackie Harriett House Approved Premises,APPR,Y
+NBR013,Newcastle Probation Office,Newcastle West Probation Office,COMM,Y
+KSWRTH,Kneesworth House,Kneesworth House,HSHOSP,Y
+MYDENB,Mary Dendy Unit,Mary Dendy Unit,HSHOSP,Y
+MCG050,Varley Street Probation Office,Varley Street Probation Office,COMM,Y
+HPS050,Southampton Town Quay Probation Office,Southampton Town Quay Probation Office,COMM,Y
+WMP009,Shrewsbury Crown Court Probation Office,Shrewsbury Crown Court Probation Office,COMM,Y
+SWS004,Cardiff Community Service Centre,Cardiff Community Service Centre,COMM,Y
+MCG017,Moss Side Probation Office,Moss Side Probation Office,COMM,Y
+LNDCTR,The Linden Centre,The Linden Centre,HSHOSP,Y
+MLWAP7,Sycamore Lodge Approved Premises,Sycamore Lodge Approved Premises,APPR,Y
+AMERSH,Amersham General,Amersham General,HSHOSP,Y
+MRSY03,St Helens YOT,St Helens YOT,YOT,Y
+LDM104,High Path,High Path,COMM,Y
+YSWAP2,ELM BANK Approved Premises,ELM BANK Approved Premises,APPR,Y
+LNS004,Lincoln MC Liaison Probation Unit,Lincoln MC Liaison Probation Unit,COMM,Y
+STARDH,Stoddard House,Stoddard House,HSHOSP,Y
+THORS,Thors Park,Thors Park,HSHOSP,Y
+LDM049,East Hill Probation Office,East Hill Probation Office,COMM,Y
+WMPAP1,Braley House Approved Premises,Braley House Approved Premises,APPR,Y
+REDFRD,Redford Lodge Psychiatric Hospital,Redford Lodge Psychiatric Hospital,HSHOSP,Y
+KNT001,Kent Area Office,Kent Area Office,COMM,Y
+TES005,Middlesbrough Crt Sers and Pub Prob Unit,Middlesbrough Crt Sers and Pub Protn Unit,COMM,Y
+KNT009,Folkestone Probation Office,Folkestone Probation Office,COMM,Y
+HGHYDS,High Royds,High Royds,HSHOSP,Y
+MLW007,Handsworth Probation Office,Handsworth Probation Office,COMM,Y
+NFKAP1,John Boag House Approved Premises,John Boag House Approved Premises,APPR,Y
+CLIFHO,Clifton House,Clifton House,HSHOSP,Y
+LDM043,53 Holloway Road,53 Holloway Road,COMM,Y
+MCG023,Bury Magistrates Court Probation Office,Bury Magistrates Court Probation Office,COMM,Y
+WMP010,Kidderminster Probation Office,Kidderminster Probation Office,COMM,Y
+LDM021,Kimpton Road,Kimpton Road,COMM,Y
+LDM042,Mornington Grove,Mornington Grove,COMM,Y
+HTHRTN,Hatherton Centre,Hatherton Centre,HSHOSP,Y
+DCP005,St Austell Probation Office,St Austell Probation Office,COMM,Y
+LDM016,Askew Road Probation Office,Askew Road Probation Office,COMM,Y
+LDM002,Southwark Crown Court Probation Office,Southwark Crown Court Probation Office,COMM,Y
+KNTY03,Mid Kent YOT,Mid Kent YOT,YOT,Y
+WSNAP2,Ty Newydd,Ty Newydd,APPR,Y
+HERLDG,Heron Lodge,Heron Lodge,HSHOSP,Y
+LCSY08,Preston YOT,Preston YOT,YOT,Y
+MLWAP3,Crowley House Approved Premises,Crowley House Approved Premises,APPR,Y
+CHEADL,Cheadle Royal Hospital,Cheadle Royal Hospital,HSHOSP,Y
+LDM074,Westbourne House Hostel,Westbourne House Hostel,APPR,Y
+LDM132,Hounslow Probation Office,Hounslow Probation Office,COMM,Y
+MLW010,Perry Bar Probation Centre,Perry Bar Probation Centre,COMM,Y
+THA021,Abingdon Probation Office,Abingdon Probation Office,COMM,Y
+BROADM,Broadmoor Hospital,Broadmoor Hospital,HSHOSP,Y
+MLW015,Dudley Probation Centre,Dudley Probation Centre,COMM,Y
+CBS001,Cambridgeshire  Head Office,Cambridgeshire  Head Office,COMM,Y
+DCP010,Torquay Probation Office - Thurlow Road,Torquay Probation Office - Thurlow Road,COMM,Y
+NBR032,Houghton-Le-Spring Mags Court Prob Off,Houghton-Le-Spring Mags Court Prob Off,COMM,Y
+CHLSEA,Chelsea & Westminster Hosp,Chelsea & Westminster Hosp,HSHOSP,Y
+LDM086,Olympic House,Olympic House,COMM,N
+DRS008,Wareham Community Service Office,Wareham Community Service Office,COMM,Y
+SSX006,Horsham Probation Office,Horsham Probation Office,COMM,Y
+MCG006,Rochdale Probation Office,Rochdale Probation Office,COMM,Y
+LDM058,Greenwich Magistrates Court,Greenwich Magistrates Court,COMM,Y
+NHS017,Worksop Prolific Offender Unit,Worksop Prolific Offender Unit,COMM,Y
+NEWBGE,Newbridge House,Newbridge House,HSHOSP,Y
+MRSY01,Liverpool YOT Court Services,Liverpool YOT Court Services,YOT,Y
+NTS017,Kettering Probation Office,Kettering Probation Office,COMM,Y
+MRS026,Wirral DRR,Wirral DRR,COMM,Y
+DNGATE,Doncaster Gate Hospital,Doncaster Gate Hospital,HSHOSP,Y
+LDM008,Latchmere Road,Latchmere Road,COMM,Y
+NBR038,PPO Unit,PPO Unit,COMM,Y
+NTS013,Wellingborough Probation Office,Wellingborough Probation Office,COMM,Y
+SSX019,Hove Crown Court Liaison Unit,Hove Crown Court Liaison Unit,COMM,Y
+STYDFL,St Tydfil's (Merthyr Tydfil),St Tydfil's (Merthyr Tydfil),HSHOSP,Y
+SSX025,Crawley Mags Crt Probation Office,Crawley Magistrates Court Probation Office,COMM,Y
+MLW025,Wolverhampton MC Liaison Unit,Wolverhampton MC Liaison Unit,COMM,Y
+STF040,Stoke Prolific Offenders Unit,Stoke Prolific Offenders Unit,COMM,Y
+MCG019,Bolton CC Liaison Unit,Bolton CC Liaison Unit,COMM,Y
+CHS010,Ashley House,Ashley House,COMM,Y
+ESX004,Colchester Probation Office,Colchester Probation Office,COMM,Y
+NHWKMC,North Warwickshire MC,North Warwickshire Magistrates Court,CRT,Y
+TESAP1,Linthorpe Probation Hostel,Linthorpe Probation Hostel,APPR,Y
+HPS044,Southampton Magistrates Court (Prob),Southampton Magistrates Court (Probation),COMM,Y
+ESURRY,East Surrey Hospital,East Surrey Hospital,HSHOSP,Y
+MCG056,Middleton Probation Office,Middleton Probation Office,COMM,Y
+MLWY10,Washwood Heath YOT,Washwood Heath YOT,YOT,Y
+SWSY02,Merthyr Tydfil YOT,Merthyr Tydfil YOT,YOT,Y
+NBR030,SE Northumberland Mags Crt Probation Off,SE Northumberland Mags Crt Probation Off,COMM,Y
+NBR011,Jarrow Probation Office,Jarrow Probation Office,COMM,Y
+WTS003,Salisbury Probation Centre,Salisbury Probation Centre,COMM,Y
+NBR018,South Shields Probation Office,South Shields Probation Office,COMM,Y
+EGWARE,Edgware Community Hospital,Edgware Community Hospital,HSHOSP,Y
+STF021,Staffordshire Public Protection Unit,Staffordshire Public Protection Unit,COMM,Y
+GWT002,BARGOED Probation Centre,BARGOED Probation Centre,COMM,N
+LNSDAL,"Lonsdale Unit, Lancaster","Lonsdale Unit, Lancaster",HSHOSP,Y
+LDM077,Stratford Probation Office,Stratford Probation Office,COMM,Y
+LDM010,Notting Hill Gate,Notting Hill Gate,COMM,Y
+PROSPE,Prospect Park Hospital,Prospect Park Hospital,HSHOSP,Y
+LDM119,Ealing Magistrates Court,Ealing Magistrates Court,COMM,Y
+WINWCK,Winwick Hospital,Winwick Hospital,HSHOSP,Y
+YSW004,Kirklees Programmes Unit,Kirklees Programmes Unit,COMM,Y
+DRS004,Bournemouth MC Liaison Office,Bournemouth MC Liaison Office,COMM,Y
+NFK009,Norfolk Programmes Unit,Norfolk Programmes Unit,COMM,Y
+LDM175,Alexandra Court,Alexandra Court,COMM,Y
+NBR025,Washington Probation Office,Washington Probation Office,COMM,Y
+THA004,RJ Project Thames Valley,RJ Project Thames Valley,COMM,Y
+STF038,Stafford DRR Unit,Stafford DRR Unit,COMM,Y
+WTSY03,Salisbury YOT,Salisbury YOT,YOT,Y
+MILTON,Milestone HDU,Milestone HDU,HSHOSP,Y
+MRS010,Project & ICT Unit,Project & ICT Unit,COMM,Y
+HMEFLD,Homefield Hospital,Homefield Hospital,HSHOSP,Y
+MCG045,St Joseph's Approved Premises,St Joseph's Approved Premises,APPR,Y
+LDM069,Crown Court Newington Causeway,Crown Court Newington Causeway,COMM,Y
+DRHY02,Co Durham South Area YOT,Co Durham South Area YOT,YOT,Y
+YSWAP3,ALBION STREET Approved Premises,ALBION STREET Approved Premises,APPR,Y
+MLWY12,Hockley YOT,Hockley YOT,YOT,Y
+LNSY01,Lincolnshire YOT East,Lincolnshire YOT East,YOT,Y
+BROGRN,Broadgreen Hospital,Broadgreen Hospital,HSHOSP,Y
+MCG002,Hopwood House Approved Premises,Hopwood House Approved Premises,APPR,Y
+MSCALS,Mascalls park,Mascalls park,HSHOSP,Y
+WWS005,Warwick ECP Unit,Warwick ECP Unit,COMM,Y
+HMDWHO,Hollow Meadows Hospital,Hollow Meadows Hospital,HSHOSP,Y
+CSWELL,The Caswell Clinic,The Caswell Clinic,HSHOSP,Y
+QMARY,Queen Mary's Hospital,Queen Mary's Hospital,HSHOSP,Y
+WSN011,Mold Crown Court,Mold Crown Court,COMM,Y
+CMB006,MARYPORT Programmes Unit,MARYPORT Programmes Unit,COMM,Y
+YSN003,Harrogate Probation Office,Harrogate Probation Office,COMM,Y
+GCS002,Cheltenham Probation Centre,Cheltenham Probation Centre,COMM,Y
+HBSAP2,Scunthorpe Probation and Bail Hostel,Scunthorpe Probation and Bail Hostel,APPR,Y
+THA031,Reading Crown Court Probation Office,Reading Crown Court Probation Office,COMM,Y
+DBS014,Derbyshire Area TPO Study Centre,Derbyshire Area TPO Study Centre,COMM,N
+WMP003,West Mercia Training & Development Suite,West Mercia Training & Development Suite,COMM,Y
+MRS024,Southport Probation Centre,Southport Probation Centre,COMM,Y
+LDM127,Harrow Crown Court Probation Office,Harrow Crown Court Probation Office,COMM,Y
+LNS009,Louth Probation Office,Louth Probation Office,COMM,Y
+WMP005,Worcester Probation Office,Worcester Probation Office,COMM,Y
+LDM115,Brent Probation Office,Brent Probation Office,COMM,Y
+YSS008,"Patmos House, Sheffield","Patmos House, Sheffield",COMM,Y
+BEDY04,Oakwood Ave Youth Offending Service,Oakwood Ave Youth Offending Service,YOT,Y
+LDM116,Ealing DTTO,Ealing DTTO,COMM,Y
+YSW008,KEIGHLEY Probation Office,KEIGHLEY Probation Office,COMM,Y
+CMB009,WORKINGTON PROBATION OFFICE,WORKINGTON PROBATION OFFICE,COMM,Y
+LDM079,"Havering, Barking and Dagenham LDU","Havering, Barking and Dagenham Local Delivery Unit",COMM,Y
+MRANDA,Miranda House,Miranda House,HSHOSP,Y
+LNS007,Lincoln Probation Office,Lincoln Probation Office,COMM,Y
+LCS006,BLACKPOOL Probation Office,BLACKPOOL Probation Office,COMM,Y
+STCHRL,St Charles's Hospital (London),St Charles's Hospital (London),HSHOSP,Y
+GCS009,Criminal Justice Intervention Unit,Criminal Justice Intervention Unit,COMM,N
+ASP005,North Bristol Probation Centre,North Bristol Probation Centre,COMM,Y
+LDM131,Highgate Probation Office,Highgate Probation Office,COMM,Y
+STF046,HANLEY YOT,HANLEY YOT,YOT,Y
+NHS015,Nottingham Prolific Offender Unit,Nottingham Prolific Offender Unit,COMM,Y
+LDM022,Woolwich Mags Court Probation Office,Woolwich Mags Court Probation Office,COMM,Y
+SWS003,Pontypridd Probation Office,Pontypridd Probation Office,COMM,Y
+NTS020,Northamptonshire MAPPA Unit,Northamptonshire MAPPA Unit,COMM,Y
+NTS003,Bridgewood House Approved Premises,Bridgewood House Approved Premises,APPR,Y
+PRNCSR,Princess Royal Hospital,Princess Royal Hospital,HSHOSP,Y
+KNT010,Maidstone Probation Office,Maidstone Probation Office,COMM,Y
+ESXY02,Thurrock Youth Offending Team,Thurrock Youth Offending Team,YOT,Y
+NTS001,Northamptonshire Head Office,Northamptonshire Head Office,COMM,Y
+SRY015,Guildford Probation,Guildford Probation,COMM,Y
+SRY002,St Catherine's Priory Approved Hostel,St Catherine's Priory Approved Hostel,APPR,Y
+SRY014,Woking Probation Centre,Woking Probation Centre,COMM,Y
+D40AB1,Thames Valley Probation Hostel,Thames Valley Probation Hostel,COMM,Y
+NTS018,Rose Project - Finedon,Rose Project - Finedon,COMM,Y
+SRY010,Staines Probation Centre,Staines Probation Centre,COMM,Y
+SRY012,Guildford Crown Court Liaison Office,Guildford Crown Court Liaison Office,COMM,Y
+SRY009,Surrey Probation Head Office,Surrey Probation Head Office,COMM,Y
+SRY004,Redhill Probation Centre,Redhill Probation Centre,COMM,N
+ACTNCC,Acton Crown Court,"Acton Crown Court - Closed, transferred to Isleworth",CRT,N
+BEVLCC,Beverley Crown Court,"Beverley Crown Court - Closed, transferred to Hull",CRT,N
+BIRKCC,Birkenhead Crown Court,"Birkenhead Crown Court - Closed, transferred to ??",CRT,N
+BODMCC,Bodmin Crown Court,"Bodmin Crown Court - Closed, transferred to Truro",CRT,N
+KGHTCC,Knightsbridge Crown Court,"Knightsbridge Crown Court - Closed, transferred to Blackfriars ",CRT,N
+POOLCC,Poole Crown Court,"Poole Crown Court - Closed, transferred to Bournemouth ",CRT,N
+HUDDCC,Huddersfield Crown Court,"Huddersfield Crown Court - Closed, transferred to Bradford ",CRT,N
+BRCHCC,Bristol (Guildhall) Crown Court,"Bristol (Guildhall) Crown Court - Closed, transferred to Bristol ",CRT,N
+BRBSCC,Bristol (Bridewell St) Crown Court,"Bristol (Bridewell St) Crown Court - Closed, transferred to Bristol ",CRT,N
+BRCSCC,Bristol (Corn St) Crown Court,"Bristol (Corn St) Crown Court - Closed, transferred to Bristol ",CRT,N
+CAPRCC,Cardiff (Penarth Rd) Crown Court,"Cardiff (Penarth Rd) Crown Court - Closed, transferred to Cardiff ",CRT,N
+WALLCC,Wallington Crown Court,"Wallington Crown Court - Closed, transferred to Croydon ",CRT,N
+SURRCC,Surrey Crown Court,"Surrey Crown Court - Closed, transferred to Croydon ",CRT,N
+UPPNCC,Upper Norwood Crown Court,"Upper Norwood Crown Court - Closed, transferred to Croydon ",CRT,N
+WILLCC,Willesden Crown Court,"Willesden Crown Court - Closed, transferred to Harrow ",CRT,N
+KNCPCC,Kingston (Canbury Park) Crown Court,"Kingston (Canbury Park) Crown Court - Closed, transferred to Kingston ",CRT,N
+SURBCC,Surbiton Crown Court,"Surbiton Crown Court - Closed, transferred to Kingston ",CRT,N
+KENDCC,Kendal Crown Court,"Kendal Crown Court - Closed, transferred to Lancaster ",CRT,N
+WAKECC,Wakefield Crown Court,"Wakefield Crown Court - Closed, transferred to Leeds ",CRT,N
+HOVECC,Hove Crown Court,Hove Crown Court,CRT,Y
+HAYHCC,Haywards Heath Crown Court,"Haywards Heath Crown Court - Closed, transferred to Lewes",CRT,N
+ROCHCC,Rochester Crown Court,"Rochester Crown Court - Closed, transferred to Maidstone",CRT,N
+OLDHCC,Oldham Crown Court,"Oldham Crown Court - Closed, transferred to Manchester Crown Square",CRT,N
+MIDGCC,Mid Glamorgan Crown Court,"Mid Glamorgan Crown Court - Closed, transferred to Merthyr Tydfil",CRT,N
+NRGHCC,Northants (Guildhall) Crown Court,"Northants (Guildhall) Crown Court - Closed, transferred to Northampton ",CRT,N
+NRCHCC,Northants (County Hall) Crown Court,"Northants (County Hall) Crown Court - Closed, transferred to Northampton ",CRT,N
+PRSHCC,Preston (Sessions House) Crown Court,Preston (Sessions House) Crown Court,CRT,Y
+PRSMCC,Preston (Amounderness) Crown Court,"Preston (Amounderness) Crown Court - Closed, transferred to Preston ",CRT,N
+REAHCC,Reading (Artillery House) Crown Court,"Reading (Artillery House) Crown Court - Closed, transferred to Reading ",CRT,N
+RESHCC,Reading (Shire Hall) Crown Court,"Reading (Shire Hall) Crown Court - Closed, transferred to Reading ",CRT,N
+HAMPCC,Hampshire Crown Court,"Hampshire Crown Court - Closed, transferred to Southampton ",CRT,N
+MAYBCC,Maybush Crown Court,"Maybush Crown Court - Closed, transferred to Southampton ",CRT,N
+STENCC,Southend Crown Court,"Southend Crown Court - Closed, transferred to Southend ",CRT,N
+WATFCC,Watford Crown Court,"Watford Crown Court - Closed, transferred to St Albans",CRT,N
+SWGHCC,Swansea (Guildhall) Crown Court,"Swansea (Guildhall) Crown Court - Closed, transferred to Swansea ",CRT,N
+DEVICC,Devizes Crown Court,"Devizes Crown Court - Closed, transferred to Swindon ",CRT,N
+WILTCC,Wiltshire Crown Court,"Wiltshire Crown Court - Closed, transferred to Swindon ",CRT,N
+DUDLCC,Dudley Crown Court,"Dudley Crown Court - Closed, transferred to Wolverhampton ",CRT,N
+WALSCC,Walsall Crown Court,"Walsall Crown Court - Closed, transferred to Wolverhampton ",CRT,N
+BRGHCC,Brighton Crown Court,Brighton Crown Court,CRT,Y
+HATMAG,Hatfield Magistrates Court,Hatfield Magistrates Court,CRT,N
+HUNTCC,Huntingdon Crown Court,Huntingdon Crown Court,CRT,Y
+NOTPPO,Nottingham PPO,Nottingham PPO,COMM,Y
+BLAPRO,Blackburn Probation Office,Blackburn Probation Office,COMM,Y
+BRI,BURE (HMP),HMP BURE,INST,Y
+ISI,ISIS HMP/YOI,HMP/YOI ISIS,INST,Y
+LCS021,Leyland Probation Office,Leyland Probation Office,COMM,Y
+HBPO01,Hull Probation Office,Hull Probation Office,COMM,N
+MLW045,West Midlands Probation,West Midlands Probation Office,COMM,Y
+GLOPBO,Gloucester Probation Centre,Gloucester Probation Centre,COMM,Y
+MLW046,West Midlands Probation HORU,West Midlands Probation HORU,COMM,Y
+PFI,PETERBOROUGH FEMALE HMP,HMP PETERBOROUGH FEMALE,INST,Y
+DBS017,Bayheath House Probation,Bayheath House Probation,COMM,Y
+LDM005,Finchley Probation,Finchley Probation Drug Treatment Office,COMM,Y
+MATPRO,Matlock Lime Grove Walk Probation,Matlock Lime Grove Walk Probation,COMM,Y
+BDL001,South Bedfordshire Probation Office,South Bedfordshire Probation Office,COMM,Y
+DBS018,Alfreton Probation Office,Alfreton Probation Office,COMM,Y
+THA054,Oxford Probation Office,"Oxford Probation Office, MacMillan House",COMM,Y
+THA056,Oxford IOM Probation Office,"Oxford IOM Probation Office, The Old Music Hall",COMM,Y
+DBS019,Cotton Lane Probation Service,Cotton Lane Probation Service,COMM,N
+R1,South West / South East,South West and the South East PECS Region,PECS,N
+R2,London /East of England,London and East of England PECS Region,PECS,N
+R3,East Mids/ Yorks and Humber/North East,East Midlands / Yorkshire and Humberside/North East PECS Region,PECS,N
+R4,North West /West Midlands /Wales,North West /West Midlands /Wales PECS Region,PECS,N
+MCG071,Withington Probation,Withington Probation office,COMM,Y
+OWI,OAKWOOD (HMP),OAKWOOD (HMP),INST,Y
+TSI,THAMESIDE (HMP),THAMESIDE (HMP),INST,Y
+NLI,NORTHUMBERLAND (HMP),NORTHUMBERLAND (HMP),INST,Y
+MRSAP5,Stafford House,Stafford House Probation Hostel,APPR,Y
+YSS002,"Acorn House, Barnsley Probation Office","Acorn House, Barnsley Probation Office",COMM,Y
+BRAAIT,Bradford AIT,Bradford AIT,CRT,Y
+BIRAIT,Birmingham AIT,Birmingham AIT,CRT,Y
+BROAIT,Bromley AIT,Bromley AIT,CRT,Y
+BELAIT,Belfast AIT,Belfast AIT,CRT,Y
+FIEAIT,Field House AIT,Field House AIT,CRT,Y
+GLAAIT,Glasgow AIT,Glasgow AIT,CRT,Y
+HARAIT,Harmondsworth AIT,Harmondsworth AIT,CRT,Y
+IWI,ISLE OF WIGHT (HMP),HMP ISLE OF WIGHT,INST,Y
+YSN007,York YACRO Hostel,York YACRO Hostel,HOST,Y
+D46KT1,Swale Probation Office,,COMM,Y
+ASP022,Bristol Central Probation,Bristol Central Probation,COMM,Y
+LDM081,Plaistow Police Sation (Probation Off),Plaistow Police Sation (Probation Off),COMM,Y
+HMI,HUMBER (HMP),HMP HUMBER,INST,Y
+PLYPPO,Plymouth Prolific Offender Unit,Plymouth Prolific Offender Unit,COMM,Y
+FSH001,Freshstart Hostel,Freshstart Secure Hostel,APPR,Y
+GWT10,Blackwood Probation Office,Blackwood Probation Office,COMM,Y
+LDM245,"Foreign Nationals Unit, Mitre House","Foreign Nationals Unit, Mitre House",COMM,Y
+DGW09,Newport Probation Office,Newport Probation Office,COMM,Y
+HFS006,East Herts Probation Office (Cheshunt),East Herts Probation Office (Cheshunt),COMM,Y
+HPS008,Fareham CRC,Fareham CRC,COMM,Y
+MDPL01,Middlesbrough Police Station,Middlesbrough Police Station,COMM,Y
+BGSWCR,BGSW Chippenham CRC,BGSW Chippenham CRC,CRC,Y
+MTIA,Mablethorpe Inter Agency Centre,Mablethorpe Inter Agency Centre,CRC,Y
+BRWPB,Barrow Probation Office,Barrow Probation Office,COMM,Y
+LCSAP3,Edith Rigby House Approved Premises,Edith Rigby House Approved Premises,APPR,Y
+WILMCR,Wilmslow CRC,Wilmslow CRC,CRC,Y
+WELLSC,Wells Reporting Centre,Wells Reporting Centre,CRC,Y
+CLPCRC,Preston Cumbria & Lancashire CRC,Preston Cumbria & Lancashire CRC,CRC,Y
+NEW002,FERRYHILL LADDER CENTRE CRC,FERRYHILL LADDER CENTRE CRC,CRC,Y
+HULLTW,Hull Together Women Project,Hull Together Women Project,CRC,Y
+SHEFTW,Sheffield Together Women Project,,CRC,Y
+BARNCR,Barnsley CRC,Barnsley CRC,CRC,Y
+LEETWP,Leeds Together Women Project,Leeds Together Women Project,CRC,Y
+BRATWP,Bradford Together Women Project,Bradford Together Women Project,CRC,Y
+HUDWM,Huddersfield Women's Centre,Huddersfield Women's Centre,CRC,Y
+DONCL,Doncaster Changing Lives,Doncaster Changing Lives,CRC,Y
+BRSEAP,Bury St Edmunds Approved Premises,Bury St Edmunds Approved Premises,APPR,Y
+JERSPS,Jersey Probation Services,Jersey Probation Services,COMM,Y
+SWS012,Bridgend Police Station,Bridgend Police Station,COMM,Y
+YSWY02,West Yorkshire Probation Office,,COMM,Y
+LTS016,Mansfield House Probation,,COMM,Y
+DBS020,Derby Probation Office,Derby Probation Office,COMM,Y
+HPS030,Phoenix House,,APPR,Y
+LDM177,Kensington Police Station,Kensington Police Station,COMM,Y
+SALICT,Salisbury Law Court,Salisbury Law Court,COMM,Y
+BODPO,Bodmin Probation Office,Bodmin Probation Office,COMM,Y
+MCG029,Warrington Street Probation Office,Warrington Street Probation Office,COMM,Y
+ROTHPB,Rotherham Probation Office,Rotherham Probation Office,COMM,Y
+SUDBHC,Sudbury Community Health Centre,Sudbury Community Health Centre,HSHOSP,Y
+CRIWID,Crime Reduction Initiative,Crime Reduction Initiative,CRC,Y
+DCP020,Liskeard CRC Reporting Office,Liskeard CRC Reporting Office,CRC,Y
+LCSY10,Stockport Youth Offending Team,Stockport Youth Offending Team,YOT,Y
+HBS020,Bridlington Police Station (Probation),Bridlington Police Station (Probation Office),COMM,Y
+LMYOS,Lambeth YOS,Olive Morris House,COMM,Y
+DCP021,Torquay Working links CRC Hub,Torquay Working links CRC Hub,CRC,Y
+MLW048,Birmingham CRC Probation Office,Birmingham CRC Probation Office,CRC,Y
+YSS033,BARNSLEY SOUTH YORKSHIRE CRC,Barnsley South Yorkshire CRC,CRC,Y
+KNT023,Sevenoaks Council Offices,,COMM,Y
+MLW049,Telford Steps Centre,Telford Steps Centre,CRC,Y
+CANTCR,Canterbury Probation Office  KSSCRC,Canterbury Probation Office  KSSCRC,CRC,Y
+D46KT2,Swale Probation Office KSSCRC,Swale Probation Office KSSCRC,CRC,Y
+MEDCRC,Medway Chatham Probation CRC,Medway Chatham Probation CRC,CRC,Y
+FOLKCR,Folkstone Probation Office KSSCRC,Folkstone Probation Office KSSCRC,CRC,Y
+GRACRC,Gravesend Probation KSSCRC,Gravesend Probation KSSCRC,CRC,Y
+THANCR,Thanet Probation NPS,Thanet Probation KSSCRC,CRC,Y
+TUNCRC,Tunbridge Wells KSSCRC,Tunbridge Wells KSSCRC,CRC,Y
+STF051,Hanley Probation Office,Hanley Probation Office,COMM,Y
+STF052,Tamworth CRC,Tamworth CRC Probation,CRC,Y
+DRS013,IOM/Turnaround Bournemouth,IOM/Turnaround Bournemouth,COMM,Y
+YSS034,Doncaster CRC,Doncaster CRC,CRC,Y
+CHTPRO,Chatham Probation Office,Chatham Probation Office,COMM,Y
+D20BM1,Bournville Lane Probation Office,Bournville Lane Probation Office,COMM,Y
+CRE001,Crewe Probation Office,Crewe Probation Office,COMM,Y
+BDGHL,The Bridges,The Bridges,CRC,Y
+LDM178,Hackney Homeless Persons Unit,Hackney Homeless Persons Unit,APPR,Y
+MRS062,Tomorrow's Women Wirral,Tomorrow's Women Wirral,COMM,Y
+STF050,Melbourne House Probation Office,Melbourne House Probation Office,COMM,Y
+BDS016,Luton Probation,Luton Probation,COMM,Y
+LCS003,Blackpool CRC,Blackpool CRC,COMM,Y
+GCS013,Nelson Trust Stroud,Nelson Trust Stroud,APPR,Y
+ESX010,Chelmsford Probation CRC,Chelmsford Probation CRC,COMM,Y
+MINEHD,Minehead Police Station,Minehead Police Station,COMM,Y
+D52WSM,Weston Police Station,Weston Police Station,COMM,Y
+HBS022,Kingston YOT,created in error,COMM,N
+LDM179,Kingston YOT,Kingston YOT,COMM,Y
+BWI,BERWYN (HMP),HMP BERWYN,INST,Y
+MWI,MEDWAY (STC),STC MEDWAY,INST,Y
+ESX012,Colchester Probation CRC,Colchester Probation CRC,CRC,Y
+HBS023,Hull CRC - Norwich House,Hull CRC - Norwich House,CRC,Y
+STHPBN,Southend Probation Office,Southend Probation Office,COMM,Y
+NRTCRC,Northwich CRC,Northwich CRC,CRC,Y
+CHS012,Warrington CRC,Warrington CRC,CRC,Y
+NHS022,DLNR Probation Services,DLNR Probation Services,CRC,Y
+SRY017,KSS CRC Guildford Office,KSS CRC Guildford Office,CRC,Y
+CUMB01,Kendal CRC,Kendal CRC,CRC,Y
+HDCRC,Huddersfield CRC,Huddersfield CRC,CRC,Y
+NBR040,Northumbria CRC,Blyth LMC Office,CRC,Y
+HLNCRC,HLNY CRC,"HLNY CRC, Grimsby",CRC,Y
+SRY018,Redhill Probation Office CRC,Redhill Probation Office CRC,COMM,Y
+ROCH,Rochdale CRC,Rochdale CRC,CRC,Y
+LDM150,Lewisham Mental Health Supported Housing,Lewisham Mental Health Supported Housing,CRC,Y
+SWS014,Domestic Abuse One Stop Shop,Domestic Abuse One Stop Shop,CRC,Y
+SSX004,Littlehampton CRC,Littlehampton CRC,CRC,Y
+DUR015,Durham Tees Valley CRC - Wear House,Durham Tees Valley CRC - Wear House,CRC,Y
+PSYOS,Positive Steps Youth Justice Services,Positive Steps Youth Justice Services,YOT,Y
+GCS11,Gloucester Probation Office,Gloucester Probation Office - Twyver Hse,COMM,Y
+MLW034,Dudley Probation Trust,Dudley Probation Trust,COMM,Y
+DSW03,Barry Probation Office,Barry Probation Office,COMM,Y
+DVTTTA,Torquay Probation,Torquay Probation,COMM,Y
+KLPS,Kirkleatham Police Station,Kirkleatham Police Station,COMM,Y
+RCCL,Redcar Probation Office,Redcar Probation Office,COMM,Y
+ASP024,Frome CRC Reporting Office,Frome CRC Reporting Office,COMM,Y
+LCS022,The Thomas Project CRC,The Thomas Project CRC,CRC,Y
+DD001,Buckhaven Burgh Chambers,,COMM,Y
+STECJS,Criminal Justice Services,Criminal Justice Services,COMM,Y
+YSW019,Leeds West Yorkshire CRC,Leeds West Yorkshire CRC,COMM,Y
+MLW047,Solihull IOM Unit,Solihull Integrated Offender Management Unit,COMM,Y
+HBPO02,Hull Probation Office,Hull Probation Office,COMM,Y
+NHAMYO,Newham Youth Offending Team,Newham Youth Offending Team,YOT,Y
+DRS012,Bournemouth Rehabilitation Unit,Bournemouth Rehabilitation Unit,HSHOSP,Y
+DUR019,Peterlee Probation,Peterlee Probation,COMM,Y
+ESX011,South Management Centre,South Management Centre,CRC,Y
+GRIWC,Grimsby Women's Centre,Grimsby Women's Centre,CRC,Y
+SRY016,Guildford Custody Suite,Guildford Police Station,POLICE,Y
+NUMCRC,"Northumbria CRC, Newcastle LMC","Northumbria CRC, Newcastle LMC",CRC,Y
+STAFCR,Stafford Probation CRC,Stafford Probation CRC,CRC,Y
+STEP2,Steps2 Recovery,Steps2 Recovery,CRC,Y
+EXTPRO,Exeter Probation Office,Exeter Probation Office,COMM,Y
+WORKCR,Neighbourhood Centre CRC Workington,Neighbourhood Centre CRC  Workington,CRC,Y
+NOT1,Nottingham One CRC,"The Derbyshire, Leicestershire, Nottinghamshire and Rutland CRC Ltd",CRC,Y
+NEWCRC,Newark CRC,Newark CRC,CRC,Y
+CMBCR1,Barrow CRC,Barrow CRC,CRC,Y
+WACRC2,Wakefield Community Rehab Company,,CRC,Y
+HFXCRC,Halifax Community Rehabilitation Company,Halifax Community Rehabilitation Company,CRC,Y
+GWT010,Newport Probation Office,Newport Probation Office,COMM,Y
+STOK01,Stockton-On-Tees CRC,Stockton-On-Tees CRC,CRC,Y
+GWT011,Pontypool CRC,Pontypool CRC,CRC,Y
+LDM180,Haringey Youth Offending Service,Haringey Youth Offending Service,COMM,Y
+D05M01,Liverpool IOM Team,Liverpool IOM Team,COMM,Y
+GPO01,Greenwich Probation Office,Greenwich Probation Office,COMM,Y
+BOUNDS,Boundary Street Project,Boundary Street Project,APPR,Y
+MCG072,West Didsbury Police Station,Probation and Police Office,COMM,Y
+FALPO,Falmouth Probation Office,Falmouth Probation Office,COMM,Y
+DCCPRB,DCC Probation,DCC Probation,COMM,Y
+PNZCRC,The Penwith Centre,The Penwith Centre,CRC,Y
+MCG073,Stockport Spotlight Unit,Stockport Spotlight Unit,COMM,Y
+COOPRC,Coops Recovery Centre,Coops Recovery Centre,COMM,Y
+DCP022,Exeter Working Links CRC hub,Exeter Working Links CRC hub,CRC,Y
+HBS021,Hull CRC - Liberty House,Hull CRC - Liberty House,CRC,Y
+MCG075,Minshull Street Probation Office,Minshull Street Probation Office,COMM,Y
+CRISTF,CRI Step Forward,CRI Step Forward,COMM,Y
+YSS032,Rotherham CRC,Rotherham CRC,COMM,Y
+WAKCRC,Wakefield CRC,Wakefield CRC,CRC,Y
+BARCRC,Barnstaple CRC,Barnstaple CRC,CRC,Y
+STF029,Staffordshire and West Midlands CRC,Staffordshire and West Midlands CRC,CRC,Y
+CRC,As Specified Below,At a location specified by your Supervising Officer,CRC,Y
+SSX026,Hastings Probation,Hastings probation,COMM,Y
+NTS023,Kettering Bench CRC,Kettering Bench CRC,CRC,Y
+RHYCRC,Dewi Sant Centre,Dewi Sant Centre CRC,CRC,Y
+DOLCRC,Dolgellau Police Station,Dolgellau Police Station CRC,CRC,Y
+HPS014,Portsmouth CRC,Portsmouth CRC,CRC,Y
+MCG54,Oldham CRC,Oldham CRC,CRC,Y
+PRES01,Preston CRC,Preston CRC,CRC,Y
+STF053,Sutton Coldfield Police Station,Sutton Coldfield Police Station,COMM,Y
+CRACRC,Crawley CRC,Crawley CRC,COMM,Y
+CHIN01,Waltham Forest IOM,Waltham Forest IOM,CRC,Y
+COLHMC,Colchester Magistrates Court,Colchester Magistrates Court,CRT,Y
+NEWLMC,Newcastle-Under-Lyme Magistrates Court,Newcastle-Under-Lyme Magistrates Court,CRT,Y
+DURDEC,Co Durham and Darlington EC,County Durham and Darlington Enforcement Court,CRT,Y
+PLY004,Shekinah Mission,Shekinah Mission,CRC,Y
+LDM090,Ilford Probation,Ilford Probation,COMM,Y
+TES011,Stockton Probation Office,Stockton on Tees Probation Office,COMM,Y
+HBS002,Pocklington Probation Office,Pocklington Probation Office,COMM,Y
+DCP018,Plymouth CRC Engage Supervision Office,Plymouth CRC Engage Supervision Office,CRC,Y
+D12AP3,Nelson House Approved Premises,Nelson House Approved Premises,APPR,Y
+STECH,Stechford Police Station PPO Team,Stechford Police Station PPO Team,COMM,Y
+WDG001,Wood Green Custody Suite,Wood Green Custody Suite,COMM,Y
+YSW018,Wakefield Probation Office,Wakefield Probation Office,COMM,Y
+LDM031,Hackney Service Centre,Hackney Service Centre,COMM,Y
+DCP019,Torquay CRC Community Hub,Torquay CRC Community Hub,CRC,Y
+MCG058,Tameside Women's Centre,Tameside Women's Centre,APPR,Y
+BCROFT,Birchcroft Probation Office,Birchcroft Probation Office,COMM,Y
+KLGCS,"TTG Team, The Grange Coffee Shop","TTG Team, The Grange Coffee Shop",CRC,Y
+MSG073,Denton Centre Probation,,COMM,Y
+MCG074,Denton Centre Probation,Denton Centre Probation,COMM,Y
+CBS010,Peterborough Probation Newark Road,Peterborough Probation,COMM,Y
+SHEFCR,Sheffield CRC,Sheffield CRC,CRC,Y
+HATFPB,"Hatfield Probation, Hatfield Police Stn","Hatfield Probation, Hatfield Police Station",COMM,Y
+HMLHPB,Hemel Hempstead Probation Office,Hemel Hempstead Probation Office,COMM,Y
+TPDIP,The Turning Point DIP,The Turning Point DIP,CRC,Y
+BDS017,Bench CRC West One,Bench CRC West One,CRC,Y
+SPETPO,Spetchells Centre,Spetchells Centre,COMM,Y
+SANPRB,"Sanctuary 21, Durham","Sanctuary 21, Durham",CRC,Y
+DLNRCR,"Derby, Leics, Notts & Rutland CRC","Derbyshire, Leicestershire, Nottinghamshire & Ruland CRC",CRC,Y
+DERBPR,Derby Probation,Derby Probation,COMM,Y
+GRAYSC,GRAYS PROBATION CRC,GRAYS PROBATION CRC,CRC,Y
+BASCRC,Basildon Probation CRC,Basildon Probation CRC,CRC,Y
+CHES01,Chesterfield Probation,Chesterfield National Probation Service,COMM,Y
+TRU001,Truro Probation Working Links,Truro Probation Working Links,COMM,Y
+CAER01,CAERPHILLY PROBATION CRC,CAERPHILLY PROBATION CRC,CRC,Y
+EBBW01,EBBW VALE PROBATION CRC,EBBW VALE PROBATION CRC,CRC,Y
+NORUM1,Northumbria CRC - S.Shields Local Centre,Northumbria CRC - S.Shields Local Centre,CRC,Y
+DCP027,Penzance Probation Hub,Penzance Probation Hub,COMM,Y
+ASP027,Yeovil Probation Office,Yeovil Probation Office,COMM,Y
+NWCRC,New Wortley Community Centre,New Wortley Community Centre,CRC,Y
+HATAIT,Hatton Cross- York House AIT,Hatton Cross- York House AIT,CRT,Y
+HAYAIT,Hatton Cross- Gloucester House AIT,Hatton Cross- Gloucester House AIT,CRT,Y
+MANAIT,Manchester AIT,Manchester AIT,CRT,Y
+NEWAIT,Newport AIT,Newport AIT,CRT,Y
+NORAIT,North Shields AIT,North Shields AIT,CRT,Y
+NOTAIT,Nottingham AIT,Nottingham AIT,CRT,Y
+BRYAIT,Byron House AIT,Byron House AIT,CRT,Y
+PROAIT,Procession House (Field House) AIT,Procession House (Field House) AIT,CRT,Y
+STOAIT,Stoke on Trent AIT,Stoke on Trent AIT,CRT,Y
+SUTAIT,Sutton AIT,Sutton AIT,CRT,Y
+TAYAIT,Taylor House AIT,Taylor House AIT,CRT,Y
+WALAIT,Walsall AIT,Walsall AIT,CRT,Y
+YARAIT,Yarls Wood AIT,Yarls Wood AIT,CRT,Y
+MRS061,Knowsley Probation Centre,,COMM,Y
+BULMIL,Bulford Military Court Centre,Bulford Military Court Centre,CRT,Y
+CITWMC,City of Westminster Mag Court,City of Westminster Magistrates Court,CRT,N
+SYWY1,Shipley Probation Office,Shipley Probation Office,COMM,Y
+YOT001,Hampshire Youth Offending Team,Hampshire Youth Offending Team,YOT,Y
+NHS16,Vanguard Plus Team,Vanguard Plus Team,COMM,Y
+CHAPPR,Clarks House Approved Premises,Clarks House Approved Premises,APPR,N
+LONY01,Westminster Youth Offending Team,Westminster Youth Offending Team,YOT,Y
+LON001,Enfield CRC,,COMM,Y
+NEW001,Newton Aycliffe Community Hub,,COMM,Y
+TAUNCR,Taunton Working Links CRC hub,Taunton Working Links CRC hub,CRC,Y
+MID001,Hillingdon Youth Offending Service,Hillingdon Youth Offending Service,YOT,Y
+SSX027,CRAWLEY PROBATION OFFICE,CRAWLEY PROBATION OFFICE,COMM,Y
+DEV01,Kingsley House Probation Office,Kingsley House Probation Office,COMM,Y
+GCS014,Nelson House,Nelson House,APPR,Y
+NHS020,CRC DLNR Worksop Probation,CRC DLNR Worksop Probation,CRC,Y
+LOND10,THE POINT WOOLWICH,THE POINT WOOLWICH,COMM,Y
+SWAD01,Swadlincote Probation,Swadlincote Probation,COMM,Y
+D20HW,Handsworth Police Station CRC PPO Team,Handsworth Police Station CRC PPO Team,CRC,Y
+KNT025,KSS CRC Ashford Office,KSS CRC Ashford Office,CRC,Y
+LDM100,Newham Probation NPS & CRC,Newham Probation NPS & CRC,COMM,Y
+DCP026,The Elms,The Elms CRC Hub,CRC,Y
+YSW017,Leeds PPO Probation Office,Leeds PPO Probation Office,COMM,Y
+LDM065,Foreign National Unit Mitre Hse Probatio,Foreign National Unit Mitre Hse Probation Office,COMM,Y
+WSM001,Weston Probation Office,Weston Probation Office (West Police Station),COMM,Y
+CFCTLN,Central Family Court,"Central Family Court, First Avenue House",CRT,Y
+ELONCT,East London County Court,East London County Court,CRT,Y
+HBBRPZ,CRC Hub Breadline,CRC Hub Breadline,CRC,Y
+TORQ,Torquay Probation Centre,Torquay Probation Centre,COMM,Y
+ASP025,Bath Probation Office,Julian House,COMM,Y
+CUMLAN,Accrington Cumbria and Lancashire CRC,Accrington Cumbria and Lancashire CRC,CRC,Y
+YSS031,Sheffield South Yorkshire CRC,Sheffield South Yorkshire CRC,COMM,Y
+NTS022,Northampton CRC,Northampton CRC,CRC,Y
+DCP023,Penzance Probation Hub,Penzance Probation Hub,CRC,Y
+BOSTPR,Boston Probation Office,Boston Probation Office,COMM,Y
+KNT024,Maidstone Probation Service – CRC,Maidstone Probation Service – CRC,CRC,Y
+CBS011,Huntingdon Bench CRC Local Mang/t Centre,Huntingdon Bench CRC Local Management Centre,CRC,Y
+DCP024,The Job Centre CRC,,CRC,Y
+ASP026,BGSW Resettlement Hub Bristol,BGSW Resettlement Hub Bristol,CRC,Y
+SKF007,Ipswich Office CRC,Ipswich Office CRC,CRC,Y
+DCP025,Eagles Community CRC Barnstaple,Eagles Community CRC Barnstaple,CRC,Y
+HBS006,Goole CRC,Goole CRC,CRC,Y
+WMP011,Worcester Step Centre,Worcester Step Centre,CRC,Y
+LEICDN,Leicester DLNR CRC,Leicester DLNR CRC,CRC,Y
+SWS008,Merthyr Probation and CRC Office,Merthyr Probation and CRC Office,COMM,Y
+SWS013,Pontypridd CRC,,CRC,Y
+BOOT01,Sefton (Bootle) Probation  CRC,Sefton (Bootle)  Probation CRC,COMM,Y
+STF005,Northern IOM,Northern IOM,COMM,Y
+YSN013,York CRC,York CRC,CRC,Y
+SUND01,Sunderland LMC (Northumbria CRC),Sunderland LMC (Northumbria CRC,CRC,Y
+TEES01,Stockton on Tees CRC Probation Office,Stockton on Tees CRC Probation Office,CRC,Y
+NBR044,Northumbria CRC - Gateshead Local Centre,Northumbria CRC - Gateshead Local Centre,CRC,Y
+CARD01,Cardiff Pathfinder CRC,Cardiff Pathfinder CRC,CRC,Y
+CALHOS,Callington Road Hospital,Callington Road Hospital,HSHOSP,Y
+LEYT01,Leytonstone Probation  & YOT,Leytonstone Probation  & YOT,COMM,Y
+CBS012,Wisbech Probation Office,Wisbech Probation Office,COMM,Y
+DRHY05,North Road Methodist Church,North Road Methodist Church CRC,CRC,Y
+HPS056,Southampton IOM,Southampton IOM House,CRC,Y
+DUR016,Durham and Tees Valley CRC - Grove Hill,Durham and Tees Valley CRC - Grove Hill,CRC,Y
+LDM181,London CRC - Bromley,London CRC - Bromley,CRC,Y
+WRXCRC,Wrexham CRC - Working Links,Wrexham CRC - Working Links,CRC,Y
+TES012,Criminal Jusice Hub,Criminal Jusice Hub,COMM,Y
+MRS053,Liverpool Central CRC,Liverpool Central CRC,CRC,Y
+WRCCJC,Worcester Police Station,Worcester Police Station,COMM,Y
+SCUCRC,Scunthorpe CRC,Scunthorpe CRC,CRC,Y
+BICPRO,Bicester Probation Office,Bicester Probation Office,COMM,Y
+DC7,Isles of Scilly Custody Suite,,POLICE,Y
+HMB4,Birchin Way Custody Suite,,POLICE,Y
+HMB5,Grimsby Custody Suite,,POLICE,N
+KNT8,Kent Custody Suite,,POLICE,N
+MPS33,Harrow Custody Suite,,POLICE,Y
+MPS30,Hounslow Custody Suite,,POLICE,Y
+MPS31,Kentish Town Custody Suite,,POLICE,Y
+MPS32,Sutton Custody Suite,,POLICE,Y
+WYP8,Eccleshill Custody Suite,,POLICE,Y
+WYP9,Pudsey Custody Suite,,POLICE,Y
+ASHEHO,Ashen Hill/Southview,Ashen Hill/Southview,HOSPITAL,Y
+AVESHO,"Avesbury House, Care UK","Avesbury House, Care UK",HOSPITAL,Y
+BARTHO,Bartholemew Court/Oak Tree Lodge,Bartholemew Court/Oak Tree Lodge,HOSPITAL,Y
+BEECHO,Beech House,Beech House,HOSPITAL,Y
+BROCHO,Brockfield House (frm. Runwell Hospital),Brockfield House (frm. Runwell Hospital),HOSPITAL,Y
+BURSHO,Burston House,Burston House,HOSPITAL,Y
+CEDAHO,"Cedar House, Care Principles","Cedar House, Care Principles",HOSPITAL,Y
+CEDUHO,Cedar Unit,Cedar Unit,HOSPITAL,Y
+CHASHO,Chaseways,Chaseways,HOSPITAL,Y
+COASHO,Coastlands,Coastlands,HOSPITAL,Y
+CYGNHO,Cygnet Hospital Stevenage,Cygnet Hospital Stevenage,HOSPITAL,Y
+DEACHO,Deacon Ward,Deacon Ward,HOSPITAL,Y
+GLENHO,Glenhurst Hospital,Glenhurst Hospital,HOSPITAL,Y
+MARLHO,Marlborough House,Marlborough House,HOSPITAL,Y
+MEADHO,Meadowlands,Meadowlands,HOSPITAL,Y
+YSW020,CHART - Dewsbury CRC,CHART - Dewsbury CRC,CRC,Y
+REDCRC,Redditch CRC Probation Office,Redditch CRC Probation Office,CRC,Y
+MCG076,Stockport CRC,Stockport CRC,CRC,Y
+BSE001,Bury St Edmunds Probation Office,Bury St Edmunds Probation Office,COMM,Y
+SCOCJS,Scottish Criminal Justice Services,Scottish Criminal Justice Services,COMM,Y
+CARRRC,Teen Challenge UK - Wales,Teen Challenge - Residential Rehabilitation Centre,CRC,Y
+NWRK01,Newark Probation Office - Castle House,Newark Probation Office - Castle House,COMM,Y
+DP1,Aberystwyth Custody Suite,Aberystwyth Police Station,POLICE,Y
+SCOCJD,Scottish Criminal Justice Department,Scottish Criminal Justice Department,COMM,Y
+YSW021,British Muslim Association,British Muslim Association,APPR,Y
+BRCHHO,Bristol Childrens Hospital,Bristol Childrens Hospital,HOSPITAL,Y
+BRRIHO,Bristol Royal Infirmary,Bristol Royal Infirmary,HOSPITAL,Y
+BARUHO,Bath Royal United Hospital,Bath Royal United Hospital,HOSPITAL,Y
+LICOHO,Lincoln County Hospital,Lincoln County Hospital,HOSPITAL,Y
+BOPIHO,Boston Pilgrim Hospital,Boston Pilgrim Hospital,HOSPITAL,Y
+GRADHO,Grantham and District Hospital,Grantham and District Hospital,HOSPITAL,Y
+MKUNHO,Milton Keynes University Hospital,Milton Keynes University Hospital,HOSPITAL,Y
+NUNGHO,Northampton University/General Hospital,Northampton University/General Hospital,HOSPITAL,Y
+RSTCHO,Rugby St Cross Hospital,Rugby St Cross Hospital,HOSPITAL,Y
+STROHO,Salford Royal Hospital,Salford Royal Hospital,HOSPITAL,Y
+NGENHO,Northern General,Northern General,HOSPITAL,Y
+SHCHHO,Sheffield Children's Hospital,Sheffield Children's Hospital,HOSPITAL,Y
+DAMEHO,Darlington Memorial Hospital,Darlington Memorial Hospital,HOSPITAL,Y
+UONDHO,University Hospital of North Durham,University Hospital of North Durham,HOSPITAL,Y
+BIAUHO,Bishop Auckland Hospital,Bishop Auckland Hospital,HOSPITAL,Y
+RSTUHO,Royal Stoke University Hospital,Royal Stoke University Hospital,HOSPITAL,Y
+HAWIHO,Haywood Walk-In Centre,Haywood Walk-In Centre,HOSPITAL,Y
+LEMOHO,Leek Moorlands Hospital,Leek Moorlands Hospital,HOSPITAL,Y
+LEGEHO,Leeds General Infirmary,Leeds General Infirmary,HOSPITAL,Y
+STJUHO,St James's University Hospital,St James's University Hospital,HOSPITAL,Y
+YCHCHO,Yeadon Community Health Centre,Yeadon Community Health Centre,HOSPITAL,Y
+LESEHO,Leeds Sexual Health,Leeds Sexual Health,HOSPITAL,Y
+WHARHO,Wharfedale Hospital,Wharfedale Hospital,HOSPITAL,Y
+RDENHO,Reginald Centre (Dental),Reginald Centre (Dental),HOSPITAL,Y
+AMERCC,AMERSHAM CROWN COURT,AMERSHAM CROWN COURT,CRT,Y
+BROOHO,BROOMFIELD HOSPITAL,BROOMFIELD HOSPITAL,HOSPITAL,Y
+BOW001,Tower Hamlets Probation  Bow,Tower Hamlets Probation  Bow,COMM,Y
+WLVPO,Wolverhampton Probation Office,Wolverhampton Probation Office,COMM,Y
+SELPR,Selby Probation Office,Selby Probation Office,COMM,Y
+WTS008,Salisbury CRC,Salisbury CRC,CRC,Y
+WLSCRC,Walsall CRC,Walsall Community Rehabilitation Company,CRC,Y
+MCG078,Bolton and Bury CRC,Bolton and Bury CRC,CRC,Y
+LDM007,The Beth Centre,The Beth Centre,CRC,Y
+WAKCR1,Langley House Trust,Langley House Trust,CRC,Y
+SSX028,Brighton KSSCRC Office,Brighton KSSCRC Office,CRC,Y
+MLW050,New Leaf CRC,New Leaf CRC,CRC,Y
+PHFUT,Phoenix Futures,Phoenix Futures,CRC,Y
+SCH2,Aldine House Secure Children's Centre,Aldine House Secure Children's Centre,SCH,Y
+SCH3,Aycliffe House Secure Children's Centre,Aycliffe House Secure Children's Centre,SCH,Y
+SCH1,Adel Beck Secure Children's Home,Adel Beck Secure Children's Home,SCH,Y
+SCH4,Barton Moss Secure Care Centre,Barton Moss Secure Care Centre,SCH,Y
+SCH5,Clayfields House Secure Unit,Clayfields House Secure Unit,SCH,Y
+SCH6,Hillside Secure Centre,Hillside Secure Centre,SCH,Y
+SCH8,Lincolnshire Secure Unit,Lincolshire Secure Unit,SCH,Y
+SCH9,Vinney Green Secure Unit,Vinney Green Secure Unit,SCH,Y
+PRKHOS,NHS Park House North Manchester,NHS Park House North Manchester,HOSPITAL,Y
+BETHOS,River House,River Hosue,HOSPITAL,Y
+GLOHOS,Gisburn Lodge,Gisburn Lodge,HOSPITAL,Y
+CHESHO,Cheswold Park Hospital,Cheswold Park Hospital,HOSPITAL,Y
+ALPHOS,Alpha Hospital,Alpha Hospital,HOSPITAL,Y
+SGCHOS,St George's Centre,St George's Centre,HOSPITAL,Y
+SEAHOS,Seacroft Hospital,Seacroft Hospital,HOSPITAL,Y
+CHAHOS,Chapel Alleton Hospital,Chapel Allerton Hospital,HOSPITAL,Y
+STHPOL,St Helens Police Station,St Helens Police Station,POLICE,Y
+NWA6,Holyhead (Anglesey) Police Station,Holyhead (Anglesey) Police Station,POLICE,Y
+WLT2,Chippenham Police Station,Chippenham Police Station,POLICE,Y
+DRB8,Butterley Police Station,Butterley Police Station,POLICE,Y
+BCCACC,Birmingham Crown Court (Annex),Birmingham Crown Court (Annex),CRT,Y
+NORTH,PECS Gen4 - North,PECS Gen4 - North,PECS,Y
+ROSEB,Roseberry Park Hospital,Roseberry Park Hospital,HSHOSP,Y
+LGHBH,Loughborough Hospital,Loughborough Hospital,HSHOSP,Y
+DUR005,Durham Tees Valley CRC - Darlington,Durham Tees Valley CRC - Darlington,CRC,Y
+LPYOT,Liverpool YOT,Liverpool YOT,YOT,Y
+LCS012,Parkview,Parkview Approved Premises,APPR,Y
+RAM001,Ramsgate Probation Office,Ramsgate Probation Office,COMM,Y
+GLA001,Quay Project Criminal Justice Social Wrk,Quay Project Criminal Justice Social Wrk,COMM,Y
+CHS013,Through the Gate Hub,Through the Gate Hub - HMP Risley,COMM,Y
+HARIRC,Colnbrook Immigration Removal Centre,Colnbrook Immigration Removal Centre,IMDC,Y
+LDM083,Barkingside Magistrates Court,Barkingside Magistrates Court,CRT,Y
+RAIN01,Rainsbrook STC,Rainsbrook Secure Training Centre,COMM,Y
+GLA002,Block 1 Kilsyth Road Workspace,Block 1 Kilsyth Road Workspace,COMM,Y
+SOUTH,PECS Gen4 - South,PECS Gen4 South,PECS,Y
+ESX8,Braintree Police Station,Braintree Police Station,POLICE,Y
+DRB9,Ilkeston Police Station,Ilkeston Police Station,POLICE,Y
+NEPTHO,Neptune/Jupiter House,Neptune/Jupiter House,HSHOSP,Y
+BARRMC,BARROW IN FURNESS Magistrates Court,BARROW IN FURNESS Magistrates Court,CRT,Y
+KLYNMC,King's Lynn Magistrates Court,King's Lynn Magistrates Court,CRT,Y
+STOTMC,Stoke-on-Trent Magistrates Court,Stoke-on-Trent Magistrates Court,CRT,Y
+WINCMC,Winchester Magistrates Court,Winchester Magistrates Court,CRT,Y
+NWA8,Llandudno Police Station,Llandudno Police Station,POLICE,Y
+NWA9,Llangefni Police Station,Llangefni Police Station,POLICE,Y
+PRCORC,Preston Coroners Court,Preston Coroners Court,CRT,Y
+NWA10,Prestatyn Police Station,Prestatyn Police Station,POLICE,Y
+NWA11,Rhyl Police Station,Rhyl Police Station,POLICE,Y
+WARNCC,Warrington Crown Court,Warrington Crown Court,CRT,Y
+NEUTCC,Newcastle upon Tyne Crown Court Quayside,Newcastle upon Tyne Crown Court Quayside,CRT,Y
+SOBEDH,Southwing Bedford,Southwing Bedford,HOSPITAL,Y
+NOBEDH,Northwing Bedford,Northwing Bedford,HOSPITAL,Y
+LANDUH,Luton and Dunstable,Luton and Dunstable,HOSPITAL,Y
+ADDENH,Addenbrookes,Addenbrookes,HOSPITAL,Y
+PAPWOH,Papworth,Papworth,HOSPITAL,Y
+LISTEV,Lister Stevenage,Lister Stevenage,HOSPITAL,Y
+AULPO,NPS Ashton-under-Lyne,NPS Ashton-under-Lyne,COMM,Y
+AULMPO,Ashton-under-Lyne MAPPA Unit,Ashton-under-Lyne MAPPA Unit,COMM,Y
+KNOWPO,Knowsley YOS,Knowsley YOS,COMM,Y
+CARDCR,Cardiff CRC,Cardiff CRC,CRC,Y
+SWS015,Bridge End CRC,Bridge End CRC,CRC,Y
+MEDWY2,Medway Chatham Probation CRC,Medway Chatham  Probation CRC,CRC,N
+CHTHPO,Chatham Probation Office,Chatham Probation Office,COMM,Y
+LLANPO,Llangefni Probation Office,Llangefni Probation Office,COMM,Y
+TYNE01,Northumbria CRC,Northumbria CRC,CRC,Y
+MLW051,West Bromwich Police Station,West Bromwich Police Station,POLICE,Y
+BANBCT,Banbury County Court,Banbury County Court,CRT,Y
+LEAMCT,Leamington Spa County Court,Leamington Spa County Court,CRT,Y
+MANCCT,Manchester Civil Justice Centre,Manchester Civil Justice Centre,CRT,Y
+PRINCT,Central Family Court,Central Family Court,CRT,Y
+SOUTCT,Southport County Court,Southport County Court,CRT,Y
+KINGCC,Kingston-upon-Hull Crown Court,Kingston-upon-Hull Crown Court,CRT,Y
+BRIGMC,Brighton Combined Court,Brighton Combined Court,CRT,N
+HATFMC,Hatfield Remand Court,Hatfield Remand Court,CRT,Y
+HIGHMC,High Wycombe Magistrates Court,High Wycombe Magistrates Court,CRT,Y
+HIGBMC,Highbury Corner Magistrates Court,Highbury Corner Magistrates Court,CRT,Y
+MEDWMC,Medway Magistrates Court,Medway Magistrates Court,CRT,Y
+NEWPMC,Newport (South Wales) Magistrates Court,Newport (South Wales) Magistrates Court,CRT,Y
+NORTMC,North Shields Magistrates Court,North Shields Magistrates Court,CRT,N
+NORSMC,North Somerset Magistrates Court,North Somerset Magistrates Court,CRT,Y
+NUNEMC,Nuneaton Magistrates Court,Nuneaton Magistrates Court,CRT,N
+SCARMC,Scarborough Magistrates Court,Scarborough Magistrates Court,CRT,Y
+SEFTMC,Sefton Magistrates Court,Sefton Magistrates Court,CRT,Y
+WESTMC,Westminster Magistrates Court,Westminster Magistrates Court,CRT,Y
+WORNMC,Workington (West Cumbria) Magistrates Ct,Workington (West Cumbria) Magistrates Ct,CRT,Y
+CHICPL,Chichester Police Station,Chichester Police Station,POLICE,N
+SUS7,Chichester Police Station,Chichester Police Station,POLICE,Y
+MWBHOS,NHS Meadowbrook Mental Health Unit,NHS Meadowbrook Mental Health Unit,HOSPITAL,Y
+HSTHOS,NHS Hallam Street Hospital,NHS Hallam Street Hospital,HOSPITAL,Y
+ALDHOS,NHS Alderley Unit,NHS Alderley Unit,HOSPITAL,Y
+PNRPO,Preston New Road Probation Office,Preston New Road Probation Office,COMM,Y
+PEPSPO,Penrith Probation Service,Penrith Probation Service,COMM,Y
+KNOHEL,Knowsley & St Helens CRC,Knowsley & St Helens CRC,CRC,Y
+HPS055,Two Saints Hostel,Two Saints Hostel,APPR,Y
+THA011,Thames Valley CRC,Thames Valley CRC,CRC,Y
+YSN010,Selby CRC,Selby CRC,CRC,Y
+NFK012,Norwich Rehabilitation Centre,Norwich Residential Rehabilitation Centre,APPR,Y
+DUN001,Dundee Criminal Justice Office,Dundee Criminal Justice Office,COMM,Y
+STCUSU,Staines Custody Suite,Staines Custody Suite,POLICE,Y
+SFCUSU,Salfords Custody Suite,Salfords Custody Suite,POLICE,N
+TVP1,Abingdon Custody Suite,ABINGDON POLICE STATION,POLICE,Y
+MPS1,Acton Custody Suite,Acton Police Station,POLICE,Y
+DP2,Ammanford Custody Suite,AMMANFORD POLICE STATION,POLICE,Y
+NFL1,Aylsham Custody Suite,Aylsham PIC,POLICE,Y
+SYP1,Barnsley Custody Suite,BARNSLEY POLICE STATION,POLICE,Y
+DC1,Barnstaple Custody Suite,BARNSTAPLE POLICE STATION,POLICE,Y
+ESX1,Basildon Custody Suite,Basildon Police Station,POLICE,Y
+HNT1,Basingstoke Custody Suite (North),BASINGSTOKE PIC,POLICE,Y
+LCS1,Beaumont Leys Custody Suite,BEAUMONT LEYS POLICE STATION,POLICE,Y
+MPS2,Bethnal Green Custody Suite,BETHNAL GREEN POLICE STATION,POLICE,Y
+DHM1,Bishop Auckland Custody Suite,BISHOP AUCKLAND POLICE STATION,POLICE,Y
+LNC1,Boston Custody Suite,BOSTON POLICE STATION,POLICE,Y
+DST1,Bournemouth Custody Suite,BOURNEMOUTH POLICE STATION,POLICE,Y
+WMP1,BOURNVILLE LANE POLICE STATION,BOURNVILLE LANE POLICE STATION,POLICE,N
+NTS1,Nottingham Bridewell Custody Suite,BRIDEWELL (NOTTINGHAM) POLICE STATION,POLICE,Y
+HMB1,BRIDLINGTON POLICE STATION,BRIDLINGTON POLICE STATION,POLICE,N
+SUS1,Brighton Custody Suite,BRIGHTON POLICE STATION,POLICE,Y
+MPS3,Brixton Custody Suite,Brixton Police Station,POLICE,Y
+STF1,Burton Central Custody Suite,BURTON CENTRAL POLICE STATION,POLICE,Y
+SFL1,Bury St Edmunds Custody Suite,Bury St Edmunds PIC,POLICE,Y
+DRB1,BUXTON POLICE STATION,BUXTON POLICE STATION,POLICE,N
+NWA1,Caernarfon Custody suite,CAERNARFON POLICE STATION,POLICE,Y
+WYP1,Halifax Custody Suite,"Halifax Central Police Station - Richmond Close, Halifax",POLICE,Y
+DC2,Camborne Custody Suite,CAMBORNE POLICE STATION,POLICE,Y
+CAM1,Parkside Custody Suite,Cambridge (Parkside) Police Station,POLICE,Y
+KNT1,Canterbury Custody Suite,CANTERBURY POLICE STATION,POLICE,Y
+SWL1,Cardiff Bay Custody Suite,CARDIFF BAY POLICE STATION,POLICE,Y
+NFK011,Norfolk and Suffolk CRC,Norfolk and Suffolk Community Rehabilitation Company,CRC,Y
+WILTCR,BGSW CRC,BGSW CRC,CRC,Y
+MRS009,Liverpool Probation Office,Liverpool Probation Office,COMM,Y
+HUNHOU,Huntingdon House CRC,Huntingdon House CRC,CRC,Y
+BUDCRC,Bude Reporting Centre,Bude Reporting Centre,CRC,Y
+DUR020,Durham Tees Valley CRC,Durham Tees Valley CRC,CRC,Y
+LDM182,London Community Rehabilitation Company,London Community Rehabilitation Company,CRC,Y
+MLW052,Langley House Trust Office,Langley House Trust Office,CRC,Y
+STC1,Medway Secure Training Centre,Medway secure training Centre,STC,Y
+STC2,Rainsbrook Secure Training Centre,Rainsbrook Secure Training Centre,STC,Y
+STC3,Oakhill Secure Training Centre,Oakhill Secure Training Centre,STC,Y
+CMB1,Carlisle Durranhill Custody Suite,CARLISLE POLICE STATION,POLICE,Y
+DC3,Plymouth Custody Suite,PLYMOUTH CENTRAL (CHARLES CROSS) POLICE STATION,POLICE,Y
+GMP1,Cheadle Heath Custody Suite,CHEADLE HEATH POLICE STATION,POLICE,Y
+ESX2,Chelmsford Custody Suite,Chelmsford Police Station,POLICE,Y
+DRB2,Chesterfield Custody Suite,CHESTERFIELD POLICE STATION,POLICE,Y
+ESX3,Clacton Custody Suite,Clacton Police Station,POLICE,Y
+HMB2,Clough Road Custody Suite,CLOUGH ROAD CUSTODY SUITE,POLICE,Y
+ESX4,Colchester Custody Suite,COLCHESTER POLICE STATION,POLICE,Y
+MPS4,Colindale Custody Suite,COLINDALE POLICE STATION,POLICE,Y
+MRS1,Copy Lane Custody Suite,COPY LANE POLICE STATION,POLICE,Y
+WMP2,Coventry Central Custody Suite,Coventry Police Station,POLICE,Y
+DHM2,Darlington Custody Suite,DARLINGTON POLICE STATION,POLICE,Y
+NWA2,Dolgellau Custody Suite,DOLGELLAU POLICE STATION,POLICE,Y
+SYP2,Doncaster Custody Suite,DONCASTER CENTRAL POLICE STATION,POLICE,Y
+DHM3,Durham City Custody Suite,DURHAM POLICE STATION,POLICE,Y
+LCS2,Euston Street Custody Suite,Euston Street Police Station,POLICE,Y
+DC4,Exeter Custody Suite,EXETER POLICE STATION,POLICE,Y
+MPS5,Forest Gate Custody Suite,FOREST GATE POLICE STATION,POLICE,Y
+LNC2,Grantham Custody Suite,GRANTHAM POLICE STATION,POLICE,Y
+ESX5,Grays Custody Suite,GRAYS POLICE STATION,POLICE,Y
+NFL2,Great Yarmouth Custody Suite,Great Yarmouth PIC,POLICE,Y
+ESX6,Harlow Custody Suite,Harlow Police Station,POLICE,Y
+NYK1,Harrogate Custody Suite,HARROGATE POLICE STATION,POLICE,Y
+SUS2,Hastings Custody Suite,HASTINGS POLICE STATION,POLICE,Y
+WWM1,Hereford Custody Suite,HEREFORD POLICE STATION,POLICE,Y
+TVP2,High Wycombe Custody Suite,HIGH WYCOMBE POLICE STATION,POLICE,Y
+MPS6,Holborn Custody Suite,HOLBORN POLICE STATION,POLICE,Y
+MPS7,Ilford Custody Suite,Ilford Police Station,POLICE,Y
+MPS8,Islington Custody Suite,Islington Police Station,POLICE,Y
+BDS1,Luton Custody Suite,Bedford (Kempston) Police Station,POLICE,Y
+LCS3,Keyham Lane Custody Suite,KEYHAM LANE (HAMILTON) POLICE STATION,POLICE,Y
+AVS1,Keynsham Custody Suite,KEYNSHAM POLICE CENTRE ,POLICE,Y
+WWM2,Kidderminster Custody Suite,KIDDERMINSTER POLICE STATION,POLICE,Y
+MPS9,Kingston Custody Suite,Kingston Police Station,POLICE,Y
+WYP2,Huddersfield Custody Suite,Huddersfield Police Station,POLICE,Y
+LAN1,Lancaster Custody Suite,LANCASTER POLICE STATION,POLICE,Y
+WYP3,Elland Road Custody Suite,Leeds Bridewell Police Station,POLICE,Y
+LNC3,Lincoln Custody Suite,LINCOLN POLICE STATION,POLICE,Y
+GMP2,Longsight Custody Suite,LONGSIGHT POLICE STATION,POLICE,Y
+BDS2,Kempston Custody Suite,LUTON POLICE STATION,POLICE,Y
+NTS2,Mansfield Custody Suite,MANSFIELD POLICE STATION,POLICE,Y
+KNT2,Margate Custody Suite,MARGATE POLICE STATION,POLICE,Y
+SFL2,Martlesham Custody Suite,Martlesham PIC,POLICE,Y
+KNT3,Medway Custody Suite,MEDWAY POLICE STATION,POLICE,Y
+NRU1,Middle Engine Custody Suite,Wallsend Police Station,POLICE,Y
+CVL1,Middlesbrough District Police Station,Middlesbrough District Police Station,POLICE,N
+TVP3,Milton Keynes Custody Suite,MILTON KEYNES POLICE STATION,POLICE,Y
+TVP4,Newbury Custody Suite,NEWBURY POLICE STATION,POLICE,Y
+GWN1,Newport Custody Suite (Gwent),NEWPORT (SW) CENTRAL POLICE STATION,POLICE,Y
+HNT2,Newport Custody Suite (IOW),NEWPORT (IOW) PS,POLICE,Y
+DC5,Newquay Custody Suite,NEWQUAY POLICE STATION,POLICE,Y
+DP3,Newtown Custody Suite,NEWTOWN POLICE STATION,POLICE,Y
+WMP3,Oldbury Custody Suite,OLDBURY CUSTODY BLOCK,POLICE,Y
+AVS2,Patchway Custody Suite,PATCHWAY POLICE CENTRE ,POLICE,Y
+WMP4,Perry Barr Custody Suite,PERRY BARR CUSTODY SUITE,POLICE,Y
+CAM2,PETERBOROUGH (THORPEWOOD) POLICE STATION,PETERBOROUGH (THORPEWOOD) POLICE STATION,POLICE,N
+MPS10,Plumstead Custody Suite,Plumstead Police Station,POLICE,Y
+HNT3,Eastern PIC Custody Suite,Eastern PIC Custody Suite,POLICE,Y
+MPS11,Romford Custody Suite,Romford Police Station,POLICE,Y
+SRY1,SALFORDS (SURREY) CUSTODY SUITE,SALFORDS (SURREY) CUSTODY SUITE,POLICE,Y
+NYK2,Scarborough Custody Suite,SCARBOROUGH POLICE STATION,POLICE,Y
+WWM3,Shrewsbury Custody Suite,SHREWSBURY POLICE STATION,POLICE,Y
+LNC4,Skegness Custody Suite,SKEGNESS POLICE STATION,POLICE,Y
+LAN2,Skelmersdale Custody Suite,SKELMERSDALE POLICE STATION,POLICE,Y
+WMP6,SOLIHULL POLICE STATION,SOLIHULL POLICE STATION,POLICE,N
+HNT4,Southampton Custody Suite (Central),SOUTHAMPTON CENTRAL POLICE STATION,POLICE,Y
+ESX7,Southend Custody Suite,Southend-On-Sea Police Station,POLICE,Y
+NRU2,Southwick Custody Suite,SOUTHWICK POLICE STATION,POLICE,Y
+MRS2,St Anne St. Custody Suite,ST. ANNE STREET POLICE STATION,POLICE,Y
+STF2,Watling Custody Suite,WATLING HOUSE POLICE STATION (WGHPS),POLICE,Y
+SRY2,STAINES POLICE STATION,STAINES POLICE STATION,POLICE,N
+HRT1,Stevenage Custody Suite,Stevenage Police Station,POLICE,Y
+MPS12,Stoke Newington Custody Suite,Stoke Newington Police Station,POLICE,Y
+GMP3,Tameside Custody Suite,Ashton Police Station,POLICE,Y
+WWM4,Malinsgate Custody Suite,Malinsgate Police Station,POLICE,Y
+DC6,Torquay Custody Suite,TORQUAY POLICE STATION,POLICE,Y
+MPS13,Wandsworth Custody Suite,WANDSWORTH POLICE STATION,POLICE,Y
+MPS14,Wembley Custody Suite,Wembley Police Station,POLICE,Y
+WMP5,Wolverhampton Custody Suite,WOLVERHAMPTON POLICE STATION,POLICE,Y
+SUS3,Worthing Custody Suite,WORTHING POLICE STATION,POLICE,Y
+NWA3,WREXHAM POLICE STATION,WREXHAM POLICE STATION,POLICE,N
+NFL3,Wymondham Custody Suite,Wymondham PIC,POLICE,Y
+NYK3,York Custody Suite,YORK POLICE STATION,POLICE,Y
+BTP1,Central London Custody Suite (BTP),Central London Police Station,POLICE,Y
+BTP2,West Ham Custody Suite (BTP),West Ham BTP,POLICE,Y
+BTP3,"BTP, Fulham Palace Road","BTP, Fulham Palace Road",POLICE,Y
+TVP5,Aylesbury Custody Suite,"Wendover Rd, Aylesbury",POLICE,Y
+TVP6,Banbury Custody Suite,"Warwick Rd, Banbury",POLICE,Y
+MPS15,Barking & Dagenham Custody Suite,"Unit 24, Muirhead Quay, Quay Rd, Barking",POLICE,Y
+CMB2,Barrow Custody Suite,"Andrews Way, Barrow-in-Furness",POLICE,Y
+MPS16,Bexleyheath Custody Suite,2 Arnsberg Way,POLICE,Y
+CLP1,Bishopsgate Custody Suite,182 Bishopsgate,POLICE,Y
+LAN3,Greenbank Custody Suite,BLACKBURN (EASTERN DIV) POLICE STATION,POLICE,Y
+LAN4,Blackpool Custody Suite,Gerry Richardson Way,POLICE,Y
+CHE1,Blacon Custody Suite,"Blacon Ave, Blacon, Chester",POLICE,Y
+WMP7,Bloxwich Custody Suite,Station Street,POLICE,Y
+GMP4,Bolton Custody Suite,"Scholey Street, Manchester Road, Bolton",POLICE,Y
+WYP4,Bradford Custody Suite,"58 Nelson St, Bradford��",POLICE,Y
+DP4,Brecon Custody Suite,"Plas Y Ffynnon, Cambrian Way, Brecon",POLICE,Y
+SWL2,Bridgend Custody Suite,"Brackla St, Bridgend��",POLICE,Y
+AVS3,Bridgwater Custody Suite,"��Express Park, Bristol Rd, Bridgwater��",POLICE,Y
+MPS17,Bromley Custody Suite,"��High St, Bromley",POLICE,Y
+LAN5,Burnley Custody Suite,"Parker Ln, Burnley",POLICE,Y
+GMP5,Bury Custody Suite,"Dunster Rd, Bury",POLICE,Y
+DP5,Cardigan Custody Suite,Priory Street,POLICE,Y
+MPS18,Charing Cross Custody Suite (Lower),"Agar St, Charing Cross, London",POLICE,Y
+MPS19,Charing Cross Custody Suite (Upper),"Agar St, Charing Cross, London",POLICE,Y
+NTT1,Northampton (HQ) Police Station,"700 Pavilion Dr, Northampton",POLICE,Y
+GCS1,Compass House Custody Suite,"1 Waterwells Dr, Quedgeley, Gloucester",POLICE,Y
+DHM4,Consett Custody Suite,"Parliament St, Consett",POLICE,Y
+SUS4,Crawley Custody Suite,"Northgate Ave, Crawley",POLICE,Y
+MPS20,Croydon Custody Suite,"90 Windmill Rd, Croydon",POLICE,Y
+DRB3,St Mary's Wharf Police Station,St Mary's Wharf Police Station,POLICE,Y
+WYP5,Dewsbury Custody Suite,Aldams Road,POLICE,Y
+BDS3,Dunstable Police Station,"40 West St, Dunstable��",POLICE,N
+SUS5,Eastbourne Custody Suite,"Hammonds Dr, Eastbourne",POLICE,Y
+MPS21,Edmonton Custody Suite,462 Fore Street,POLICE,Y
+KNT4,Folkestone Custody Suite,"Bouverie House, Bouverie Rd W, Folkestone",POLICE,Y
+NRU3,Forth Banks Custody Suite,"Forth Banks, Newcastle upon Tyne��",POLICE,Y
+DRB4,Glossop,"Ellison St, Glossop��",POLICE,N
+SRY3,GUILDFORD POLICE STATION,"Margaret Rd, Guildford",POLICE,N
+MPS22,Hammersmith Custody Suite,31 Fulham Place Road,POLICE,Y
+CVL2,HARTLEPOOL POLICE STATION,"Avenue Rd, Hartlepool TS24 8AJ",POLICE,N
+HRT2,Hatfield Custody Suite,"Comet Way, Hatfield",POLICE,N
+DP6,Haverfordwest Custody Suite,Haverfordwest,POLICE,Y
+MPS23,Heathrow Custody Suite,"316 Bath Rd, Sipson, Harmondsworth, West Drayton",POLICE,Y
+CAM3,Huntingdon Custody Suite,"Ferrars Rd, Huntingdon",POLICE,Y
+CMB3,Kendal Custody Suite,"Busher Walk, Kendal",POLICE,Y
+NTT3,Kettering Custody Suite,"Cherry Hall Rd, Kettering",POLICE,Y
+NFL4,Kings Lynn Custody Suite,"��St James St, King's Lynn",POLICE,N
+LDM134,Greater London Probation Service,Greater London Probation Service,COMM,Y
+WWM5,Leamington Spa Custody Suite,"Warwickshire Justice Centre, Newbold Terrace, Leamington Spa",POLICE,Y
+MPS24,Lewisham Custody Suite,"��43 Lewisham High St, Lewisham, London",POLICE,Y
+MPS25,Leyton Custody Suite,"Boreham Cl, Leyton, London",POLICE,Y
+DP7,Llanelli Custody Suite,Waunlanyrfon,POLICE,Y
+TVP7,Loddon Valley Custody Suite,"Rushey Way, Lower Earley, Berks��",POLICE,Y
+HNT5,Lyndhurst,Pikes Hill,POLICE,N
+TVP8,Maidenhead Custody Suite,"Bridge Rd, Maidenhead",POLICE,Y
+KNT5,Maidstone Custody Suite,"Palace Ave, Maidstone",POLICE,Y
+CAM4,March Custody Suite,"Burrowmoor Rd, March",POLICE,Y
+WLT1,Melksham Custody Suite,"Hampton Park W, Melksham��",POLICE,Y
+SWL3,Merthyr Tydfil Custody Suite,Merthyr Tydfil,POLICE,Y
+CHE2,Middlewich Custody Suite,"35B Queen St, Middlewich",POLICE,Y
+NTS3,Newark Custody Suite,"Queen's Rd, Newark",POLICE,Y
+KNT6,North Kent Custody Suite,"Thames Way, Northfleet, Gravesend, Kent",POLICE,Y
+GMP6,North Manchester Custody Suite,"Northampton Rd, Manchester",POLICE,Y
+NYK4,Northallerton,72 High Street,POLICE,N
+WWM6,Nuneaton Custody Suite,"Warwickshire Justice Centre, Vicarage Street, Nuneaton",POLICE,Y
+MPS26,Peckham Custody Suite,177 Peckham High Street,POLICE,Y
+GMP7,Pendleton Custody Suite,"Meyrick Rd, Salford M6 5RN",POLICE,Y
+DHM5,Peterlee Custody Suite,"St Aidans Way, Peterlee",POLICE,Y
+DST2,Poole Custody Suite,"Wimborne Road, Poole",POLICE,Y
+LAN6,Preston Custody Suite,"Lancaster Rd N, Preston",POLICE,Y
+HMB3,Priory Road Custody Suite,Priory Road,POLICE,Y
+DRB5,Ripley Custody Suite,Wyatts Way,POLICE,N
+CHE3,Runcorn Custody Suite,"Halton Link Rd, Runcorn",POLICE,Y
+SYP3,Shepcote Lane Custody Suite,"Shepcote Ln, Sheffield��",POLICE,Y
+NRU4,South Tynside Custody Suite,"Millbank, Station Road",POLICE,Y
+DHM6,Spennymoor Custody Suite,Wesleyan Road,POLICE,Y
+NWA4,St Asaph Police Station,"St Asaph Business Park, Saint Asaph",POLICE,Y
+MRS3,Belle Vale Custody Suite,College Street,POLICE,Y
+STF3,STAFFORD POLICE STATION,Eastgate Street,POLICE,N
+WYP6,Stainbeck Custody Suite,"Stainbeck Ln, Leeds",POLICE,Y
+WMP8,Stechford Custody Suite,"338 Station Rd, Birmingham",POLICE,Y
+STF4,Northern Area Custody Suite,"5NP, Crown St��",POLICE,Y
+SWL4,Swansea Central Custody Suite,"Grove Place, Swansea",POLICE,N
+WLT4,Swindon Gablecross Custody Suite,"Shrivenham Rd, Swindon",POLICE,Y
+GMP8,Swinton Custody Suite,"Greater Manchester Police, Chorley Rd, Swinton, Manchester��",POLICE,Y
+STF5,TAMWORTH NORTH POLICE STATION (TMWPS),Spinning School Lane,POLICE,N
+KNT7,Tonbridge Custody Suite,"1 Pembury Rd, Tonbridge",POLICE,Y
+WYP7,Havertop Custody suite,"Havertop Ln, Normanton",POLICE,N
+MPS27,Walworth Custody Suite,"12-28 Manor Pl, Walworth, London",POLICE,Y
+HNT6,Waterlooville Custody Suite,Swiss Road,POLICE,Y
+MRS4,Wavertree Road Custody Suite,Wavertree Road,POLICE,Y
+MPS28,West End Central Custody Suite,"  27 Savile Row, Mayfair, London ",POLICE,N
+DST3,Weymouth Custody Suite,"Radipole Ln, weymouth",POLICE,Y
+GMP9,Wigan Custody Suite,"Robin Park Rd, Wigan",POLICE,Y
+MRS5,Wirral Custody Suite,"Mortimer St, Birkenhead",POLICE,Y
+SRY4,Woking Custody Suite,Station Approach,POLICE,Y
+MPS29,Wood Green Custody Suite,"Wood Green, London",POLICE,Y
+CLP2,Wood Street,Wood Street,POLICE,N
+WWM7,Worcester Custody Suite,"Castle St, Worcester",POLICE,Y
+CMB4,Workington Custody Suite,"West Area Headquarters, Hall Brow, Workington��",POLICE,Y
+GWN2,Ystrad Mynach Custody Suite,"7ep, 9 Caerphilly Rd, Ystrad Mynach, Hengoed��",POLICE,Y
+BTP4,Brewery Road Custody Suite (BTP),Brewery Road BTP,POLICE,Y
+BTP5,Wembley Custody Suite (BTP),"49 Bridge Road, Wembley",POLICE,Y
+CAM5,Thorpe Wood Custody Suite,Thorpe Wood Custody Suite,POLICE,Y
+NWA5,Llay Custody Suite,Llay Police Station,POLICE,Y
+CVL3,Middlehaven Custody Suite,Middlehaven Custody Suite,POLICE,Y
+ECW001,Emmaus Coventry and Warwickshire,Emmaus Coventry and Warwickshire,APPR,Y
+CBS013,Cambridge Probation Office			,Cambridge Probation Office	,COMM,Y
+FYI,FELTHAM A (HMPYOI),FELTHAM A (HMPYOI),INST,Y
+HORN01,Hornchurch CRC,Hornchurch CRC,CRC,Y
+BDS013,Luton Probation Office,Luton Probation Office,COMM,Y
+CLP3,Snow Hill Custody Suite,Snow Hill Custody Suite,POLICE,Y
+MPS63,Southall Custody Suite,Southall Custody Suite,POLICE,N
+DRB7,Buxton Custody Suite,Buxton Custody Suite,POLICE,Y
+WMP13,Chace Av (Willenhall) Custody Suite,Chace Av (Willenhall) Custody Suite,POLICE,Y
+NTH1,Corby Custody Suite,Corby Custody Suite,POLICE,Y
+NTH2,Daventry Custody Suite,Daventry Custody Suite,POLICE,Y
+NTH4,Northampton CJC Brackmills CS,Northampton CJC Brackmills CS,POLICE,Y
+WMP23,Solihull Custody Suite,Solihull Custody Suite,POLICE,Y
+NTH5,Wellingborough Custody Suite,Wellingborough Custody Suite,POLICE,Y
+NRU5,Bedlington Custody Suite,Bedlington Custody Suite,POLICE,Y
+NRU6,Berwick Custody Suite,Berwick Custody Suite,POLICE,Y
+NRU7,Etal Lane Custody Suite,Etal Lane Custody Suite,POLICE,Y
+WYP19,Wakefield District Custody Suite,Wakefield District Custody Suite,POLICE,Y
+LAN7,Blackburn (Eastern Div) Custody Suite,Blackburn (Eastern Div) Custody Suite,POLICE,N
+NFL5,Kings Lynn PIC,Kings Lynn PIC,POLICE,Y
+DST4,Blandford Custody Suite,Blandford Custody Suite,POLICE,Y
+DST6,Christchurch Custody Suite,Christchurch Custody Suite,POLICE,Y
+DC8,Launceston Custody Suite,Launceston Custody Suite,POLICE,Y
+GCS5,Stroud Custody Suite,Stroud Custody Suite,POLICE,Y
+WLT7,Swindon Custody Suite,Swindon Custody Suite,POLICE,N
+DP8,Brecon Custody Suite,Brecon Custody Suite,POLICE,N
+NWA7,Mold Custody Suite,Mold Custody Suite,POLICE,Y
+SWL17,Swansea Custody Suite,Swansea Custody Suite,POLICE,Y
+BIGAPT,Biggin Hill Airport,Biggin Hill Airport,AIRPORT,Y
+BROIRC,Brook House Immigration Removal Centre,Brook House Immigration Removal Centre,IMDC,Y
+CAMIRC,Campsfield House IRC,Campsfield House IRC,IMDC,Y
+MORIRC,Morton Hall Immigration Removal Centre,Morton Hall Immigration Removal Centre,IMDC,Y
+PENIRC,Pennine House Immigration Removal Centre,Pennine House Immigration Removal Centre,IMDC,Y
+TINIRC,Tinsley House Immigration Removal Centre,Tinsley House Immigration Removal Centre,IMDC,Y
+YARIRC,Yarlswood Immigration Removal Centre,Yarlswood Immigration Removal Centre,IMDC,Y
+HUNTBC,Huntingdon Law Courts,Huntingdon Law Courts,CRT,N
+KINGBC,King's Lynn Combined Court,King's Lynn Combined Court,CRT,N
+NEWCBC,Newcastle-Upon-Tyne Comb. Ct. (Quayside),Newcastle-Upon-Tyne Comb. Ct. (Quayside),CRT,N
+SOUTBC,Southend Combined Court,Southend Combined Court,CRT,N
+STOKBC,Stoke-on-Trent Combined Court,Stoke-on-Trent Combined Court,CRT,N
+WARWBC,Warwickshire Justice Centre (L'ton Spa),Warwickshire Justice Centre (L'ton Spa),CRT,N
+BARRBC,Barrow-in-Furness Combined Court,Barrow-in-Furness Combined Court,CRT,N
+BOLTBC,Bolton Combined Court,Bolton Combined Court,CRT,N
+CBS014,Cambridge Bench CRC,Cambridge Neighbourhood Centre,CRC,Y
+EXETBC,Exeter Combined Court Centre,Exeter Combined Court Centre,CRT,N
+SALIBC,Salisbury Law Courts,Salisbury Law Courts,CRT,N
+CAERBC,Caernarfon Combined Court,Caernarfon Combined Court,CRT,N
+HAVEBC,Haverfordwest Combined Court,Haverfordwest Combined Court,CRT,N
+MERTBC,Merthyr Tydfil Combined Court,Merthyr Tydfil Combined Court,CRT,N
+MOLDBC,Mold Combined Court,Mold Combined Court,CRT,N
+NEWPBC,Newport (IoW) Combined Court,Newport (IoW) Combined Court,CRT,N
+OAKTHO,Oaktree Manor,Oaktree Manor,HOSPITAL,Y
+ROBIHO,Robin Pinto,Robin Pinto,HOSPITAL,Y
+ROWAHO,Rowan House,Rowan House,HOSPITAL,Y
+STAEHO,St Andrew's Healthcare Essex,St Andrew's Healthcare Essex,HOSPITAL,Y
+STMAHO,St Magnus,St Magnus,HOSPITAL,Y
+SUTTHO,Sutton Manor,Sutton Manor,HOSPITAL,Y
+TAREHO,Tarentfort Centre,Tarentfort Centre,HOSPITAL,Y
+WESTHO,Westwood Unit/Westwood Centre,Westwood Unit/Westwood Centre,HOSPITAL,Y
+WOODHO,Woodlands,Woodlands,HOSPITAL,Y
+WODLHO,Woodlea,Woodlea,HOSPITAL,Y
+YEWTHO,Yew Trees,Yew Trees,HOSPITAL,Y
+CALVHO,Calverton Hill,Calverton Hill,HOSPITAL,Y
+DOULHO,Doulton Lodge,Doulton Lodge,HOSPITAL,Y
+FRANHO,Francis Willis Unit,Francis Willis Unit,HOSPITAL,Y
+MEAVHO,Meadow View,Meadow View,HOSPITAL,Y
+WELLHO,Wells Road Service,Wells Road Service,HOSPITAL,Y
+BATTHO,Battersea Bridge House,Battersea Bridge House,HOSPITAL,Y
+BOSTHO,Bostall House,Bostall House,HOSPITAL,Y
+CYGWHO,Cygnet Wing Blackheath,Cygnet Wing Blackheath,HOSPITAL,Y
+HAZEHO,Hazelwood & Greenwood Unit,Hazelwood & Greenwood Unit,HOSPITAL,Y
+HOPTHO,Hopton Road - SLAM,Hopton Road - SLAM,HOSPITAL,Y
+TOWEHO,Tower Hamlets Ctr for MH (Mill. & Rb. W),Tower Hamlets Ctr for MH (Mill. & Rb. W),HOSPITAL,Y
+WARDHO,Ward in the Community - SLAM,Ward in the Community - SLAM,HOSPITAL,Y
+GERRHO,Gerry Simon Clinic,Gerry Simon Clinic,HOSPITAL,Y
+HILLHO,Hillis Lodge,Hillis Lodge,HOSPITAL,Y
+STABHO,St Andrew's Healthcare - Birmingham,St Andrew's Healthcare - Birmingham,HOSPITAL,Y
+THEWHO,"The Woodhouse, Acorncare","The Woodhouse, Acorncare",HOSPITAL,Y
+WROXHO,Wroxeter Ward,Wroxeter Ward,HOSPITAL,Y
+BIGFHO,Bigfoot Independent Hospital,Bigfoot Independent Hospital,HOSPITAL,Y
+CHARHO,Charles House,Charles House,HOSPITAL,Y
+HAMPHO,Hamptons,Hamptons,HOSPITAL,Y
+JIGSHO,Jigsaw Independent Hospital,Jigsaw Independent Hospital,HOSPITAL,Y
+REGEHO,"Regency Lodge, Heswall","Regency Lodge, Heswall",HOSPITAL,Y
+RIDGHO,Ridge Lea Hospital,Ridge Lea Hospital,HOSPITAL,Y
+STMYHO,St Mary's Hospital,St Mary's Hospital,HOSPITAL,Y
+STMBHO,St Marys Hspl. (Burl'ton Wd & Harlow Wd),St Marys Hspl. (Burl'ton Wd & Harlow Wd),HOSPITAL,Y
+AVONHO,"Avon House, Devon Partnership trust","Avon House, Devon Partnership trust",HOSPITAL,Y
+BUTLHO,Butler Clinic,Butler Clinic,HOSPITAL,Y
+CYGKHO,Cygnet Kewstoke,Cygnet Kewstoke,HOSPITAL,Y
+ALPHHO,Alpha Hospitals Sheffield,Alpha Hospitals Sheffield,HOSPITAL,Y
+COUNHO,County Unit,County Unit,HOSPITAL,Y
+CYGBHO,"Cygnet, Bierley","Cygnet, Bierley",HOSPITAL,Y
+WATHHO,Wathwood Hospital,Wathwood Hospital,HOSPITAL,Y
+HUNCRC,Huntington CRC,Huntington CRC,CRC,Y
+YSN024,Scarborough NPS Office,Scarborough National Probation Service,COMM,Y
+GMP13,Manchester Airport Police Station,Manchester Airport Police Station,POLICE,Y
+BLUBHO,Bluebird House,Bluebird House,HOSPITAL,Y
+FARNHO,FARNBOROUGH HOSPITAL,FARNBOROUGH HOSPITAL,HOSPITAL,Y
+KICOHO,KINGS COLLEGE HOSPITAL,KINGS COLLEGE HOSPITAL,HOSPITAL,Y
+NHSMHO,NHS MEADOWFIELD HOSPTIAL,NHS MEADOWFIELD HOSPTIAL,HOSPITAL,Y
+NWLMHO,NHS WOOTON LAWN MENTAL HOSPITAL,NHS WOOTON LAWN MENTAL HOSPITAL,HOSPITAL,Y
+SOUAPT,SOUTHAMPTON AIRPORT,SOUTHAMPTON AIRPORT,AIRPORT,Y
+CUCOCT,SURREY CORONERS COURT,SURREY CORONERS COURT,CRT,Y
+NANUHO,NORFOLK AND NORWICH UNIVERSITY HOSPITAL,NORFOLK AND NORWICH UNIVERSITY HOSPITAL,HOSPITAL,Y
+NHLMHO,NHS LYNFIELD MOUNT HOSPITAL,NHS LYNFIELD MOUNT HOSPITAL,HOSPITAL,N
+NFL6,NORWICH CITY POLICE STATION,NORWICH CITY POLICE STATION,POLICE,Y
+MPS34,Harrow Road Police Station,Harrow Road Police Station,POLICE,Y
+DUNIRC,Dungavel House IRC,Dungavel House Immigration Remand Centre,IMDC,Y
+HMWIRC,Harmondsworth Immigration Removal Centre,Harmondsworth Immigration Removal Centre,IMDC,Y
+LARIRC,Larne House Immigration Removal Centre,Larne House Immigration Removal Centre,IMDC,Y
+MONTHO,Montpellier Secure Recovery Unit,Montpelier Secure Recovery Unit,HOSPITAL,Y
+UHCHOS,University Hospital Cov. And W'wickshire,University Hospital Coventry and Warwickshire,HOSPITAL,Y
+HILLIH,Hillingdon Hospital,Hillingdon Hospital,HOSPITAL,Y
+NORPO,Northwich Probation Service,Northwich Probation Service,COMM,Y
+SEFPO,Sefton YOS,Sefton YOS,COMM,Y
+STHYPO,NPS YOS St Helens,NPS YOS St Helens,COMM,Y
+STOYPO,Stockport YOS,Stockport YOS,COMM,Y
+KENPO,Kent Probation Service,Kent Probation Service,COMM,Y
+MENPO,Meneghy House,Meneghy House,COMM,Y
+BRIPO,Bridgend Probation Office,Bridgend Probation Office,COMM,Y
+CCJCPO,Caernarfon Criminal Justice Centre,Caernarfon Criminal Justice Centre,COMM,Y
+CHUCPO,Churchill House,Churchill House,COMM,Y
+DPMUPO,Dyfed Powys MAPPA Unit,Dyfed Powys MAPPA Unit,COMM,Y
+NEPOPO,North East Primary Office,North East Primary Office,COMM,Y
+NUTMQC,Newcastle Upon Tyne Mag Court (Quayside),Newcastle Upon Tyne Mag Court (Quayside),CRT,Y
+SRY019,Redhill Probation Office NPS,Redhill Probation Office NPS,COMM,Y
+SOLOHO,Southfield Low Secure Unit,Southfield Low Secure Unit,HOSPITAL,Y
+DHM8,Peterlee Police Station,Peterlee Police Station,POLICE,Y
+FNP1,HMP Edinburgh,HMP Edinburgh,FNP,Y
+WKTMC,Workington Magistrates Court,Workington Magistrates Court,CRT,Y
+NRU8,South Shields Police Station,South Shields Police Station,POLICE,Y

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AgencyDetailsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AgencyDetailsServiceTest.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.service
+
+import com.nhaarman.mockitokotlin2.doThrow
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.NomisReferenceDataProvider
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ActiveProfiles("test")
+@ContextConfiguration(classes = [TestConfig::class])
+internal class AgencyDetailsServiceTest(@Autowired private val referenceData: NomisReferenceDataProvider) {
+
+  private val monitoringService: MonitoringService = mock()
+
+  private val service = AgencyDetailsService(referenceData, monitoringService)
+
+  @BeforeEach
+  internal fun mirrorPostConstructAnnotation() {
+    service.loadInMemoryNomisLocationsReferenceData()
+  }
+
+  @Test
+  internal fun `AGY_LOC_ID location not found and is captured by the monitoring service`() {
+    assertThat(service.findAgencyLocationNameBy("AGY_LOC_ID")).isNull()
+
+    verify(monitoringService).capture("No match found looking up reference data for agency id 'AGY_LOC_ID'")
+  }
+
+  @Test
+  internal fun `multiple agency id location names are found`() {
+    assertThat(service.findAgencyLocationNameBy("THA044")).isEqualTo("MILTON KEYNES PROBATION OFFICE")
+    assertThat(service.findAgencyLocationNameBy("LEEDYC")).isEqualTo("LEEDS YOUTH COURT")
+
+    verifyZeroInteractions(monitoringService)
+  }
+
+  @Test
+  internal fun `trimmed agency id location names are found`() {
+    assertThat(service.findAgencyLocationNameBy(" THA044")).isEqualTo("MILTON KEYNES PROBATION OFFICE")
+    assertThat(service.findAgencyLocationNameBy("LEEDYC ")).isEqualTo("LEEDS YOUTH COURT")
+
+    verifyZeroInteractions(monitoringService)
+  }
+
+  @Test
+  internal fun `mixed case agency id location names are found`() {
+    assertThat(service.findAgencyLocationNameBy(" ThA044")).isEqualTo("MILTON KEYNES PROBATION OFFICE")
+    assertThat(service.findAgencyLocationNameBy("LeeDYC ")).isEqualTo("LEEDS YOUTH COURT")
+
+    verifyZeroInteractions(monitoringService)
+  }
+
+  @Test
+  internal fun `failure to load reference is captured and monitored`() {
+    val badData: NomisReferenceDataProvider = mock { on { get() } doThrow(RuntimeException("something went wrong")) }
+
+    AgencyDetailsService(badData, monitoringService).loadInMemoryNomisLocationsReferenceData()
+
+    verify(monitoringService).capture("An error occurred loading the NOMIS location reference data.")
+  }
+}


### PR DESCRIPTION
Changes:

This is to support the upcoming UI changes to display NOMIS location names when mapping NOMIS agencys IDs for journeys without an already mapped location name.

For now we are pulling the mappings from a CSV file.  A possible future change is to pull this from the BaSM API subject to some API changes.

It is possible there will be some mappings missing from the CSV file but this should cover most cases.