### PR TITLE
P4 2805 display location history

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditableEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditableEvent.kt
@@ -20,6 +20,8 @@ data class AuditableEvent(
   companion object {
     private val terminal = "_TERMINAL_"
 
+    fun isSystemGenerated(event: AuditEvent) = event.username.toUpperCase().trim() == terminal
+
     private fun createEvent(
       type: AuditEventType,
       authentication: Authentication? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/LocationHistoryDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/LocationHistoryDto.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.controller
+
+import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditEvent
+import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditableEvent
+import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.MapLocationMetadata
+import java.time.LocalDateTime
+
+data class LocationHistoryDto(val datetime: LocalDateTime, val action: String, val by: String) {
+  companion object {
+    fun valueOf(event: AuditEvent, data: MapLocationMetadata): LocationHistoryDto {
+
+      val action = buildString {
+        if (data.isRemapping()) {
+          if (data.newName != null) append("Location name changed from '${data.oldName}' to '${data.newName}'")
+          if (data.newName != null && data.newType != null) append(" and location type changed from '${data.oldType?.label}' to '${data.newType.label}'")
+          if (data.newType != null && data.newName == null) append("Location type changed from '${data.oldType?.label}' to '${data.newType.label}'")
+        } else {
+          append("Assigned to location name ${data.newName} and type ${data.newType?.label}")
+        }
+      }
+
+      return LocationHistoryDto(
+        event.createdAt,
+        action,
+        if (AuditableEvent.isSystemGenerated(event)) "SYSTEM" else event.username
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ManageSchedule34LocationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ManageSchedule34LocationsController.kt
@@ -78,6 +78,13 @@ class ManageSchedule34LocationsController(
             ?: "Sorry, we are currently unable to retrieve the NOMIS Location Name. Please try again later."
         )
       )
+
+      model.addAttribute(
+        "history",
+        service.locationHistoryForAgencyId(agencyId)
+          .map { history -> LocationHistoryDto.valueOf(history.key, history.value) }
+          .sortedByDescending { lh -> lh.datetime }
+      )
     }
 
     return "manage-location"
@@ -92,7 +99,16 @@ class ManageSchedule34LocationsController(
   ): String {
     logger.info("performing manage location")
 
-    if (result.hasErrors()) return "manage-location"
+    if (result.hasErrors()) {
+      model.addAttribute(
+        "history",
+        service.locationHistoryForAgencyId(location.agencyId)
+          .map { history -> LocationHistoryDto.valueOf(history.key, history.value) }
+          .sortedByDescending { lh -> lh.datetime }
+      )
+
+      return "manage-location"
+    }
 
     return if (isDuplicate(location)) {
       "manage-location".also { result.duplicateLocation() }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MapFriendlyLocationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MapFriendlyLocationController.kt
@@ -62,10 +62,17 @@ class MapFriendlyLocationController(
         )
       )
 
+      model.addAttribute(
+        "history",
+        service.locationHistoryForAgencyId(agencyId)
+          .map { history -> LocationHistoryDto.valueOf(history.key, history.value) }
+          .sortedByDescending { lh -> lh.datetime }
+      )
+
       model.addCancelLinkFor(UriComponentsBuilder.fromUriString(SEARCH_JOURNEYS_RESULTS_URL))
       model.rememberLocationChangeTypePriorToUpdate(origin!!)
 
-      return "map-location"
+      return "update-location"
     }
 
     model.addAttribute(
@@ -77,7 +84,7 @@ class MapFriendlyLocationController(
       )
     )
 
-    return "map-location"
+    return "add-location"
   }
 
   private fun ModelMap.rememberLocationChangeTypePriorToUpdate(type: String) {
@@ -96,9 +103,20 @@ class MapFriendlyLocationController(
     val searchResultsUrl = UriComponentsBuilder.fromUriString(SEARCH_JOURNEYS_RESULTS_URL)
 
     if (result.hasErrors()) {
-      if (form.operation == "update") model.addCancelLinkFor(searchResultsUrl)
+      if (form.operation == "update") {
+        model.addCancelLinkFor(searchResultsUrl)
 
-      return "map-location"
+        model.addAttribute(
+          "history",
+          service.locationHistoryForAgencyId(form.agencyId)
+            .map { history -> LocationHistoryDto.valueOf(history.key, history.value) }
+            .sortedByDescending { lh -> lh.datetime }
+        )
+
+        return "update-location"
+      }
+
+      return "add-location"
     }
 
     service.setLocationDetails(form.agencyId, form.locationName, form.locationType!!)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AuditService.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditEvent
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditEventRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditEventType
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditableEvent
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 
@@ -20,4 +21,6 @@ class AuditService(private val auditEventRepository: AuditEventRepository, priva
       )
     )
   }
+
+  internal fun auditEventsByType(type: AuditEventType) = auditEventRepository.findByEventType(type)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/LocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/LocationsService.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.service
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditEventType
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditableEvent
+import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.MapLocationMetadata
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.Location
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationRepository
@@ -60,6 +62,11 @@ class LocationsService(
       )
     ).let { e -> auditService.create(e) }
   }
+
+  fun locationHistoryForAgencyId(agencyId: String) =
+    auditService.auditEventsByType(AuditEventType.LOCATION)
+      .associateWith { MapLocationMetadata.map(it) }
+      .filterValues { sanitised(it.nomisId) == sanitised(agencyId) }
 
   private fun sanitised(value: String) = value.trim().toUpperCase()
 }

--- a/src/main/resources/templates/add-location.html
+++ b/src/main/resources/templates/add-location.html
@@ -27,17 +27,10 @@
         </div>
 
         <div class="mv4">
-            <div th:if="${form.operation == 'create'}">
                 <h1 class="govuk-heading-xl mv2" th:inline="text">Map location</h1>
                 <p class="govuk-heading-s govuk-body govuk-!-font-weight-regular">Please add a Schedule 34 location name
                     for this NOMIS agency ID.</p>
-            </div>
-            <div th:if="${form.operation == 'update'}">
-                <h1 class="govuk-heading-xl mv2" th:inline="text">Update location</h1>
-                <p class="govuk-heading-s govuk-body govuk-!-font-weight-regular">Update Schedule 34 location.</p>
-            </div>
         </div>
-
 
         <div class="govuk-form-group" th:classappend="${#fields.hasErrors('*')} ? 'govuk-form-group--error'">
             <ol class="list pl0">
@@ -84,8 +77,7 @@
             <button class="govuk-button mv3 mr3" data-module="govuk-button">
                 Confirm and save
             </button>
-            <a href="/journeys" class="govuk-link" th:if="${form.operation == 'create'}">Cancel</a>
-            <a th:href="${cancelLink}" class="govuk-link" th:if="${form.operation == 'update'}">Cancel</a>
+            <a href="/journeys" class="govuk-link">Cancel</a>
         </div>
     </form>
 </div>

--- a/src/main/resources/templates/manage-location.html
+++ b/src/main/resources/templates/manage-location.html
@@ -11,74 +11,117 @@
 
 <div class="govuk-width-container" layout:fragment="content">
 
-    <form th:action="@{/manage-location}" th:object="${form}" method="post">
+  <a href="/search-locations" class="govuk-back-link">Back</a>
+
+  <div class="govuk-tabs" data-module="govuk-tabs">
+    <h2 class="govuk-tabs__title">
+      Contents
+    </h2>
+    <ul class="govuk-tabs__list">
+      <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+        <a class="govuk-tabs__tab" href="#update-location">
+          Update location
+        </a>
+      </li>
+      <li class="govuk-tabs__list-item">
+        <a class="govuk-tabs__tab" href="#location-history">
+          Location history
+        </a>
+      </li>
+    </ul>
+    <div class="govuk-tabs__panel" id="update-location">
+      <form th:action="@{/manage-location}" th:object="${form}" method="post">
         <div class="govuk-error-summary mv3" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
              data-module="govuk-error-summary" th:if="${#fields.hasErrors('*')}">
-            <h2 class="govuk-error-summary__title" id="error-summary-title">
-                There is a problem
-            </h2>
-            <div class="govuk-error-summary__body">
-                <ul class="govuk-list govuk-error-summary__list">
-                    <li>
-                        <a href="#location-name" th:errors="*">Error</a>
-                    </li>
-                </ul>
-            </div>
+          <h2 class="govuk-error-summary__title" id="error-summary-title">
+            There is a problem
+          </h2>
+          <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list">
+              <li>
+                <a href="#location-name" th:errors="*">Error</a>
+              </li>
+            </ul>
+          </div>
         </div>
 
         <div class="mv4">
-            <h1 class="govuk-heading-xl mv2" th:inline="text">Update location</h1>
-            <p class="govuk-heading-s govuk-body govuk-!-font-weight-regular">Update Schedule 34 location.</p>
+          <h2 class="govuk-heading-xl mv2" th:inline="text">Update location</h2>
+          <p class="govuk-heading-s govuk-body govuk-!-font-weight-regular">Update Schedule 34 location.</p>
         </div>
 
 
         <div class="govuk-form-group" th:classappend="${#fields.hasErrors('*')} ? 'govuk-form-group--error'">
-            <ol class="list pl0">
-                <li class="mv3">
-                  <p class="govuk-label govuk-body govuk-!-font-weight-bold">NOMIS Location Name</p>
-                  <p th:text="*{nomisLocationName}" class="govuk-body ma0"></p>
-                  <input type="hidden" th:field="*{nomisLocationName}" class="dn"/>
-                </li>
-                <li class="mv3">
-                  <p class="govuk-label govuk-body govuk-!-font-weight-bold">NOMIS Agency ID</p>
-                  <p th:text="*{agencyId}" class="govuk-body ma0"></p>
-                  <input type="hidden" th:field="*{agencyId}" class="dn"/>
-                </li>
-                <li class="mv3">
-                    <label class="govuk-label govuk-body govuk-!-font-weight-bold" for="location-name">Maps to Schedule
-                        34 location</label>
-                    <p th:if="${#fields.hasErrors('*')}" class="govuk-error-message">
-                        <span class="govuk-visually-hidden">Error:</span> <span th:errors="*"></span>
-                    </p>
-                    <input class="govuk-input govuk-input--width-20" id="location-name" name="location-name" type="text"
-                           th:field="*{locationName}"
-                           th:classappend="${#fields.hasErrors('locationName')} ? 'govuk-input--error'">
-                </li>
-                <li class="mv3">
-                    <label class="govuk-label govuk-body govuk-!-font-weight-bold" for="location-type-id">Add location type</label>
-                    <select name="location-type" id="location-type-id" th:field="*{locationType}" class="govuk-select">
-                        <option th:each="type : ${T(uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType).values()}"
-                                th:value="${type}"
-                                th:text="${type.label}">type
-                        </option>
-                    </select>
-                </li>
-            </ol>
+          <ol class="list pl0">
+            <li class="mv3">
+              <p class="govuk-label govuk-body govuk-!-font-weight-bold">NOMIS Location Name</p>
+              <p th:text="*{nomisLocationName}" class="govuk-body ma0"></p>
+              <input type="hidden" th:field="*{nomisLocationName}" class="dn"/>
+            </li>
+            <li class="mv3">
+              <p class="govuk-label govuk-body govuk-!-font-weight-bold">NOMIS Agency ID</p>
+              <p th:text="*{agencyId}" class="govuk-body ma0"></p>
+              <input type="hidden" th:field="*{agencyId}" class="dn"/>
+            </li>
+            <li class="mv3">
+              <label class="govuk-label govuk-body govuk-!-font-weight-bold" for="location-name">Maps to Schedule
+                34 location</label>
+              <p th:if="${#fields.hasErrors('*')}" class="govuk-error-message">
+                <span class="govuk-visually-hidden">Error:</span> <span th:errors="*"></span>
+              </p>
+              <input class="govuk-input govuk-input--width-20" id="location-name" name="location-name" type="text"
+                     th:field="*{locationName}"
+                     th:classappend="${#fields.hasErrors('locationName')} ? 'govuk-input--error'">
+            </li>
+            <li class="mv3">
+              <label class="govuk-label govuk-body govuk-!-font-weight-bold" for="location-type-id">Add location type</label>
+              <select name="location-type" id="location-type-id" th:field="*{locationType}" class="govuk-select">
+                <option th:each="type : ${T(uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType).values()}"
+                        th:value="${type}"
+                        th:text="${type.label}">type
+                </option>
+              </select>
+            </li>
+          </ol>
         </div>
         <div class="govuk-warning-text mv3">
-            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-            <strong class="govuk-warning-text__text">
-                <span class="govuk-warning-text__assistive">Warning</span>
-                <span th:inline="text">Mapping a Schedule 34 location name will not update location names in NOMIS.</span>
-            </strong>
+          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text">
+            <span class="govuk-warning-text__assistive">Warning</span>
+            <span th:inline="text">Mapping a Schedule 34 location name will not update location names in NOMIS.</span>
+          </strong>
         </div>
         <div class="flex items-center">
-            <button class="govuk-button mv3 mr3" data-module="govuk-button">
-                Confirm and save
-            </button>
-            <a href="/search-locations" class="govuk-link">Cancel</a>
+          <button class="govuk-button mv3 mr3" data-module="govuk-button">
+            Confirm and save
+          </button>
+          <a href="/search-locations" class="govuk-link">Cancel</a>
         </div>
-    </form>
+      </form>
+    </div>
+
+    <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="location-history">
+      <h2 class="govuk-heading-l">Location history</h2>
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Date</th>
+          <th scope="col" class="govuk-table__header">Time</th>
+          <th scope="col" class="govuk-table__header">Action</th>
+          <th scope="col" class="govuk-table__header">By</th>
+        </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        <tr class="govuk-table__row" th:each="event: ${history}">
+          <td class="govuk-table__cell" scope="row" th:inline="text">[[${#temporals.format(event.datetime, 'dd MMMM yyyy')}]]</td>
+          <td class="govuk-table__cell" scope="row" th:inline="text">[[${#temporals.format(event.datetime, 'HH:mm a')}]]</td>
+          <td class="govuk-table__cell" scope="row" th:inline="text">[[${event.action}]]</td>
+          <td class="govuk-table__cell" scope="row" th:inline="text">[[${event.by}]]</td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
 </div>
 </body>
 

--- a/src/main/resources/templates/update-location.html
+++ b/src/main/resources/templates/update-location.html
@@ -6,12 +6,12 @@
 <head>
     <title>Calculate Journey Variable Payments - GOV.UK</title>
 </head>
-
+govuk-table__caption
 <body>
 
 <div class="govuk-width-container" layout:fragment="content">
 
-  <a href="/search-locations" class="govuk-back-link">Back</a>
+  <a th:href="${cancelLink}" class="govuk-back-link">Back</a>
 
   <div class="govuk-tabs" data-module="govuk-tabs">
     <h2 class="govuk-tabs__title">
@@ -30,7 +30,7 @@
       </li>
     </ul>
     <div class="govuk-tabs__panel" id="update-location">
-      <form th:action="@{/manage-location}" th:object="${form}" method="post">
+      <form th:action="@{/map-location}" th:object="${form}" method="post">
         <div class="govuk-error-summary mv3" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
              data-module="govuk-error-summary" th:if="${#fields.hasErrors('*')}">
           <h2 class="govuk-error-summary__title" id="error-summary-title">
@@ -61,6 +61,7 @@
               <p class="govuk-label govuk-body govuk-!-font-weight-bold">NOMIS Agency ID</p>
               <p th:text="*{agencyId}" class="govuk-body ma0"></p>
               <input type="hidden" th:field="*{agencyId}" class="dn"/>
+              <input type="hidden" th:field="*{operation}" class="dn"/>
             </li>
             <li class="mv3">
               <label class="govuk-label govuk-body govuk-!-font-weight-bold" for="location-name">Maps to Schedule
@@ -94,7 +95,7 @@
           <button class="govuk-button mv3 mr3" data-module="govuk-button">
             Confirm and save
           </button>
-          <a href="/search-locations" class="govuk-link">Cancel</a>
+          <a th:href="${cancelLink}" class="govuk-link">Cancel</a>
         </div>
       </form>
     </div>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MapFriendlyLocationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MapFriendlyLocationControllerTest.kt
@@ -17,9 +17,13 @@ import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
+import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditEvent
+import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditEventType
+import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.MapLocationMetadata
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.BasmClientApiService
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.LocationsService
+import java.time.LocalDateTime
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -48,7 +52,7 @@ internal class MapFriendlyLocationControllerTest(@Autowired private val wac: Web
 
     mockMvc.get("/map-location/$agencyId")
       .andExpect { model { attribute("form", MapFriendlyLocationController.MapLocationForm(agencyId, nomisLocationName = nomisLocationName)) } }
-      .andExpect { view { name("map-location") } }
+      .andExpect { view { name("add-location") } }
       .andExpect { status { isOk() } }
 
     verify(service).findAgencyLocationAndType(agencyId)
@@ -61,20 +65,22 @@ internal class MapFriendlyLocationControllerTest(@Autowired private val wac: Web
 
     mockMvc.get("/map-location/$agencyId")
       .andExpect { model { attribute("form", MapFriendlyLocationController.MapLocationForm(agencyId, nomisLocationName = "Sorry, we are currently unable to retrieve the NOMIS Location Name. Please try again later.")) } }
-      .andExpect { view { name("map-location") } }
+      .andExpect { view { name("add-location") } }
       .andExpect { status { isOk() } }
 
     verify(service).findAgencyLocationAndType(agencyId)
   }
 
   @Test
-  internal fun `get mapping for existing friendly location`() {
-    whenever(service.findAgencyLocationAndType(agencyId)).thenReturn(
-      Triple(
-        agencyId,
-        "existing location",
-        LocationType.AP
-      )
+  internal fun `get mapping for existing friendly location and location audit history`() {
+    val (agencyId, agencyName, agencyType) = Triple("ABCDEF", "EXISTING LOCATION", LocationType.CC)
+    val auditEventDatetime = LocalDateTime.now()
+    val auditEventMetadata = MapLocationMetadata(agencyId, newName = agencyName, newType = agencyType)
+
+    whenever(service.findAgencyLocationAndType(agencyId)).thenReturn(Triple(agencyId, agencyName, agencyType))
+
+    whenever(service.locationHistoryForAgencyId(agencyId)).thenReturn(
+      mapOf(AuditEvent(AuditEventType.LOCATION, auditEventDatetime, "Jane", auditEventMetadata) to auditEventMetadata)
     )
 
     whenever(basmClientApiService.findNomisAgencyLocationNameBy(agencyId)).thenReturn(nomisLocationName)
@@ -84,11 +90,12 @@ internal class MapFriendlyLocationControllerTest(@Autowired private val wac: Web
         model {
           attribute(
             "form",
-            MapFriendlyLocationController.MapLocationForm(agencyId, "existing location", LocationType.AP, "update", nomisLocationName)
+            MapFriendlyLocationController.MapLocationForm("ABCDEF", "EXISTING LOCATION", LocationType.CC, "update", nomisLocationName)
           )
         }
       }
-      .andExpect { view { name("map-location") } }
+      .andExpect { model { attribute("history", listOf(LocationHistoryDto(auditEventDatetime, "Assigned to location name EXISTING LOCATION and type Crown Court", "Jane"))) } }
+      .andExpect { view { name("update-location") } }
       .andExpect { model { attribute("origin", "from") } }
       .andExpect { status { isOk() } }
 
@@ -200,7 +207,7 @@ internal class MapFriendlyLocationControllerTest(@Autowired private val wac: Web
       param("locationType", "CC")
     }
       .andExpect { model { attributeHasFieldErrorCode("form", "locationName", "NotEmpty") } }
-      .andExpect { view { name("map-location") } }
+      .andExpect { view { name("add-location") } }
       .andExpect { status { isOk() } }
 
     verify(service, never()).locationAlreadyExists(any(), any())
@@ -217,7 +224,7 @@ internal class MapFriendlyLocationControllerTest(@Autowired private val wac: Web
       param("locationName", "Duplicate location")
       param("locationType", "CC")
     }
-      .andExpect { view { name("map-location") } }
+      .andExpect { view { name("add-location") } }
       .andExpect { status { isOk() } }
 
     verify(service).locationAlreadyExists(agencyId, "Duplicate location")


### PR DESCRIPTION
Changes:

When updating a location the user user is presented with a tabbed view.  One tab for updating the location and another tab for the location audit history/changes.

![image](https://user-images.githubusercontent.com/60104344/118982280-2c448e00-b973-11eb-9e22-c41791832a09.png)

![image](https://user-images.githubusercontent.com/60104344/118982328-38305000-b973-11eb-9a61-a281229b9f0e.png)


