### PR TITLE
P4-2701 changes to UI layer to display the NOMIS location name when mapping an agency without a Schedule 34 mapping.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MapFriendlyLocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MapFriendlyLocationService.kt
@@ -31,16 +31,15 @@ class MapFriendlyLocationService(
       it.locationType = locationType
       it.updatedAt = timeSource.dateTime()
 
-      val event = AuditableEvent.locationEvent(
+      AuditableEvent.locationEvent(
         oldLocation,
         locationRepository.save(it).copy(),
-      )
-      event?.let { e -> auditService.create(e) }
+      )?.let { e -> auditService.create(e) }
 
       return
     }
 
-    val event = AuditableEvent.locationEvent(
+    AuditableEvent.locationEvent(
       locationRepository.save(
         Location(
           locationType,
@@ -50,7 +49,6 @@ class MapFriendlyLocationService(
           timeSource.dateTime()
         ).copy()
       )
-    )
-    event?.let { e -> auditService.create(e) }
+    )?.let { e -> auditService.create(e) }
   }
 }

--- a/src/main/resources/spreadsheets/nomis-locations.csv
+++ b/src/main/resources/spreadsheets/nomis-locations.csv
@@ -1,4 +1,7 @@
 AGY_LOC_ID,DESCRIPTION,LONG_DESCRIPTION,AGENCY_LOCATION_TYPE,ACTIVE_FLAG
+COURT1,NOMIS Court One,NOMIS Court One,CRT,Y
+POLICE1,NOMIS Police One,NOMIS Police One,COMM,Y
+PRISON1,NOMIS Prison One,NOMIS Prison One,INST,Y
 LDM011,Tulse Hill,Tulse Hill,COMM,Y
 LDM087,Havering Mags Court Probation Office,Havering Mags Court Probation Office,COMM,Y
 MUDSLY,The Maudsley Hospital,The Maudsley Hospital,HSHOSP,Y

--- a/src/main/resources/templates/map-location.html
+++ b/src/main/resources/templates/map-location.html
@@ -42,10 +42,15 @@
         <div class="govuk-form-group" th:classappend="${#fields.hasErrors('*')} ? 'govuk-form-group--error'">
             <ol class="list pl0">
                 <li class="mv3">
-                    <p class="govuk-label govuk-body govuk-!-font-weight-bold">Location</p>
-                    <p th:text="*{agencyId}" class="govuk-body ma0"></p>
-                    <input type="hidden" th:field="*{agencyId}" class="dn"/>
-                    <input type="hidden" th:field="*{operation}" class="dn"/>
+                  <p class="govuk-label govuk-body govuk-!-font-weight-bold">NOMIS Location Name</p>
+                  <p th:text="*{nomisLocationName}" class="govuk-body ma0"></p>
+                  <input type="hidden" th:field="*{nomisLocationName}" class="dn"/>
+                </li>
+                <li class="mv3">
+                  <p class="govuk-label govuk-body govuk-!-font-weight-bold">NOMIS Agency ID</p>
+                  <p th:text="*{agencyId}" class="govuk-body ma0"></p>
+                  <input type="hidden" th:field="*{agencyId}" class="dn"/>
+                  <input type="hidden" th:field="*{operation}" class="dn"/>
                 </li>
                 <li class="mv3">
                     <label class="govuk-label govuk-body govuk-!-font-weight-bold" for="location-name">Maps to Schedule


### PR DESCRIPTION
Changes:

Displays the NOMIS location name (if one can be found for the selected agency ID) on the add/update mappings screen to help the user when mapping a Schedule 34 location name.