### PR TITLE
P4-2833 updating the duplicate location check prior to auto mapping new location to check on name as well as agency id.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationRepository.kt
@@ -9,4 +9,6 @@ interface LocationRepository : JpaRepository<Location, UUID> {
   fun findByNomisAgencyId(id: String): Location?
 
   fun findBySiteName(name: String): Location?
+
+  fun findByNomisAgencyIdOrSiteName(id: String, name: String): Location?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AutomaticLocationMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AutomaticLocationMappingService.kt
@@ -22,9 +22,9 @@ class AutomaticLocationMappingService(
 
   fun mapIfNotPresentLocationsCreatedOn(date: LocalDate) {
     basmClientApi.findNomisAgenciesCreatedOn(date).forEach {
-      locationRepository.findByNomisAgencyId(it.agencyId).let { location ->
+      locationRepository.findByNomisAgencyIdOrSiteName(it.agencyId.toUpperCase().trim(), it.name.toUpperCase().trim()).let { location ->
         if (location == null) {
-          locationRepository.save(Location(it.locationType, it.agencyId, it.name, timeSource.dateTime())).also { newLocation ->
+          locationRepository.save(Location(it.locationType, it.agencyId.toUpperCase().trim(), it.name.toUpperCase().trim(), timeSource.dateTime())).also { newLocation ->
             auditService.create(AuditableEvent.autoMapLocation(newLocation))
 
             logger.info("Automatically mapped new location: agency ID '${it.agencyId}', name '${it.name}' and type '${it.locationType.label}'")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationRepositoryTest.kt
@@ -35,4 +35,14 @@ internal class LocationRepositoryTest {
       entityManager.flush()
     }.isInstanceOf(ConstraintViolationException::class.java)
   }
+
+  @Test
+  fun `can find location by agency id or site name`() {
+    val location = repository.save(Location(LocationType.PR, "agency id", "site name"))
+
+    entityManager.flush()
+
+    assertThat(repository.findByNomisAgencyIdOrSiteName("agency id", "different site name")).isEqualTo(location)
+    assertThat(repository.findByNomisAgencyIdOrSiteName("different agency id", "site name")).isEqualTo(location)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AutomaticLocationMappingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AutomaticLocationMappingServiceTest.kt
@@ -40,10 +40,10 @@ internal class AutomaticLocationMappingServiceTest {
 
   @Test
   fun `when there is a location to map there should be basm, repository and audit interactions`() {
-    val basmLocation = BasmNomisLocation("name", "agency_id", LocationType.CRT)
+    val basmLocation = BasmNomisLocation(" Name", "agency_iD ", LocationType.CRT)
 
     whenever(basmClientApiService.findNomisAgenciesCreatedOn(fixedTime.toLocalDate())).thenReturn(listOf(basmLocation))
-    whenever(locationRepository.save(any())).thenReturn(Location(LocationType.CRT, "agency_id", "name"))
+    whenever(locationRepository.save(any())).thenReturn(Location(LocationType.CRT, "AGENCY_ID", "NAME"))
 
     service.mapIfNotPresentLocationsCreatedOn(fixedTime.toLocalDate())
 
@@ -52,8 +52,8 @@ internal class AutomaticLocationMappingServiceTest {
 
     val newLocation = newLocationCaptor.firstValue
 
-    assertThat(newLocation.siteName).isEqualTo("name")
-    assertThat(newLocation.nomisAgencyId).isEqualTo("agency_id")
+    assertThat(newLocation.siteName).isEqualTo("NAME")
+    assertThat(newLocation.nomisAgencyId).isEqualTo("AGENCY_ID")
     assertThat(newLocation.locationType).isEqualTo(LocationType.CRT)
     assertThat(newLocation.addedAt).isEqualTo(fixedTime)
 
@@ -62,13 +62,13 @@ internal class AutomaticLocationMappingServiceTest {
 
   @Test
   fun `when there multiple locations to map there should be basm, repository and audit interactions`() {
-    val basmLocationOne = BasmNomisLocation("one", "agency_one_id", LocationType.CRT)
-    val basmLocationTwo = BasmNomisLocation("two", "agency_two_id", LocationType.PB)
+    val basmLocationOne = BasmNomisLocation("onE ", " Agency_one_id", LocationType.CRT)
+    val basmLocationTwo = BasmNomisLocation(" tWo", "agency_Two_id ", LocationType.PB)
 
     whenever(basmClientApiService.findNomisAgenciesCreatedOn(fixedTime.toLocalDate())).thenReturn(listOf(basmLocationOne, basmLocationTwo))
     whenever(locationRepository.save(any())).thenReturn(
-      Location(LocationType.CRT, "agency_one_id", "one"),
-      Location(LocationType.PB, "agency_two_id", "two")
+      Location(LocationType.CRT, "AGENCY_ONE_ID", "ONE"),
+      Location(LocationType.PB, "AGENCY_TWO_ID", "TWO")
     )
 
     service.mapIfNotPresentLocationsCreatedOn(fixedTime.toLocalDate())
@@ -78,15 +78,15 @@ internal class AutomaticLocationMappingServiceTest {
 
     val newLocationOne = newLocationCaptor.firstValue
 
-    assertThat(newLocationOne.siteName).isEqualTo("one")
-    assertThat(newLocationOne.nomisAgencyId).isEqualTo("agency_one_id")
+    assertThat(newLocationOne.siteName).isEqualTo("ONE")
+    assertThat(newLocationOne.nomisAgencyId).isEqualTo("AGENCY_ONE_ID")
     assertThat(newLocationOne.locationType).isEqualTo(LocationType.CRT)
     assertThat(newLocationOne.addedAt).isEqualTo(fixedTime)
 
     val newLocationTwo = newLocationCaptor.secondValue
 
-    assertThat(newLocationTwo.siteName).isEqualTo("two")
-    assertThat(newLocationTwo.nomisAgencyId).isEqualTo("agency_two_id")
+    assertThat(newLocationTwo.siteName).isEqualTo("TWO")
+    assertThat(newLocationTwo.nomisAgencyId).isEqualTo("AGENCY_TWO_ID")
     assertThat(newLocationTwo.locationType).isEqualTo(LocationType.PB)
     assertThat(newLocationTwo.addedAt).isEqualTo(fixedTime)
 
@@ -96,16 +96,16 @@ internal class AutomaticLocationMappingServiceTest {
 
   @Test
   fun `when there is a duplicate location it should be ignored and there should be basm and repository interactions only`() {
-    val duplicateBasmLocation = BasmNomisLocation("name", "agency_id", LocationType.CRT)
+    val duplicateBasmLocation = BasmNomisLocation(" nAme ", " agency_Id", LocationType.CRT)
     val duplicateLocation = Location(duplicateBasmLocation.locationType, duplicateBasmLocation.agencyId, duplicateBasmLocation.name)
 
     whenever(basmClientApiService.findNomisAgenciesCreatedOn(fixedTime.toLocalDate())).thenReturn(listOf(duplicateBasmLocation))
-    whenever(locationRepository.findByNomisAgencyId(duplicateBasmLocation.agencyId)).thenReturn(duplicateLocation)
+    whenever(locationRepository.findByNomisAgencyIdOrSiteName("AGENCY_ID", "NAME")).thenReturn(duplicateLocation)
 
     service.mapIfNotPresentLocationsCreatedOn(fixedTime.toLocalDate())
 
     verify(basmClientApiService).findNomisAgenciesCreatedOn(fixedTime.toLocalDate())
-    verify(locationRepository).findByNomisAgencyId(duplicateBasmLocation.agencyId)
+    verify(locationRepository).findByNomisAgencyIdOrSiteName("AGENCY_ID", "NAME")
     verify(locationRepository, never()).save(any())
     verifyZeroInteractions(auditService)
   }


### PR DESCRIPTION
Changes:

Through testing discovered that need to check on the site name as well as the agency id to see if a location already exists in JPC prior to auto mapping from BaSM.  Found that a site name existed in JPC with a different agency id to that in BaSM but the actual location names were the same.