### PR TITLE
P4-2723 initial commit to enforce a new price maintainer role for price maintenance.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.1.3"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.1.4"
   kotlin("plugin.spring") version "1.4.32"
   kotlin("plugin.jpa") version "1.4.32"
   kotlin("plugin.allopen") version "1.4.32"
@@ -15,7 +15,7 @@ dependencies {
   implementation("com.github.kittinunf.result:result:4.0.0")
   implementation("com.github.kittinunf.result:result-coroutines:4.0.0")
   implementation("com.beust:klaxon:5.5")
-  implementation("com.amazonaws:aws-java-sdk-s3:1.11.986")
+  implementation("com.amazonaws:aws-java-sdk-s3:1.11.989")
   implementation("io.sentry:sentry-spring-boot-starter:4.3.0")
   implementation("net.javacrumbs.shedlock:shedlock-spring:4.22.1")
   implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.22.1")
@@ -47,7 +47,7 @@ dependencies {
   testImplementation("com.squareup.okhttp3:mockwebserver:4.9.1")
   testImplementation("com.squareup.okhttp3:okhttp:4.9.1")
 
-  runtimeOnly("org.flywaydb:flyway-core:7.7.1")
+  runtimeOnly("org.flywaydb:flyway-core:7.7.2")
   runtimeOnly("com.h2database:h2")
   runtimeOnly("org.postgresql:postgresql:42.2.19")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/ExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/ExceptionHandler.kt
@@ -1,23 +1,44 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.config
 
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.MonitoringService
+import javax.servlet.http.HttpServletRequest
 
 @ControllerAdvice
 class ExceptionHandler(private val monitoringService: MonitoringService) {
-  @ExceptionHandler(java.lang.Exception::class)
-  fun handleException(e: java.lang.Exception): ModelAndView {
-    log.error("Unexpected exception", e)
+
+  private val logger = LoggerFactory.getLogger(javaClass)
+
+  @ExceptionHandler(AccessDeniedException::class)
+  fun handleAccessDeniedException(e: AccessDeniedException, request: HttpServletRequest): ModelAndView {
+    logger.warn("Access denied exception", e)
 
     return ModelAndView()
-      .apply { this.viewName = "error" }
-      .also { monitoringService.capture("An unexpected error has occurred in the JPC application, see the logs for more details.") }
+      .apply {
+        this.viewName = "error/403"
+        this.status = HttpStatus.FORBIDDEN
+      }.also {
+        SecurityContextHolder.getContext().authentication?.let {
+          logger.warn("User: ${it.name} attempted to access the protected URL: ${request.requestURI}")
+        }
+      }
   }
 
-  companion object {
-    private val log = LoggerFactory.getLogger(this::class.java)
+  @ExceptionHandler(java.lang.Exception::class)
+  fun handleException(e: java.lang.Exception): ModelAndView {
+    logger.error("Unexpected exception", e)
+
+    return ModelAndView()
+      .apply {
+        this.viewName = "error"
+        this.status = HttpStatus.BAD_REQUEST
+      }
+      .also { monitoringService.capture("An unexpected error has occurred in the JPC application, see the logs for more details.") }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/SecurityConfiguration.kt
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
 import org.springframework.context.annotation.Bean
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
@@ -30,6 +31,7 @@ import kotlin.streams.toList
 
 @EnableWebSecurity
 @ConditionalOnWebApplication
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 class SecurityConfiguration<S : Session> : WebSecurityConfigurerAdapter() {
 
   private val logger = LoggerFactory.getLogger(javaClass)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingController.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.controller
 
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Controller
 import org.springframework.ui.ModelMap
 import org.springframework.validation.BindingResult
@@ -28,6 +29,7 @@ import javax.validation.constraints.NotNull
   HtmlController.DROP_OFF_ATTRIBUTE,
   HtmlController.DATE_ATTRIBUTE
 )
+@PreAuthorize("hasRole('PECS_MAINTAIN_PRICE')")
 class MaintainSupplierPricingController(@Autowired val supplierPricingService: SupplierPricingService) {
 
   private val logger = LoggerFactory.getLogger(javaClass)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.service
 
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditableEvent
@@ -12,6 +13,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 
 @Service
 @Transactional
+@PreAuthorize("hasRole('PECS_MAINTAIN_PRICE')")
 class SupplierPricingService(
   val locationRepository: LocationRepository,
   val priceRepository: PriceRepository,

--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" lang="en"
+      xmlns:th="http://www.thymeleaf.org"
+      layout:decorate="~{layout/base}">
+<head>
+  <title>Access Denied</title>
+</head>
+<body>
+<div class="govuk-width-container" layout:fragment="content">
+  <h1 class="govuk-heading-l">Access denied</h1>
+  <p class="govuk-body">Please try again later. If this issue continues to occur please contact the Book a Secure Move team.</p>
+  <a class="govuk-button" th:href="@{/}" id="continue">OK, continue</a>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/journeys.html
+++ b/src/main/resources/templates/journeys.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout/base}">
 
 <head>
@@ -99,10 +99,15 @@
                     <td class="govuk-table__cell" scope="row" th:inline="text">[[${journey.volume}]]</td>
                     <td class="govuk-table__cell" scope="row" th:inline="text">
                         <span th:if="${journey.fromSiteName == null || journey.toSiteName == null}" th:inline="text">Awaiting location</span>
-                        <span th:unless="${journey.fromSiteName == null || journey.toSiteName == null}">
-                            <a th:href="@{'/add-price/' + ${journey.fromNomisAgencyId} + '-' + ${journey.toNomisAgencyId}}"
-                               class="ma0 govuk-link">Add price</a>
-                        </span>
+                        <div sec:authorize="!hasRole('ROLE_PECS_MAINTAIN_PRICE')">
+                            <span th:unless="${journey.fromSiteName == null || journey.toSiteName == null}" th:inline="text">Awaiting price</span>
+                        </div>
+                        <div sec:authorize="hasRole('ROLE_PECS_MAINTAIN_PRICE')">
+                            <span th:unless="${journey.fromSiteName == null || journey.toSiteName == null}">
+                                <a th:href="@{'/add-price/' + ${journey.fromNomisAgencyId} + '-' + ${journey.toNomisAgencyId}}"
+                                   class="ma0 govuk-link">Add price</a>
+                            </span>
+                        </div>
                     </td>
                 </tr>
             </tbody>

--- a/src/main/resources/templates/search-journeys-results.html
+++ b/src/main/resources/templates/search-journeys-results.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout/base}">
 
 <head>
@@ -47,12 +47,19 @@
                     </a>
                 </td>
                 <td class="govuk-table__cell" scope="row" th:inline="text">[[${journey.toLocationType}]]</td>
-                <td class="govuk-table__cell" scope="row">
-                    <a th:href="@{'/update-price/' + ${journey.fromNomisAgencyId} + '-' + ${journey.toNomisAgencyId}}"
-                       class="ma0 govuk-link" th:inline="text">
-                        £[[${#numbers.formatDecimal(journey.unitPriceInPounds(), 1, 'COMMA', 2, 'POINT')}]]
-                    </a>
-                </td>
+                <div sec:authorize="!hasRole('ROLE_PECS_MAINTAIN_PRICE')">
+                    <td class="govuk-table__cell" scope="row">
+                        <span th:inline="text">£[[${#numbers.formatDecimal(journey.unitPriceInPounds(), 1, 'COMMA', 2, 'POINT')}]]</span>
+                    </td>
+                </div>
+                <div sec:authorize="hasRole('ROLE_PECS_MAINTAIN_PRICE')">
+                    <td class="govuk-table__cell" scope="row">
+                        <a th:href="@{'/update-price/' + ${journey.fromNomisAgencyId} + '-' + ${journey.toNomisAgencyId}}"
+                           class="ma0 govuk-link" th:inline="text">
+                            £[[${#numbers.formatDecimal(journey.unitPriceInPounds(), 1, 'COMMA', 2, 'POINT')}]]
+                        </a>
+                    </td>
+                </div>
             </tr>
             </tbody>
         </table>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/ExceptionHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/ExceptionHandlerTest.kt
@@ -2,13 +2,18 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.config
 
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.AccessDeniedException
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.MonitoringService
+import javax.servlet.http.HttpServletRequest
 
 internal class ExceptionHandlerTest {
 
   private val monitoringService: MonitoringService = mock()
+  private val request: HttpServletRequest = mock()
   private val handler: ExceptionHandler = ExceptionHandler(monitoringService)
 
   @Test
@@ -16,7 +21,18 @@ internal class ExceptionHandlerTest {
     val response = handler.handleException(Exception("something unexpected has happened"))
 
     assertThat(response.viewName).isEqualTo("error")
+    assertThat(response.status).isEqualTo(HttpStatus.BAD_REQUEST)
 
     verify(monitoringService).capture("An unexpected error has occurred in the JPC application, see the logs for more details.")
+  }
+
+  @Test
+  internal fun `catch access denied handler interactions`() {
+    val response = handler.handleAccessDeniedException(AccessDeniedException("forbidden access"), request)
+
+    assertThat(response.viewName).isEqualTo("error/403")
+    assertThat(response.status).isEqualTo(HttpStatus.FORBIDDEN)
+
+    verifyZeroInteractions(monitoringService)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlControllerTest.kt
@@ -144,7 +144,7 @@ class HtmlControllerTest(@Autowired private val wac: WebApplicationContext) {
       param("reference", "REF1")
     }
       .andExpect { view { name("error") } }
-      .andExpect { status { is2xxSuccessful() } }
+      .andExpect { status { is4xxClientError() } }
 
     verify(monitoringService).capture(any())
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingServiceIntegrationTest.kt
@@ -1,0 +1,69 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.service
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.Location
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Money
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@ContextConfiguration(classes = [TestConfig::class])
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class SupplierPricingServiceIntegrationTest(
+  @Autowired private val locationRepository: LocationRepository,
+  @Autowired private val service: SupplierPricingService
+) {
+
+  @BeforeAll
+  internal fun beforeAll() {
+    locationRepository.save(
+      Location(
+        LocationType.PR,
+        "PRISON1",
+        "PRISON ONE"
+      )
+    )
+
+    locationRepository.save(
+      Location(
+        LocationType.PR,
+        "PRISON2",
+        "PRISON TWO"
+      )
+    )
+  }
+
+  @Test
+  @WithMockUser(roles = ["PECS_MAINTAIN_PRICE"])
+  fun `can maintain price with maintenance role`() {
+    assertDoesNotThrow {
+      service.addPriceForSupplier(Supplier.SERCO, "PRISON1", "PRISON2", Money.valueOf(10.00), 2021)
+      service.updatePriceForSupplier(Supplier.SERCO, "PRISON1", "PRISON2", Money.valueOf(11.00), 2021)
+    }
+  }
+
+  @Test
+  @WithMockUser(roles = ["PECS_JPC"])
+  fun `cannot maintain price without maintenance role`() {
+    assertThatThrownBy {
+      service.addPriceForSupplier(Supplier.SERCO, "PRISON1", "PRISON2", Money.valueOf(10.00), 2021)
+    }.isInstanceOf(AccessDeniedException::class.java)
+
+    assertThatThrownBy {
+      service.updatePriceForSupplier(Supplier.SERCO, "PRISON1", "PRISON2", Money.valueOf(10.00), 2021)
+    }.isInstanceOf(AccessDeniedException::class.java)
+  }
+}


### PR DESCRIPTION
**Changes:**

This change introduces additional role requirements for those users who can add and update journeys prices.

The changes have a dependency on a change to the HMPPS Auth service ([new role](https://github.com/ministryofjustice/hmpps-auth/pull/831)) being rolled out.  At time of writing this has been approved/merged and should be available in DEV.