### PR TITLE
P4-2727 changes to raise a Sentry alert if any of the reporting feeds fails or there are zero moves, people or profiles to persist for a given day.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/ReportImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/ReportImporter.kt
@@ -5,12 +5,14 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.ReportingProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.move.Move
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.MonitoringService
 import java.time.LocalDate
 import kotlin.streams.toList
 
 @Component
 class ReportImporter(
-  @Autowired val provider: ReportingProvider,
+  @Autowired private val provider: ReportingProvider,
+  @Autowired private val monitoringService: MonitoringService
 ) {
 
   private val logger = LoggerFactory.getLogger(javaClass)
@@ -51,6 +53,7 @@ class ReportImporter(
         provider.get(it)
       } catch (e: Exception) {
         logger.warn("Error attempting to get file $it, exception: $e")
+        monitoringService.capture("Error attempting to get $entity file $it, exception: ${e.message}")
         null
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
@@ -43,7 +43,13 @@ class ImportService(
       val moves = it.toList()
       movePersister.persist(moves).let { persisted ->
         auditService.create(AuditableEvent.importReportEvent("moves", date, moves.size, persisted))
-        captureMessageIf(moves.size > persisted, "moves: persisted $persisted out of ${moves.size} for reporting date $date.")
+
+        raiseMonitoringAlertIf(
+          moves.isNotEmpty() && moves.size > persisted,
+          "moves: persisted $persisted out of ${moves.size} for reporting feed date $date."
+        )
+
+        raiseMonitoringAlertIf(moves.isEmpty(), "There were no moves to persist for reporting feed date $date.")
       }
     }
   }
@@ -55,7 +61,13 @@ class ImportService(
       val people = it.toList()
       personPersister.persistPeople(people).let { persisted ->
         auditService.create(AuditableEvent.importReportEvent("people", date, people.size, persisted))
-        captureMessageIf(people.size > persisted, "people: persisted $persisted out of ${people.size} for reporting date $date.")
+
+        raiseMonitoringAlertIf(
+          people.isNotEmpty() && people.size > persisted,
+          "people: persisted $persisted out of ${people.size} for reporting feed date $date."
+        )
+
+        raiseMonitoringAlertIf(people.isEmpty(), "There were no people to persist for reporting feed date $date.")
       }
     }
 
@@ -65,13 +77,19 @@ class ImportService(
       val profiles = it.toList()
       personPersister.persistProfiles(profiles).let { persisted ->
         auditService.create(AuditableEvent.importReportEvent("profiles", date, profiles.size, persisted))
-        captureMessageIf(profiles.size > persisted, "profiles: persisted $persisted out of ${profiles.size} for reporting date $date.")
+
+        raiseMonitoringAlertIf(
+          profiles.isNotEmpty() && profiles.size > persisted,
+          "profiles: persisted $persisted out of ${profiles.size} for reporting feed date $date."
+        )
+
+        raiseMonitoringAlertIf(profiles.isEmpty(), "There were no profiles to persist for reporting feed date $date.")
       }
     }
   }
 
-  private fun captureMessageIf(isTrue: Boolean, message: String) {
-    if (isTrue) monitoringService.capture(message)
+  private fun raiseMonitoringAlertIf(isTrue: Boolean, alertMessage: String) {
+    if (isTrue) monitoringService.capture(alertMessage)
   }
 
   private fun <T> import(import: () -> T): T? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MonitoringService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/MonitoringService.kt
@@ -15,6 +15,9 @@ class MonitoringService {
   private val logger = LoggerFactory.getLogger(javaClass)
 
   internal fun capture(message: String) {
-    if (Sentry.isEnabled()) Sentry.captureMessage(message) else logger.warn("Monitoring is disabled, ignoring message $message.")
+    if (Sentry.isEnabled()) {
+      Sentry.captureMessage(message)
+      logger.warn(message)
+    } else logger.warn("Monitoring is disabled, ignoring message $message.")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/TestConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/TestConfig.kt
@@ -8,7 +8,6 @@ import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.core.io.ResourceLoader
 import org.springframework.jdbc.core.JdbcTemplate
-import org.springframework.security.oauth2.jwt.JwtDecoder
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.GeoameyPricesProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.JPCTemplateProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.ReportingProvider
@@ -18,6 +17,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.ReportImporter
 import uk.gov.justice.digital.hmpps.pecs.jpc.move.JourneyQueryRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.move.MoveQueryRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.MonitoringService
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
@@ -46,12 +46,6 @@ class TestConfig {
   }
 
   @Bean
-  fun jwtDecoder(): JwtDecoder {
-    // This is a temporary measure to prevent auth server startup/lookup errors during the tests.
-    return JwtDecoder { mock() }
-  }
-
-  @Bean
   fun dataSource(): DataSource {
     return DataSourceBuilder.create().url("jdbc:h2:mem:testdb;MODE=PostgreSQL").build()
   }
@@ -77,7 +71,7 @@ class TestConfig {
   }
 
   @Bean
-  fun reportImporter() = ReportImporter(reportingResourceProvider())
+  fun reportImporter() = ReportImporter(reportingResourceProvider(), mock { MonitoringService() })
 
   @Bean
   fun jpcTemplateProvider(): JPCTemplateProvider {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceIntegrationTest.kt
@@ -43,8 +43,8 @@ internal class ImportServiceIntegrationTest(
   internal fun `import should complete even when there are reports files with errors in them`() {
     service.importReportsOn(LocalDate.of(2020, 12, 1))
 
-    verify(monitoringService).capture("moves: persisted 1 out of 2 for reporting date 2020-12-01.")
-    verify(monitoringService).capture("people: persisted 3 out of 4 for reporting date 2020-12-01.")
+    verify(monitoringService).capture("moves: persisted 1 out of 2 for reporting feed date 2020-12-01.")
+    verify(monitoringService).capture("people: persisted 3 out of 4 for reporting feed date 2020-12-01.")
     verifyNoMoreInteractions(monitoringService)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
@@ -68,7 +68,6 @@ internal class ImportServiceTest {
     verify(reportImporter).importMovesJourneysEventsOn(timeSourceWithFixedDate.date())
     verify(reportImporter).importPeopleOn(timeSourceWithFixedDate.date())
     verify(reportImporter).importProfilesOn(timeSourceWithFixedDate.date())
-    verifyZeroInteractions(monitoringService)
   }
 
   @Test
@@ -91,7 +90,7 @@ internal class ImportServiceTest {
     whenever(movePersister.persist(any())).thenReturn(0)
 
     importService.importReportsOn(timeSourceWithFixedDate.date())
-    verify(monitoringService).capture("moves: persisted 0 out of 1 for reporting date ${timeSourceWithFixedDate.date()}.")
+    verify(monitoringService).capture("moves: persisted 0 out of 1 for reporting feed date ${timeSourceWithFixedDate.date()}.")
   }
 
   @Test
@@ -100,7 +99,7 @@ internal class ImportServiceTest {
     whenever(personPersister.persistPeople(any())).thenReturn(0)
 
     importService.importReportsOn(timeSourceWithFixedDate.date())
-    verify(monitoringService).capture("people: persisted 0 out of 1 for reporting date ${timeSourceWithFixedDate.date()}.")
+    verify(monitoringService).capture("people: persisted 0 out of 1 for reporting feed date ${timeSourceWithFixedDate.date()}.")
   }
 
   @Test
@@ -109,6 +108,30 @@ internal class ImportServiceTest {
     whenever(personPersister.persistProfiles(any())).thenReturn(0)
 
     importService.importReportsOn(timeSourceWithFixedDate.date())
-    verify(monitoringService).capture("profiles: persisted 0 out of 1 for reporting date ${timeSourceWithFixedDate.date()}.")
+    verify(monitoringService).capture("profiles: persisted 0 out of 1 for reporting feed date ${timeSourceWithFixedDate.date()}.")
+  }
+
+  @Test
+  internal fun `monitoring interactions when no moves to persist`() {
+    whenever(reportImporter.importMovesJourneysEventsOn(timeSourceWithFixedDate.date())).thenReturn(listOf())
+
+    importService.importReportsOn(timeSourceWithFixedDate.date())
+    verify(monitoringService).capture("There were no moves to persist for reporting feed date ${timeSourceWithFixedDate.date()}.")
+  }
+
+  @Test
+  internal fun `monitoring interactions when no people to persist`() {
+    whenever(reportImporter.importPeopleOn(timeSourceWithFixedDate.date())).thenReturn(sequenceOf())
+
+    importService.importReportsOn(timeSourceWithFixedDate.date())
+    verify(monitoringService).capture("There were no people to persist for reporting feed date ${timeSourceWithFixedDate.date()}.")
+  }
+
+  @Test
+  internal fun `monitoring interactions when no profiles to persist`() {
+    whenever(reportImporter.importProfilesOn(timeSourceWithFixedDate.date())).thenReturn(sequenceOf())
+
+    importService.importReportsOn(timeSourceWithFixedDate.date())
+    verify(monitoringService).capture("There were no profiles to persist for reporting feed date ${timeSourceWithFixedDate.date()}.")
   }
 }


### PR DESCRIPTION
**Changes:**

We will now get Sentry alerts if any of the reporting feeds fail or there are any instances where we have zero moves, people or profiles to persist for a given reporting feed date.