### PR TITLE
P4-2896 changes to improve the performance when reading the audit history events.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/LocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/LocationsService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.service
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditEvent
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditEventType
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditableEvent
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.MapLocationMetadata
@@ -63,11 +64,14 @@ class LocationsService(
     ).let { e -> auditService.create(e) }
   }
 
-  fun locationHistoryForAgencyId(agencyId: String) =
-    auditService.auditEventsByType(AuditEventType.LOCATION)
+  fun locationHistoryForAgencyId(agencyId: String): Set<AuditEvent> {
+    val sanitisedAgencyId = sanitised(agencyId)
+
+    return auditService.auditEventsByType(AuditEventType.LOCATION)
       .associateWith { MapLocationMetadata.map(it) }
-      .filterValues { sanitised(it.nomisId) == sanitised(agencyId) }
+      .filterValues { it.nomisId == sanitisedAgencyId }
       .keys
+  }
 
   private fun sanitised(value: String) = value.trim().toUpperCase()
 }

--- a/src/main/resources/db/migration/ddl/V1_5__add_audit_events_event_type_idx.sql
+++ b/src/main/resources/db/migration/ddl/V1_5__add_audit_events_event_type_idx.sql
@@ -1,0 +1,1 @@
+create index if not exists audit_events_event_type_idx on audit_events (event_type);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingServiceTest.kt
@@ -166,14 +166,14 @@ internal class SupplierPricingServiceTest {
 
   @Test
   internal fun `finds single price history entry for Serco`() {
-    val sercoOriginalPrice = PriceMetadata(Supplier.SERCO, "from_agency_id", "to_agency_id", 2021, Money(1000).pounds())
+    val sercoOriginalPrice = PriceMetadata(Supplier.SERCO, "FROM_AGENCY_ID", "TO_AGENCY_ID", 2021, Money(1000).pounds())
     val sercoOriginalPriceEvent = AuditEvent(AuditEventType.JOURNEY_PRICE, LocalDateTime.now(), "Jane", sercoOriginalPrice)
 
     val geoameyPriceEvent = AuditEvent(
       AuditEventType.JOURNEY_PRICE,
       LocalDateTime.now(),
       "Jane",
-      PriceMetadata(Supplier.GEOAMEY, "from_agency_id", "to_agency_id", 2021, Money(1000).pounds())
+      PriceMetadata(Supplier.GEOAMEY, "FROM_AGENCY_ID", "TO_AGENCY_ID", 2021, Money(1000).pounds())
     )
 
     whenever(auditService.auditEventsByType(AuditEventType.JOURNEY_PRICE)).thenReturn(listOf(sercoOriginalPriceEvent, geoameyPriceEvent))
@@ -186,7 +186,7 @@ internal class SupplierPricingServiceTest {
 
   @Test
   internal fun `finds multiple price history entries for GEOAmey`() {
-    val geoameyOriginalPrice = PriceMetadata(Supplier.GEOAMEY, "from_agency_id", "to_agency_id", 2021, Money(1000).pounds())
+    val geoameyOriginalPrice = PriceMetadata(Supplier.GEOAMEY, "FROM_AGENCY_ID", "TO_AGENCY_ID", 2021, Money(1000).pounds())
     val geoameyOriginalPriceEvent = AuditEvent(AuditEventType.JOURNEY_PRICE, LocalDateTime.now(), "Jane", geoameyOriginalPrice)
 
     val geoameyPriceChange = geoameyOriginalPrice.copy(newPrice = Money(2000).pounds(), oldPrice = Money(1000).pounds())
@@ -196,7 +196,7 @@ internal class SupplierPricingServiceTest {
       AuditEventType.JOURNEY_PRICE,
       LocalDateTime.now(),
       "Jane",
-      PriceMetadata(Supplier.SERCO, "from_agency_id", "to_agency_id", 2021, Money(1000).pounds())
+      PriceMetadata(Supplier.SERCO, "FROM_AGENCY_ID", "TO_AGENCY_ID", 2021, Money(1000).pounds())
     )
 
     whenever(auditService.auditEventsByType(AuditEventType.JOURNEY_PRICE)).thenReturn(listOf(geoameyOriginalPriceEvent, geoameyPriceChangeEvent, sercoPriceEvent))


### PR DESCRIPTION
**Changes**:

The is the first attempt to improve the read time of the audit history events.  I don't want to do too much at this point so only making minor changes.  Adds an new index and removes some unnecessary string santisations. 