### PR TITLE
P4-2833 enable cron to run at 3:30 am in morning for automatic location mapping task.

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -26,7 +26,7 @@ env:
   JAVA_OPTS: "-Xmx2048m"
   HMPPS_AUTH_BASE_URI: "https://sign-in.hmpps.service.justice.gov.uk/auth"
   HMPPS_AUTH_REDIRECT_BASE_URI: "https://calculate-journey-variable-payments.hmpps.service.justice.gov.uk"
-  CRON_AUTOMATIC_LOCATION_MAPPING: "-"
+  CRON_AUTOMATIC_LOCATION_MAPPING: "0 30 3 * * ?"
   CRON_IMPORT_REPORTS: "0 30 5 * * ?"
   SENTRY_ENVIRONMENT: prod
   BASM_API_BASE_URL: "https://api.bookasecuremove.service.justice.gov.uk"


### PR DESCRIPTION
Changes:

Turn on the CRON job in production to run at 3:30am to automatically map locations in BaSM to locations in CJVP if it does not already exist in CJVP.