### PR TITLE
P4-2896 migration to backfill any missing audit price history for prices added prior to introduction of audit functionality.

### DIFF
--- a/src/main/resources/db/migration/dml/V1_4__backfill_price_audit_events.sql
+++ b/src/main/resources/db/migration/dml/V1_4__backfill_price_audit_events.sql
@@ -1,0 +1,17 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+insert into audit_events
+select uuid_generate_v4() event_id,
+       p.added_at created_at,
+       'JOURNEY_PRICE' event_type,
+       '{"supplier" : "' || p.supplier || '", "from_nomis_id" : "'|| lf.nomis_agency_id ||'", "to_nomis_id" : "'|| lt.nomis_agency_id ||'", "effective_year" : '|| p.effective_year ||', "new_price" : '|| cast(p.price_in_pence / 100.0 as decimal(15,2)) ||'}' metadata,
+       '_TERMINAL_' username
+  from prices p
+       left join locations lf on p.from_location_id = lf.location_id
+       left join locations lt on p.to_location_id = lt.location_id
+ where not exists (select 1
+                     from audit_events ae
+                    where jsonb_extract_path_text(ae.metadata::jsonb, 'supplier') = p.supplier
+                      and jsonb_extract_path_text(ae.metadata::jsonb, 'from_nomis_id') = lf.nomis_agency_id
+                      and jsonb_extract_path_text(ae.metadata::jsonb, 'to_nomis_id') = lt.nomis_agency_id
+                      and ae.event_type = 'JOURNEY_PRICE');


### PR DESCRIPTION
**Changes:**

Audit functionality was added prior to some prices being added by the system (CRON job).  As a result this migration will insert rows for those prices which have no audit entries, if it has an entry already then no entry will be added.

This is done so we have at least one entry on the prices history tab.