### PR TITLE
P4-2833 providing the ability to automatically backdate locations from BaSM via the CLI tooling.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/BasmClientApiCommands.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/BasmClientApiCommands.kt
@@ -2,10 +2,18 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.commands
 
 import org.springframework.shell.standard.ShellComponent
 import org.springframework.shell.standard.ShellMethod
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.AutomaticLocationMappingService
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.BasmClientApiService
+import java.time.LocalDate
 
 @ShellComponent
-class BasmClientApiCommands(private val service: BasmClientApiService) {
+class BasmClientApiCommands(
+  private val service: BasmClientApiService,
+  private val mappingService: AutomaticLocationMappingService
+) {
   @ShellMethod("Retrieves the location name from the BaSM API for the supplied agency ID if there is a match.")
   fun findAgencyLocationNameFor(agencyId: String) = service.findNomisAgencyLocationNameBy(agencyId) ?: "no match"
+
+  @ShellMethod("Retrieves and maps new locations added/created on the given date (if any).")
+  fun mapNomisLocationsOn(date: LocalDate) = mappingService.mapIfNotPresentLocationsCreatedOn(date)
 }

--- a/wiremock-docker/__files/basm-api/locations/MULTIPLE.json
+++ b/wiremock-docker/__files/basm-api/locations/MULTIPLE.json
@@ -17,7 +17,8 @@
         "postcode": "C111 ONE",
         "latitude": null,
         "longitude": null,
-        "disabled_at": null
+        "disabled_at": null,
+        "created_at": "{{now format='yyyy-MM-dd'}}"
       },
       "relationships": {
         "suppliers": {
@@ -42,7 +43,8 @@
         "postcode": "C2 TWO",
         "latitude": null,
         "longitude": null,
-        "disabled_at": null
+        "disabled_at": null,
+        "created_at": "{{now format='yyyy-MM-dd'}}"
       },
       "relationships": {
         "suppliers": {
@@ -54,20 +56,21 @@
       "id": "2bad3789-0d49-44dc-bb8f-4ff32414fa0c",
       "type": "locations",
       "attributes": {
-        "key": "prison1",
-        "title": "Prison One",
+        "key": "prison5",
+        "title": "Prison Five",
         "location_type": "prison",
-        "nomis_agency_id": "PRISON1",
+        "nomis_agency_id": "PRISON5",
         "can_upload_documents": false,
         "young_offender_institution": false,
         "premise": null,
         "locality": null,
         "city": null,
         "country": null,
-        "postcode": "P111 ONE",
+        "postcode": "P111 FIVE",
         "latitude": null,
         "longitude": null,
-        "disabled_at": null
+        "disabled_at": null,
+        "created_at": "{{now format='yyyy-MM-dd'}}"
       },
       "relationships": {
         "suppliers": {

--- a/wiremock-docker/mappings/basm_api_location_MULTIPLE_ON_DATE.json
+++ b/wiremock-docker/mappings/basm_api_location_MULTIPLE_ON_DATE.json
@@ -1,6 +1,11 @@
 {
   "request" : {
-    "url" : "/api/reference/locations?filter%5Bcreated_at%5D=2021-05-05&per_page=100",
+    "urlPathPattern": "/api/reference/locations",
+    "queryParameters" : {
+      "filter%5Bcreated_at%5D" : {
+        "matches" : "^\\d{4}-\\d{2}-\\d{2}$"
+      }
+    },
     "method" : "GET"
   },
   "response" : {


### PR DESCRIPTION
**Changes:**

- Adding command to the CLI so we can automatically backdate a location from BaSM.
- Some small tweaks to the WireMock files just to make local manual testing a bit easier.