### PR TITLE
P4 2832 retrieve new locations added to basm

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationType.kt
@@ -10,6 +10,7 @@ enum class LocationType(val label: String) {
   CC("Crown Court"),
   CM("Combined Court"),
   CO("County Court"),
+  CRT("Court"),
   HP("Hospital"),
   IM("Immigration"),
   MC("Mag Court"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BasmClientApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BasmClientApiService.kt
@@ -1,11 +1,19 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.service
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
 import java.time.Duration
+import java.time.LocalDate
 
 @Service
 class BasmClientApiService(
@@ -20,7 +28,7 @@ class BasmClientApiService(
     logger.info("Looking up location name for agency ID '${agencyId.trim().toUpperCase()}'.")
 
     fun recordIfLocationNotFound(location: LocationResponse?) {
-      if (location?.data.isNullOrEmpty()) {
+      if (location?.locations.isNullOrEmpty()) {
         logger.info("Location name for agency ID '${agencyId.trim().toUpperCase()}' not found on calling BaSM API.")
         monitoringService.capture("Location name for agency ID '${agencyId.trim().toUpperCase()}' not found on calling BaSM API.")
       }
@@ -40,13 +48,60 @@ class BasmClientApiService(
         .block(basmApiTimeout)
     }
       .onFailure { recordLocationLookupFailure(it) }
-      .onSuccess { recordIfLocationNotFound(it) }.getOrNull()?.data?.elementAtOrNull(0)?.name()?.toUpperCase()
+      .onSuccess { recordIfLocationNotFound(it) }.getOrNull()?.locations?.elementAtOrNull(0)?.name?.toUpperCase()
   }
+
+  fun findNomisAgenciesCreatedOn(date: LocalDate): List<BasmNomisLocation?> =
+    // TODO need to record any lookup failures in the onFailure { ... }
+    Result.runCatching {
+      basmApiWebClient
+        .get()
+        .uri("api/reference/locations?filter[created_at]=$date")
+        .retrieve()
+        .bodyToMono(LocationResponse::class.java)
+        .map { it.locations }
+        .block(basmApiTimeout)
+    }.getOrDefault(listOf())
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-private data class LocationResponse(val data: List<Location> = listOf())
+data class LocationResponse(
+  @JsonProperty("data")
+  @JsonDeserialize(contentUsing = NomisLocationDeserializer::class)
+  val locations: List<BasmNomisLocation> = listOf()
+)
 
-private data class Location(val attributes: Map<Any, Any>) {
-  fun name(): String = attributes.getOrDefault("title", "unknown") as String
+data class BasmNomisLocation(
+  val name: String,
+  val agencyId: String,
+  val locationType: LocationType,
+  val createdAt: LocalDate
+)
+
+object NomisLocationDeserializer : JsonDeserializer<BasmNomisLocation>() {
+  override fun deserialize(p: JsonParser?, ctxt: DeserializationContext?): BasmNomisLocation? =
+    (p?.readValueAsTree() as JsonNode)["attributes"]?.let { attributes ->
+      val title = attributes["title"].asText().trim().toUpperCase()
+      val agencyId = attributes["nomis_agency_id"].asText().trim().toUpperCase()
+      val locationType = attributes["location_type"].asText()
+      val createdAt = LocalDate.parse(attributes["created_at"].asText())
+
+      return LocationTypeParser.parse(locationType)?.let { BasmNomisLocation(title, agencyId, it, createdAt) }
+    }
+}
+
+object LocationTypeParser {
+  fun parse(value: String): LocationType? =
+    when (value) {
+      "approved_premises" -> LocationType.APP
+      "hospital" -> LocationType.HP
+      "immigration_detention_centre" -> LocationType.IM
+      "high_security_hospital" -> LocationType.HP
+      "police" -> LocationType.PS
+      "prison" -> LocationType.PR
+      "probation_office" -> LocationType.PB
+      "secure_childrens_home" -> LocationType.SCH
+      "secure_training_centre" -> LocationType.STC
+      else -> null
+    }
 }

--- a/wiremock-docker/__files/basm-api/locations/MULTIPLE.json
+++ b/wiremock-docker/__files/basm-api/locations/MULTIPLE.json
@@ -1,0 +1,94 @@
+{
+  "data": [
+    {
+      "id": "1bad3789-0d49-44dc-bb8f-4ff32414fa0a",
+      "type": "locations",
+      "attributes": {
+        "key": "court1",
+        "title": "Court One",
+        "location_type": "court",
+        "nomis_agency_id": "COURT1",
+        "can_upload_documents": false,
+        "young_offender_institution": false,
+        "premise": null,
+        "locality": null,
+        "city": null,
+        "country": null,
+        "postcode": "C111 ONE",
+        "latitude": null,
+        "longitude": null,
+        "disabled_at": null
+      },
+      "relationships": {
+        "suppliers": {
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "2bad3789-0d49-44dc-bb8f-4ff32414fa0b",
+      "type": "locations",
+      "attributes": {
+        "key": "court2",
+        "title": "Court Two",
+        "location_type": "court",
+        "nomis_agency_id": "COURT2",
+        "can_upload_documents": false,
+        "young_offender_institution": false,
+        "premise": null,
+        "locality": null,
+        "city": null,
+        "country": null,
+        "postcode": "C2 TWO",
+        "latitude": null,
+        "longitude": null,
+        "disabled_at": null
+      },
+      "relationships": {
+        "suppliers": {
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "2bad3789-0d49-44dc-bb8f-4ff32414fa0c",
+      "type": "locations",
+      "attributes": {
+        "key": "prison1",
+        "title": "Prison One",
+        "location_type": "prison",
+        "nomis_agency_id": "PRISON1",
+        "can_upload_documents": false,
+        "young_offender_institution": false,
+        "premise": null,
+        "locality": null,
+        "city": null,
+        "country": null,
+        "postcode": "P111 ONE",
+        "latitude": null,
+        "longitude": null,
+        "disabled_at": null
+      },
+      "relationships": {
+        "suppliers": {
+          "data": []
+        }
+      }
+    }
+  ],
+  "included": [],
+  "meta": {
+    "pagination": {
+      "per_page": 100,
+      "total_pages": 1,
+      "total_objects": 3
+    }
+  },
+  "links": {
+    "self": "https://basmhost/api/reference/locations?filter%5Bnomis_agency_id%5D=COURT1&filter%5Byoung_offender_institution%5D=false&include=suppliers&page=1&per_page=100",
+    "first": "https://basmhost/api/reference/locations?filter%5Bnomis_agency_id%5D=COURT1&filter%5Byoung_offender_institution%5D=false&include=suppliers&page=1&per_page=100",
+    "prev": null,
+    "next": null,
+    "last": "https://basmhost/api/reference/locations?filter%5Bnomis_agency_id%5D=COURT1&filter%5Byoung_offender_institution%5D=false&include=suppliers&page=1&per_page=100"
+  }
+}

--- a/wiremock-docker/docker-compose.yml
+++ b/wiremock-docker/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.1'
+
+services:
+
+  hmpps-book-secure-move-api:
+    image: rodolpheche/wiremock:latest
+    networks:
+      - hmpps
+    container_name: wiremock-basm-api
+    ports:
+      - "9999:8080"
+    volumes:
+      - $PWD:/home/wiremock
+    command: --verbose --global-response-templating
+
+networks:
+  hmpps:

--- a/wiremock-docker/mappings/basm_api_location_MULTIPLE_ON_DATE.json
+++ b/wiremock-docker/mappings/basm_api_location_MULTIPLE_ON_DATE.json
@@ -1,0 +1,16 @@
+{
+  "request" : {
+    "url" : "/api/reference/locations?filter%5Bcreated_at%5D=2021-05-05&per_page=100",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName" : "basm-api/locations/MULTIPLE.json",
+    "transformers": [
+      "response-template"
+    ]
+  }
+}


### PR DESCRIPTION
Changes:

This first piece of work deals with extending the internal API which talks to BaSM to support retrieving locations added on a specific date.  This will  be invoked by a (yet to be added code based) CRON job which in turns makes calls for the previous days additions so they can automatically be added to CJVP without user (manual) intervention.