### PR TITLE
P4-2834 suppressing false positive CVE-2020-7791. It is actaully a C# CVE.

### DIFF
--- a/calculate-journey-variable-payments-suppressions.xml
+++ b/calculate-journey-variable-payments-suppressions.xml
@@ -7,4 +7,11 @@
         <packageUrl regex="true">^pkg:maven/commons\-io/commons\-io@.*$</packageUrl>
         <cve>CVE-2021-29425</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: batik-i18n-1.14.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.xmlgraphics/batik\-i18n@.*$</packageUrl>
+        <cve>CVE-2020-7791</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Changes:

Suppressing CVE-2020-7791.  It is a false positive.  See [here](https://github.com/turquoiseowl/i18n/issues/387).