### PR TITLE
P4-2895 tweaking migration to filter on the event type, if there was a price change then this was causing it to exclude add a default entry.

### DIFF
--- a/src/main/resources/db/migration/dml/V1_3__backfill_location_audit_events.sql
+++ b/src/main/resources/db/migration/dml/V1_3__backfill_location_audit_events.sql
@@ -7,6 +7,4 @@ insert into audit_events
          '{"nomis_id" : "'|| l.nomis_agency_id ||'", "new_name" : "'|| l.site_name ||'", "new_type" : "'|| l.location_type ||'"}',
          '_TERMINAL_'
     from locations l
-   where not exists (select 1 from audit_events ae where ae.metadata like '%"'|| l.nomis_agency_id ||'"%');
-
-select uuid_generate_v4(), l.added_at, 'LOCATION', '{"nomis_id" : "'|| l.nomis_agency_id ||'", "new_name" : "'|| l.site_name ||'", "new_type" : "'|| l.location_type ||'"}', '_TERMINAL_' from locations l where not exists (select 1 from audit_events ae where ae.metadata like '%"'|| l.nomis_agency_id ||'"%');
+   where not exists (select 1 from audit_events ae where ae.metadata like '%"'|| l.nomis_agency_id ||'"%' and ae.event_type = 'LOCATION');


### PR DESCRIPTION
Changes:

Updating location history event migration SQL to include the event type as part of the filter.  Without this it was picking up price events and as a result not adding the entry i.e. nothing was being added if a location had a price change.