### PR TITLE
P4-2797 suppressing OWASP CVE and updating to later libraries where available.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.1.6"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.1.7"
   kotlin("plugin.spring") version "1.4.32"
   kotlin("plugin.jpa") version "1.4.32"
   kotlin("plugin.allopen") version "1.4.32"
@@ -11,15 +11,19 @@ allOpen {
   annotation("javax.persistence.MappedSuperclass")
 }
 
+dependencyCheck {
+  suppressionFiles.add("calculate-journey-variable-payments-suppressions.xml")
+}
+
 dependencies {
   implementation("com.github.kittinunf.result:result:4.0.0")
   implementation("com.github.kittinunf.result:result-coroutines:4.0.0")
   implementation("com.beust:klaxon:5.5")
-  implementation("com.amazonaws:aws-java-sdk-s3:1.11.995")
+  implementation("com.amazonaws:aws-java-sdk-s3:1.11.1001")
   implementation("io.sentry:sentry-spring-boot-starter:4.3.0")
-  implementation("net.javacrumbs.shedlock:shedlock-spring:4.22.1")
-  implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.22.1")
-  implementation("nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:2.5.2")
+  implementation("net.javacrumbs.shedlock:shedlock-spring:4.23.0")
+  implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.23.0")
+  implementation("nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:2.5.3")
   implementation("org.apache.poi:poi-ooxml:5.0.0")
 
   constraints {
@@ -36,18 +40,18 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
-  implementation("org.springframework.session:spring-session-jdbc:2.4.2")
+  implementation("org.springframework.session:spring-session-jdbc:2.4.3")
   implementation("org.springframework.shell:spring-shell-starter:2.0.1.RELEASE")
   implementation("org.thymeleaf.extras:thymeleaf-extras-springsecurity5:3.0.4.RELEASE")
   implementation(kotlin("script-runtime"))
 
-  testImplementation("org.mockito:mockito-inline:3.8.0")
+  testImplementation("org.mockito:mockito-inline:3.9.0")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("org.springframework.security:spring-security-test")
   testImplementation("com.squareup.okhttp3:mockwebserver:4.9.1")
   testImplementation("com.squareup.okhttp3:okhttp:4.9.1")
 
-  runtimeOnly("org.flywaydb:flyway-core:7.7.3")
+  runtimeOnly("org.flywaydb:flyway-core:7.8.1")
   runtimeOnly("com.h2database:h2")
   runtimeOnly("org.postgresql:postgresql:42.2.19")
 }

--- a/calculate-journey-variable-payments-suppressions.xml
+++ b/calculate-journey-variable-payments-suppressions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+   file name: commons-io-1.3.1.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/commons\-io/commons\-io@.*$</packageUrl>
+        <cve>CVE-2021-29425</cve>
+    </suppress>
+</suppressions>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-rc-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
At time of reviewing there are no more up to date libraries for this CVE i.e. we are stuck with what we versions we have.  Action taken is to suppress the warning for now, it it not something likely to affect CJVP anyway.   Actual CVE can be found [here](https://nvd.nist.gov/vuln/detail/CVE-2021-29425).

To exercise it requires the user to supply a file name path in a particular format and utilise the specific function/method in the affected library.

CJVP does not provide this to the end user or use the affected function/method.