### PR TITLE
P4-2725 removing some duplication by iterating over location types from code instead of hard coding all into template.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ManageSchedule34LocationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ManageSchedule34LocationsController.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.service.BasmClientApiService
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.LocationsService
 import javax.validation.Valid
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
 
 /**
  * Controller to support searching and maintenance of existing Schedule 34 locations.
@@ -72,7 +73,7 @@ class ManageSchedule34LocationsController(
         LocationForm(
           agencyId = it.first,
           locationName = it.second,
-          locationType = it.third.name,
+          locationType = it.third,
           nomisLocationName = basmClientApiService.findAgencyLocationNameBy(agencyId)
             ?: "Sorry, we are currently unable to retrieve the NOMIS Location Name. Please try again later."
         )
@@ -93,10 +94,10 @@ class ManageSchedule34LocationsController(
 
     if (result.hasErrors()) return "manage-location"
 
-    return if (duplicate(location)) {
+    return if (isDuplicate(location)) {
       "manage-location".also { result.duplicateLocation() }
     } else {
-      service.setLocationDetails(location.agencyId, location.locationName, LocationType.valueOf(location.locationType))
+      service.setLocationDetails(location.agencyId, location.locationName, location.locationType!!)
 
       redirectAttributes.addFlashAttribute("flashMessage", "location-updated")
       redirectAttributes.addFlashAttribute("flashAttrMappedLocationName", location.locationName.toUpperCase())
@@ -106,7 +107,7 @@ class ManageSchedule34LocationsController(
     }
   }
 
-  private fun duplicate(form: LocationForm) = service.locationAlreadyExists(form.agencyId, form.locationName)
+  private fun isDuplicate(form: LocationForm) = service.locationAlreadyExists(form.agencyId, form.locationName)
 
   private fun BindingResult.duplicateLocation() {
     this.rejectValue("locationName", "duplicate", "There is a problem, Schedule 34 location entered already exists, please enter a new schedule 34 location")
@@ -124,8 +125,8 @@ class ManageSchedule34LocationsController(
     @get: NotBlank(message = "Please enter a schedule 34 location name")
     val locationName: String = "",
 
-    @get: NotBlank(message = "Please enter a schedule 34 location type")
-    val locationType: String = "",
+    @get: NotNull(message = "Please enter a schedule 34 location type")
+    val locationType: LocationType? = null,
 
     val nomisLocationName: String = ""
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MapFriendlyLocationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MapFriendlyLocationController.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.service.BasmClientApiService
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.LocationsService
 import javax.validation.Valid
 import javax.validation.constraints.NotEmpty
+import javax.validation.constraints.NotNull
 
 /**
  * Controller to help with mapping a user friendly location name to (missing) Schedule 34 locations names.
@@ -56,7 +57,7 @@ class MapFriendlyLocationController(
         MapLocationForm(
           agencyId = it.first,
           locationName = it.second,
-          locationType = it.third.name,
+          locationType = it.third,
           operation = "update",
           nomisLocationName = nomisLocationName
         )
@@ -94,7 +95,7 @@ class MapFriendlyLocationController(
       return "map-location"
     }
 
-    service.setLocationDetails(form.agencyId, form.locationName, LocationType.valueOf(form.locationType))
+    service.setLocationDetails(form.agencyId, form.locationName, form.locationType!!)
 
     redirectAttributes.addFlashAttribute("flashAttrMappedLocationName", form.locationName.toUpperCase())
     redirectAttributes.addFlashAttribute("flashAttrMappedAgencyId", form.agencyId)
@@ -120,8 +121,8 @@ class MapFriendlyLocationController(
     @get: NotEmpty(message = "Enter Schedule 34 location")
     val locationName: String = "",
 
-    @get: NotEmpty(message = "Enter Schedule 34 location type")
-    val locationType: String = "",
+    @get: NotNull(message = "Enter Schedule 34 location type")
+    val locationType: LocationType? = null,
 
     val operation: String = "create",
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationType.kt
@@ -18,8 +18,7 @@ enum class LocationType(val label: String) {
   PR("Prison"),
   PS("Police"),
   SCH("SCH"),
-  STC("STC"),
-  UNKNOWN("UNKNOWN");
+  STC("STC");
 
   companion object {
     /**

--- a/src/main/resources/templates/manage-location.html
+++ b/src/main/resources/templates/manage-location.html
@@ -55,23 +55,12 @@
                            th:classappend="${#fields.hasErrors('locationName')} ? 'govuk-input--error'">
                 </li>
                 <li class="mv3">
-                    <label class="govuk-label govuk-body govuk-!-font-weight-bold" for="location-type-id">Add location
-                        type</label>
+                    <label class="govuk-label govuk-body govuk-!-font-weight-bold" for="location-type-id">Add location type</label>
                     <select name="location-type" id="location-type-id" th:field="*{locationType}" class="govuk-select">
-                        <option value="AP">Airport</option>
-                        <option value="APP">Approved Premises</option>
-                        <option value="CC">Crown Court</option>
-                        <option value="CM">Combined Court</option>
-                        <option value="CO">County Court</option>
-                        <option value="HP">Hospital</option>
-                        <option value="IM">Immigration</option>
-                        <option value="MC">Mag Court</option>
-                        <option value="O">Other</option>
-                        <option value="PS">Police</option>
-                        <option value="PR">Prison</option>
-                        <option value="PB">Probation</option>
-                        <option value="SCH">SCH</option>
-                        <option value="STC">STC</option>
+                        <option th:each="type : ${T(uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType).values()}"
+                                th:value="${type}"
+                                th:text="${type.label}">type
+                        </option>
                     </select>
                 </li>
             </ol>

--- a/src/main/resources/templates/map-location.html
+++ b/src/main/resources/templates/map-location.html
@@ -63,23 +63,12 @@
                            th:classappend="${#fields.hasErrors('locationName')} ? 'govuk-input--error'">
                 </li>
                 <li class="mv3">
-                    <label class="govuk-label govuk-body govuk-!-font-weight-bold" for="location-type-id">Add location
-                        type</label>
+                    <label class="govuk-label govuk-body govuk-!-font-weight-bold" for="location-type-id">Add location type</label>
                     <select name="location-type" id="location-type-id" th:field="*{locationType}" class="govuk-select">
-                        <option value="AP">Airport</option>
-                        <option value="APP">Approved Premises</option>
-                        <option value="CC">Crown Court</option>
-                        <option value="CM">Combined Court</option>
-                        <option value="CO">County Court</option>
-                        <option value="HP">Hospital</option>
-                        <option value="IM">Immigration</option>
-                        <option value="MC">Mag Court</option>
-                        <option value="O">Other</option>
-                        <option value="PS">Police</option>
-                        <option value="PR">Prison</option>
-                        <option value="PB">Probation</option>
-                        <option value="SCH">SCH</option>
-                        <option value="STC">STC</option>
+                        <option th:each="type : ${T(uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType).values()}"
+                                th:value="${type}"
+                                th:text="${type.label}">type
+                        </option>
                     </select>
                 </li>
             </ol>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MapFriendlyLocationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MapFriendlyLocationControllerTest.kt
@@ -81,7 +81,7 @@ internal class MapFriendlyLocationControllerTest(@Autowired private val wac: Web
         model {
           attribute(
             "form",
-            MapFriendlyLocationController.MapLocationForm(agencyId, "existing location", LocationType.AP.name, "update", nomisLocationName)
+            MapFriendlyLocationController.MapLocationForm(agencyId, "existing location", LocationType.AP, "update", nomisLocationName)
           )
         }
       }


### PR DESCRIPTION
**Changes**:

Now iterates over available location types from the actual enum type instead of hard coding directly in the template.