### PR TITLE
P4-2839 reversing out config change as this may be having a knock on effect with the spreadsheet download.

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,6 @@ spring:
       hibernate.order_updates: true
       hibernate.jdbc.batch_versioned_data: true
       hibernate.generate_statistics: false
-    open-in-view: false
   datasource:
     platform: postgres
     url: ${APP_DB_URL}


### PR DESCRIPTION
Changes:

Reversed JPA config change.

This was originally done to remove a application startup warning but may have had an undesired effect on the spreadsheet download.