### PR TITLE
P4-2597 initial commit for prepping the audit changes for displaying location history.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditEvent.kt
@@ -15,7 +15,7 @@ import javax.validation.constraints.NotBlank
 data class AuditEvent(
   @Enumerated(EnumType.STRING)
   @Column(name = "event_type", nullable = false)
-  var eventType: AuditEventType,
+  val eventType: AuditEventType,
 
   @Column(name = "created_at", nullable = false)
   val createdAt: LocalDateTime,
@@ -30,4 +30,15 @@ data class AuditEvent(
   @Id
   @Column(name = "audit_event_id", nullable = false)
   val id: UUID = UUID.randomUUID()
-)
+) {
+  constructor(eventType: AuditEventType, createdAt: LocalDateTime, username: String, metadata: Metadata?) : this(
+    eventType = eventType,
+    createdAt = createdAt,
+    username = username,
+    metadata = metadata?.toJsonString()
+  )
+}
+
+fun interface Metadata {
+  fun toJsonString(): String
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditEventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditEventRepository.kt
@@ -3,4 +3,6 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.auditing
 import org.springframework.data.repository.CrudRepository
 import java.util.UUID
 
-interface AuditEventRepository : CrudRepository<AuditEvent, UUID>
+interface AuditEventRepository : CrudRepository<AuditEvent, UUID> {
+  fun findByEventType(eventType: AuditEventType): List<AuditEvent>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/MapLocationMetadata.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/MapLocationMetadata.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.auditing
+
+import com.beust.klaxon.Json
+import com.beust.klaxon.Klaxon
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.Location
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
+
+/**
+ * Metadata to capture mapping of new locations and remapping of existing locations.
+ */
+data class MapLocationMetadata(
+  @Json(name = "nomis_id", index = 1)
+  val nomisId: String,
+
+  @Json(name = "new_name", index = 2, serializeNull = false)
+  val newName: String? = null,
+
+  @Json(name = "new_type", index = 3, serializeNull = false)
+  val newType: LocationType? = null,
+
+  @Json(name = "old_name", index = 4, serializeNull = false)
+  val oldName: String? = null,
+
+  @Json(name = "old_type", index = 5, serializeNull = false)
+  val oldType: LocationType? = null
+) : Metadata {
+  private constructor(location: Location) : this(location.nomisAgencyId, location.siteName, location.locationType)
+
+  private constructor(old: Location, new: Location) : this(
+    nomisId = old.nomisAgencyId,
+    newName = if (old.siteName != new.siteName) new.siteName else null,
+    oldName = if (old.siteName != new.siteName) old.siteName else null,
+    newType = if (old.locationType != new.locationType) new.locationType else null,
+    oldType = if (old.locationType != new.locationType) old.locationType else null
+  )
+
+  init {
+    if (newName == null && newType == null && oldName == null && oldType == null) throw IllegalStateException("Only NOMIS ID provided.")
+  }
+
+  companion object {
+    fun map(location: Location) = MapLocationMetadata(location)
+
+    fun remap(old: Location, new: Location): MapLocationMetadata {
+      if (old.id != new.id) throw IllegalArgumentException("Different locations provided.")
+
+      if (old == new) throw IllegalArgumentException("Old and new location data is exactly the same.")
+
+      return MapLocationMetadata(old, new)
+    }
+  }
+
+  fun isRemapping() = oldName != null || oldType != null
+
+  override fun toJsonString(): String = Klaxon().toJsonString(this)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AuditService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.service
 
-import com.beust.klaxon.Klaxon
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditEvent
@@ -14,10 +13,10 @@ class AuditService(private val auditEventRepository: AuditEventRepository, priva
   fun create(event: AuditableEvent) {
     auditEventRepository.save(
       AuditEvent(
-        event.type,
-        timeSource.dateTime(),
-        event.username.trim().toUpperCase(),
-        event.extras?.let { Klaxon().toJsonString(it) }
+        eventType = event.type,
+        createdAt = timeSource.dateTime(),
+        username = event.username.trim().toUpperCase(),
+        metadata = event.metadata
       )
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/LocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/LocationsService.kt
@@ -39,15 +39,12 @@ class LocationsService(
       it.locationType = locationType
       it.updatedAt = timeSource.dateTime()
 
-      AuditableEvent.locationEvent(
-        oldLocation,
-        locationRepository.save(it).copy(),
-      )?.let { e -> auditService.create(e) }
+      AuditableEvent.remapLocation(oldLocation, locationRepository.save(it).copy()).let { e -> auditService.create(e) }
 
       return
     }
 
-    AuditableEvent.locationEvent(
+    AuditableEvent.mapLocation(
       locationRepository.save(
         Location(
           locationType,
@@ -57,6 +54,6 @@ class LocationsService(
           timeSource.dateTime()
         ).copy()
       )
-    )?.let { e -> auditService.create(e) }
+    ).let { e -> auditService.create(e) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/MapLocationMetadataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/MapLocationMetadataTest.kt
@@ -1,0 +1,78 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.auditing
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.Location
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
+
+class MapLocationMetadataTest {
+  @Test
+  fun `mapping a new location`() {
+    val metadata = MapLocationMetadata.map(Location(LocationType.PR, "AGENCY_ID", "SITE NAME"))
+
+    assertThat(metadata.nomisId).isEqualTo("AGENCY_ID")
+    assertThat(metadata.newName).isEqualTo("SITE NAME")
+    assertThat(metadata.newType).isEqualTo(LocationType.PR)
+    assertThat(metadata.oldName).isNull()
+    assertThat(metadata.oldType).isNull()
+    assertThat(metadata.isRemapping()).isFalse
+  }
+
+  @Test
+  fun `remapping of existing location name`() {
+    val existingLocation = Location(LocationType.PR, "AGENCY_ID", "OLD SITE NAME")
+    val metadata = MapLocationMetadata.remap(existingLocation, existingLocation.copy(siteName = "NEW SITE NAME"))
+
+    assertThat(metadata.nomisId).isEqualTo("AGENCY_ID")
+    assertThat(metadata.newName).isEqualTo("NEW SITE NAME")
+    assertThat(metadata.newType).isNull()
+    assertThat(metadata.oldName).isEqualTo("OLD SITE NAME")
+    assertThat(metadata.oldType).isNull()
+  }
+
+  @Test
+  fun `remapping of existing location type`() {
+    val existingLocation = Location(LocationType.PR, "AGENCY_ID", "SITE NAME")
+    val metadata = MapLocationMetadata.remap(existingLocation, existingLocation.copy(locationType = LocationType.AP))
+
+    assertThat(metadata.nomisId).isEqualTo("AGENCY_ID")
+    assertThat(metadata.newName).isNull()
+    assertThat(metadata.newType).isEqualTo(LocationType.AP)
+    assertThat(metadata.oldName).isNull()
+    assertThat(metadata.oldType).isEqualTo(LocationType.PR)
+    assertThat(metadata.isRemapping()).isTrue
+  }
+
+  @Test
+  fun `remapping of existing location name and type`() {
+    val existingLocation = Location(LocationType.PR, "AGENCY_ID", "OLD SITE NAME")
+    val metadata = MapLocationMetadata.remap(existingLocation, existingLocation.copy(siteName = "NEW SITE NAME", locationType = LocationType.AP))
+
+    assertThat(metadata.nomisId).isEqualTo("AGENCY_ID")
+    assertThat(metadata.newName).isEqualTo("NEW SITE NAME")
+    assertThat(metadata.newType).isEqualTo(LocationType.AP)
+    assertThat(metadata.oldName).isEqualTo("OLD SITE NAME")
+    assertThat(metadata.oldType).isEqualTo(LocationType.PR)
+    assertThat(metadata.isRemapping()).isTrue
+  }
+
+  @Test
+  fun `remapping fails when not same locations`() {
+    val locationA = Location(LocationType.PR, "AGENCY_A", "OLD SITE NAME")
+    val locationB = Location(LocationType.PR, "AGENCY_B", "OLD SITE NAME")
+
+    assertThatThrownBy { MapLocationMetadata.remap(locationA, locationB) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Different locations provided.")
+  }
+
+  @Test
+  fun `remapping fails when no actual location changes`() {
+    val location = Location(LocationType.PR, "AGENCY_A", "OLD SITE NAME")
+
+    assertThatThrownBy { MapLocationMetadata.remap(location, location.copy()) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Old and new location data is exactly the same.")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BulkPricesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BulkPricesServiceTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.service
 
-import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
@@ -42,14 +41,10 @@ internal class BulkPricesServiceTest {
     verify(priceRepository).findBySupplierAndEffectiveYear(Supplier.SERCO, 2020)
     verify(priceRepository, times(2)).save(priceCaptor.capture())
     verify(auditService).create(
-      argThat(
-        AuditableEventMatcher(
-          AuditableEvent(
-            AuditEventType.JOURNEY_PRICE_BULK_UPDATE,
-            "_TERMINAL_",
-            mapOf("supplier" to Supplier.SERCO, "multiplier" to 1.5)
-          )
-        )
+      AuditableEvent(
+        AuditEventType.JOURNEY_PRICE_BULK_UPDATE,
+        "_TERMINAL_",
+        mapOf("supplier" to Supplier.SERCO, "multiplier" to 1.5)
       )
     )
     assertOnSupplierPriceAndEffectiveYear(priceCaptor.firstValue, Supplier.SERCO, Money(1500), 2021)
@@ -70,14 +65,10 @@ internal class BulkPricesServiceTest {
     verify(priceRepository).findBySupplierAndEffectiveYear(Supplier.GEOAMEY, 2021)
     verify(priceRepository, times(2)).save(priceCaptor.capture())
     verify(auditService).create(
-      argThat(
-        AuditableEventMatcher(
-          AuditableEvent(
-            AuditEventType.JOURNEY_PRICE_BULK_UPDATE,
-            "_TERMINAL_",
-            mapOf("supplier" to Supplier.GEOAMEY, "multiplier" to 2.0)
-          )
-        )
+      AuditableEvent(
+        AuditEventType.JOURNEY_PRICE_BULK_UPDATE,
+        "_TERMINAL_",
+        mapOf("supplier" to Supplier.GEOAMEY, "multiplier" to 2.0)
       )
     )
     assertOnSupplierPriceAndEffectiveYear(priceCaptor.firstValue, Supplier.GEOAMEY, Money(3000), 2022)


### PR DESCRIPTION
This PR lays out the initial groundwork for sanitising the auditing metadata for Schedule 34 location mapping and remapping.  This is needed to make it easier to extract the auditing information for use in the presentation layer for location mapping history.

Further work will be needed when this has been merged to go back and update already existing location audit records to reflect the changes to the metadata structure, this will be most likely via a DB migration.