### PR TITLE
P4-2833 removing redudant date parsing from location call on return fom call to BaSM endpoint.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BasmClientApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BasmClientApiService.kt
@@ -82,7 +82,6 @@ data class BasmNomisLocation(
   val name: String,
   val agencyId: String,
   val locationType: LocationType,
-  val createdAt: LocalDate
 )
 
 object NomisLocationDeserializer : JsonDeserializer<BasmNomisLocation>() {
@@ -104,9 +103,8 @@ object NomisLocationDeserializer : JsonDeserializer<BasmNomisLocation>() {
       val title = attributes["title"].asText().trim().toUpperCase()
       val agencyId = attributes["nomis_agency_id"].asText().trim().toUpperCase()
       val locationType = attributes["location_type"].asText()
-      val createdAt = LocalDate.parse(attributes["created_at"].asText())
 
-      return (mayBe[locationType] ?: mayBeCourt(locationType, title))?.let { BasmNomisLocation(title, agencyId, it, createdAt) }
+      return (mayBe[locationType] ?: mayBeCourt(locationType, title))?.let { BasmNomisLocation(title, agencyId, it) }
     }
 
   private fun mayBeCourt(type: String, title: String): LocationType? {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AutomaticLocationMappingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AutomaticLocationMappingServiceTest.kt
@@ -40,7 +40,7 @@ internal class AutomaticLocationMappingServiceTest {
 
   @Test
   fun `when there is a location to map there should be basm, repository and audit interactions`() {
-    val basmLocation = BasmNomisLocation("name", "agency_id", LocationType.CRT, fixedTime.toLocalDate())
+    val basmLocation = BasmNomisLocation("name", "agency_id", LocationType.CRT)
 
     whenever(basmClientApiService.findNomisAgenciesCreatedOn(fixedTime.toLocalDate())).thenReturn(listOf(basmLocation))
     whenever(locationRepository.save(any())).thenReturn(Location(LocationType.CRT, "agency_id", "name"))
@@ -62,8 +62,8 @@ internal class AutomaticLocationMappingServiceTest {
 
   @Test
   fun `when there multiple locations to map there should be basm, repository and audit interactions`() {
-    val basmLocationOne = BasmNomisLocation("one", "agency_one_id", LocationType.CRT, fixedTime.toLocalDate())
-    val basmLocationTwo = BasmNomisLocation("two", "agency_two_id", LocationType.PB, fixedTime.toLocalDate())
+    val basmLocationOne = BasmNomisLocation("one", "agency_one_id", LocationType.CRT)
+    val basmLocationTwo = BasmNomisLocation("two", "agency_two_id", LocationType.PB)
 
     whenever(basmClientApiService.findNomisAgenciesCreatedOn(fixedTime.toLocalDate())).thenReturn(listOf(basmLocationOne, basmLocationTwo))
     whenever(locationRepository.save(any())).thenReturn(
@@ -96,7 +96,7 @@ internal class AutomaticLocationMappingServiceTest {
 
   @Test
   fun `when there is a duplicate location it should be ignored and there should be basm and repository interactions only`() {
-    val duplicateBasmLocation = BasmNomisLocation("name", "agency_id", LocationType.CRT, fixedTime.toLocalDate())
+    val duplicateBasmLocation = BasmNomisLocation("name", "agency_id", LocationType.CRT)
     val duplicateLocation = Location(duplicateBasmLocation.locationType, duplicateBasmLocation.agencyId, duplicateBasmLocation.name)
 
     whenever(basmClientApiService.findNomisAgenciesCreatedOn(fixedTime.toLocalDate())).thenReturn(listOf(duplicateBasmLocation))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BasmClientApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BasmClientApiServiceTest.kt
@@ -123,59 +123,59 @@ internal class BasmClientApiServiceTest {
     fun locationMappingTestData(): List<Arguments> = listOf(
       Arguments.of(
         FakeNomisLocation(" Approved ", " Approved_agency_ID ", "approved_premises", LocalDate.of(2021, 5, 1)),
-        BasmNomisLocation("APPROVED", "APPROVED_AGENCY_ID", LocationType.APP, LocalDate.of(2021, 5, 1))
+        BasmNomisLocation("APPROVED", "APPROVED_AGENCY_ID", LocationType.APP)
       ),
       Arguments.of(
         FakeNomisLocation(" Hospital ", " hospital_agency_ID ", "hospital", LocalDate.of(2021, 5, 2)),
-        BasmNomisLocation("HOSPITAL", "HOSPITAL_AGENCY_ID", LocationType.HP, LocalDate.of(2021, 5, 2))
+        BasmNomisLocation("HOSPITAL", "HOSPITAL_AGENCY_ID", LocationType.HP)
       ),
       Arguments.of(
         FakeNomisLocation(" Police ", " police_agency_ID ", "police", LocalDate.of(2021, 5, 3)),
-        BasmNomisLocation("POLICE", "POLICE_AGENCY_ID", LocationType.PS, LocalDate.of(2021, 5, 3))
+        BasmNomisLocation("POLICE", "POLICE_AGENCY_ID", LocationType.PS)
       ),
       Arguments.of(
         FakeNomisLocation(" Prison ", " prison_agency_ID ", "prison", LocalDate.of(2021, 5, 4)),
-        BasmNomisLocation("PRISON", "PRISON_AGENCY_ID", LocationType.PR, LocalDate.of(2021, 5, 4))
+        BasmNomisLocation("PRISON", "PRISON_AGENCY_ID", LocationType.PR)
       ),
       Arguments.of(
         FakeNomisLocation(" Probation ", " probation_agency_ID ", "probation_office", LocalDate.of(2021, 5, 5)),
-        BasmNomisLocation("PROBATION", "PROBATION_AGENCY_ID", LocationType.PB, LocalDate.of(2021, 5, 5))
+        BasmNomisLocation("PROBATION", "PROBATION_AGENCY_ID", LocationType.PB)
       ),
       Arguments.of(
         FakeNomisLocation(" Immigration ", " immigration_agency_ID ", "immigration_detention_centre", LocalDate.of(2021, 5, 6)),
-        BasmNomisLocation("IMMIGRATION", "IMMIGRATION_AGENCY_ID", LocationType.IM, LocalDate.of(2021, 5, 6))
+        BasmNomisLocation("IMMIGRATION", "IMMIGRATION_AGENCY_ID", LocationType.IM)
       ),
       Arguments.of(
         FakeNomisLocation(" High Security Hospital ", " high_security_hospital_agency_ID ", "high_security_hospital", LocalDate.of(2021, 5, 7)),
-        BasmNomisLocation("HIGH SECURITY HOSPITAL", "HIGH_SECURITY_HOSPITAL_AGENCY_ID", LocationType.HP, LocalDate.of(2021, 5, 7))
+        BasmNomisLocation("HIGH SECURITY HOSPITAL", "HIGH_SECURITY_HOSPITAL_AGENCY_ID", LocationType.HP)
       ),
       Arguments.of(
         FakeNomisLocation(" sch ", " sch_agency_ID ", "secure_childrens_home", LocalDate.of(2021, 5, 8)),
-        BasmNomisLocation("SCH", "SCH_AGENCY_ID", LocationType.SCH, LocalDate.of(2021, 5, 8))
+        BasmNomisLocation("SCH", "SCH_AGENCY_ID", LocationType.SCH)
       ),
       Arguments.of(
         FakeNomisLocation(" stc ", " stc_agency_ID ", "secure_training_centre", LocalDate.of(2021, 5, 9)),
-        BasmNomisLocation("STC", "STC_AGENCY_ID", LocationType.STC, LocalDate.of(2021, 5, 9))
+        BasmNomisLocation("STC", "STC_AGENCY_ID", LocationType.STC)
       ),
       Arguments.of(
         FakeNomisLocation(" County courT ", " court_agency_ID ", "court", LocalDate.of(2021, 5, 10)),
-        BasmNomisLocation("COUNTY COURT", "COURT_AGENCY_ID", LocationType.CO, LocalDate.of(2021, 5, 10))
+        BasmNomisLocation("COUNTY COURT", "COURT_AGENCY_ID", LocationType.CO)
       ),
       Arguments.of(
         FakeNomisLocation(" combineD courT ", " court_agency_ID ", "court", LocalDate.of(2021, 5, 11)),
-        BasmNomisLocation("COMBINED COURT", "COURT_AGENCY_ID", LocationType.CM, LocalDate.of(2021, 5, 11))
+        BasmNomisLocation("COMBINED COURT", "COURT_AGENCY_ID", LocationType.CM)
       ),
       Arguments.of(
         FakeNomisLocation(" cRown courT ", " court_agency_ID ", "court", LocalDate.of(2021, 5, 12)),
-        BasmNomisLocation("CROWN COURT", "COURT_AGENCY_ID", LocationType.CC, LocalDate.of(2021, 5, 12))
+        BasmNomisLocation("CROWN COURT", "COURT_AGENCY_ID", LocationType.CC)
       ),
       Arguments.of(
         FakeNomisLocation(" magistrates courT ", " court_agency_ID ", "court", LocalDate.of(2021, 5, 13)),
-        BasmNomisLocation("MAGISTRATES COURT", "COURT_AGENCY_ID", LocationType.MC, LocalDate.of(2021, 5, 13))
+        BasmNomisLocation("MAGISTRATES COURT", "COURT_AGENCY_ID", LocationType.MC)
       ),
       Arguments.of(
         FakeNomisLocation(" ranDom courT ", " court_agency_ID ", "court", LocalDate.of(2021, 5, 14)),
-        BasmNomisLocation("RANDOM COURT", "COURT_AGENCY_ID", LocationType.CRT, LocalDate.of(2021, 5, 14))
+        BasmNomisLocation("RANDOM COURT", "COURT_AGENCY_ID", LocationType.CRT)
       )
     )
   }

--- a/wiremock-docker/__files/basm-api/locations/MULTIPLE.json
+++ b/wiremock-docker/__files/basm-api/locations/MULTIPLE.json
@@ -18,7 +18,7 @@
         "latitude": null,
         "longitude": null,
         "disabled_at": null,
-        "created_at": "{{now format='yyyy-MM-dd'}}"
+        "created_at": "{{now}}"
       },
       "relationships": {
         "suppliers": {
@@ -44,7 +44,7 @@
         "latitude": null,
         "longitude": null,
         "disabled_at": null,
-        "created_at": "{{now format='yyyy-MM-dd'}}"
+        "created_at": "{{now}}"
       },
       "relationships": {
         "suppliers": {
@@ -70,7 +70,7 @@
         "latitude": null,
         "longitude": null,
         "disabled_at": null,
-        "created_at": "{{now format='yyyy-MM-dd'}}"
+        "created_at": "{{now}}"
       },
       "relationships": {
         "suppliers": {


### PR DESCRIPTION
**Changes:**

This change removes the unnecessary parsing of the **created_at** date/timestamp in the response from the call to BaSM locations reference data.  We don't actually care or use it.