### PR TITLE
P4-2896 adding extra indexed column to the audit_events entity to speed up audit entry reads.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditEvent.kt
@@ -7,11 +7,26 @@ import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
 import javax.persistence.Id
+import javax.persistence.Index
 import javax.persistence.Table
 import javax.validation.constraints.NotBlank
 
 @Entity
-@Table(name = "AUDIT_EVENTS")
+@Table(
+  name = "AUDIT_EVENTS",
+  indexes = [
+    Index(
+      name = "audit_events_event_type_idx",
+      columnList = "event_type",
+      unique = false
+    ),
+    Index(
+      name = "audit_events_et_mdk_idx",
+      columnList = "event_type, metadata_key",
+      unique = false
+    )
+  ]
+)
 data class AuditEvent(
   @Enumerated(EnumType.STRING)
   @Column(name = "event_type", nullable = false)
@@ -27,18 +42,27 @@ data class AuditEvent(
   @Column(name = "metadata", nullable = true, length = 1024)
   val metadata: String?,
 
+  @Column(name = "metadata_key", nullable = true, length = 255)
+  val metadataKey: String? = null,
+
   @Id
   @Column(name = "audit_event_id", nullable = false)
-  val id: UUID = UUID.randomUUID()
+  val id: UUID = UUID.randomUUID(),
 ) {
   constructor(eventType: AuditEventType, createdAt: LocalDateTime, username: String, metadata: Metadata?) : this(
     eventType = eventType,
     createdAt = createdAt,
     username = username,
-    metadata = metadata?.toJsonString()
+    metadata = metadata?.toJsonString(),
+    metadataKey = metadata?.key()
   )
 }
 
 fun interface Metadata {
   fun toJsonString(): String
+
+  /**
+   * Provides a constant structured value to aid querying of metadata. If querying is required then this should be overridden.
+   */
+  fun key(): String? = null
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditEventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditEventRepository.kt
@@ -4,5 +4,5 @@ import org.springframework.data.repository.CrudRepository
 import java.util.UUID
 
 interface AuditEventRepository : CrudRepository<AuditEvent, UUID> {
-  fun findByEventType(eventType: AuditEventType): List<AuditEvent>
+  fun findByEventTypeAndMetadataKey(eventType: AuditEventType, metadataKey: String): List<AuditEvent>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/MapLocationMetadata.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/MapLocationMetadata.kt
@@ -55,9 +55,13 @@ data class MapLocationMetadata(
       else
         throw IllegalArgumentException("Audit event type is not a location event.")
     }
+
+    fun key(agencyId: String) = agencyId.trim().toUpperCase()
   }
 
   fun isRemapping() = oldName != null || oldType != null
 
   override fun toJsonString(): String = Klaxon().toJsonString(this)
+
+  override fun key() = key(nomisId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/PriceMetadata.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/PriceMetadata.kt
@@ -60,9 +60,13 @@ data class PriceMetadata(
       else
         throw IllegalArgumentException("Audit event type is not a price event.")
     }
+
+    fun key(supplier: Supplier, fromNomisId: String, toNomisId: String) = "$supplier-${fromNomisId.trim().toUpperCase()}-${toNomisId.trim().toUpperCase()}"
   }
 
   fun isUpdate() = oldPrice != null
 
   override fun toJsonString(): String = Klaxon().toJsonString(this)
+
+  override fun key(): String = key(supplier, fromNomisId, toNomisId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AuditService.kt
@@ -22,5 +22,5 @@ class AuditService(private val auditEventRepository: AuditEventRepository, priva
     )
   }
 
-  internal fun auditEventsByType(type: AuditEventType) = auditEventRepository.findByEventType(type)
+  internal fun auditEventsByTypeAndMetaKey(type: AuditEventType, metaKey: String) = auditEventRepository.findByEventTypeAndMetadataKey(type, metaKey.trim().toUpperCase())
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/LocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/LocationsService.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.service
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditEvent
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditEventType
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditableEvent
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.MapLocationMetadata
@@ -64,14 +63,9 @@ class LocationsService(
     ).let { e -> auditService.create(e) }
   }
 
-  fun locationHistoryForAgencyId(agencyId: String): Set<AuditEvent> {
-    val sanitisedAgencyId = sanitised(agencyId)
-
-    return auditService.auditEventsByType(AuditEventType.LOCATION)
-      .associateWith { MapLocationMetadata.map(it) }
-      .filterValues { it.nomisId == sanitisedAgencyId }
-      .keys
-  }
+  fun locationHistoryForAgencyId(agencyId: String) =
+    auditService.auditEventsByTypeAndMetaKey(AuditEventType.LOCATION, MapLocationMetadata.key(agencyId))
+      .associateWith { MapLocationMetadata.map(it) }.keys
 
   private fun sanitised(value: String) = value.trim().toUpperCase()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingService.kt
@@ -108,12 +108,8 @@ class SupplierPricingService(
   private fun getLocationBy(agencyId: String): Location? = locationRepository.findByNomisAgencyId(sanitised(agencyId))
 
   fun priceHistoryForJourney(supplier: Supplier, fromAgencyId: String, toAgencyId: String): Set<AuditEvent> {
-    val sanitisedFrom = sanitised(fromAgencyId)
-    val sanitisedTo = sanitised(toAgencyId)
-
-    return auditService.auditEventsByType(AuditEventType.JOURNEY_PRICE)
+    return auditService.auditEventsByTypeAndMetaKey(AuditEventType.JOURNEY_PRICE, PriceMetadata.key(supplier, fromAgencyId, toAgencyId))
       .associateWith { PriceMetadata.map(it) }
-      .filterValues { it.supplier == supplier && it.fromNomisId == sanitisedFrom && it.toNomisId == sanitisedTo }
       .keys
   }
 

--- a/src/main/resources/db/migration/ddl/V1_6__add_column_to_audit_events_to_improve_read_performance.sql
+++ b/src/main/resources/db/migration/ddl/V1_6__add_column_to_audit_events_to_improve_read_performance.sql
@@ -1,0 +1,3 @@
+alter table audit_events add column if not exists metadata_key varchar(255);
+
+create index if not exists audit_events_et_mdk_idx on audit_events (event_type, metadata_key);

--- a/src/main/resources/db/migration/dml/V1_7__backfill_join_column_price_audit_events.sql
+++ b/src/main/resources/db/migration/dml/V1_7__backfill_join_column_price_audit_events.sql
@@ -1,0 +1,9 @@
+update audit_events
+   set metadata_key = jsonb_extract_path_text(metadata::jsonb, 'supplier') || '-' || jsonb_extract_path_text(metadata::jsonb, 'from_nomis_id') || '-' || jsonb_extract_path_text(metadata::jsonb, 'to_nomis_id')
+ where event_type = 'JOURNEY_PRICE'
+   and metadata_key is null;
+
+update audit_events
+   set metadata_key = jsonb_extract_path_text(metadata::jsonb, 'nomis_id')
+ where event_type = 'LOCATION'
+   and metadata_key is null;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/MapLocationMetadataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/MapLocationMetadataTest.kt
@@ -9,26 +9,28 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
 internal class MapLocationMetadataTest {
   @Test
   fun `mapping a new location`() {
-    val metadata = MapLocationMetadata.map(Location(LocationType.PR, "AGENCY_ID", "SITE NAME"))
+    val metadata = MapLocationMetadata.map(Location(LocationType.PR, "NEW_AGENCY_ID", "NEW SITE NAME"))
 
-    assertThat(metadata.nomisId).isEqualTo("AGENCY_ID")
-    assertThat(metadata.newName).isEqualTo("SITE NAME")
+    assertThat(metadata.nomisId).isEqualTo("NEW_AGENCY_ID")
+    assertThat(metadata.newName).isEqualTo("NEW SITE NAME")
     assertThat(metadata.newType).isEqualTo(LocationType.PR)
     assertThat(metadata.oldName).isNull()
     assertThat(metadata.oldType).isNull()
     assertThat(metadata.isRemapping()).isFalse
+    assertThat(metadata.key()).isEqualTo("NEW_AGENCY_ID")
   }
 
   @Test
   fun `remapping of existing location name`() {
-    val existingLocation = Location(LocationType.PR, "AGENCY_ID", "OLD SITE NAME")
+    val existingLocation = Location(LocationType.PR, "EXISTING_AGENCY_ID", "OLD SITE NAME")
     val metadata = MapLocationMetadata.remap(existingLocation, existingLocation.copy(siteName = "NEW SITE NAME"))
 
-    assertThat(metadata.nomisId).isEqualTo("AGENCY_ID")
+    assertThat(metadata.nomisId).isEqualTo("EXISTING_AGENCY_ID")
     assertThat(metadata.newName).isEqualTo("NEW SITE NAME")
     assertThat(metadata.newType).isNull()
     assertThat(metadata.oldName).isEqualTo("OLD SITE NAME")
     assertThat(metadata.oldType).isNull()
+    assertThat(metadata.key()).isEqualTo("EXISTING_AGENCY_ID")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/PriceMetadataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/PriceMetadataTest.kt
@@ -25,19 +25,21 @@ internal class PriceMetadataTest {
     assertThat(metadata.newPrice).isEqualTo(1.0)
     assertThat(metadata.oldPrice).isNull()
     assertThat(metadata.isUpdate()).isFalse
+    assertThat(metadata.key()).isEqualTo("SERCO-FROM_AGENCY_ID-TO_AGENCY_ID")
   }
 
   @Test
   fun `update price`() {
-    val metadata = PriceMetadata.update(Money.valueOf(2.0), Price(supplier = Supplier.SERCO, fromLocation = fromLocation, toLocation = toLocation, effectiveYear = 2020, priceInPence = 100))
+    val metadata = PriceMetadata.update(Money.valueOf(2.0), Price(supplier = Supplier.GEOAMEY, fromLocation = fromLocation, toLocation = toLocation, effectiveYear = 2020, priceInPence = 100))
 
-    assertThat(metadata.supplier).isEqualTo(Supplier.SERCO)
+    assertThat(metadata.supplier).isEqualTo(Supplier.GEOAMEY)
     assertThat(metadata.fromNomisId).isEqualTo("FROM_AGENCY_ID")
     assertThat(metadata.toNomisId).isEqualTo("TO_AGENCY_ID")
     assertThat(metadata.effectiveYear).isEqualTo(2020)
     assertThat(metadata.newPrice).isEqualTo(1.0)
     assertThat(metadata.oldPrice).isEqualTo(2.0)
     assertThat(metadata.isUpdate()).isTrue
+    assertThat(metadata.key()).isEqualTo("GEOAMEY-FROM_AGENCY_ID-TO_AGENCY_ID")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingServiceTest.kt
@@ -169,19 +169,12 @@ internal class SupplierPricingServiceTest {
     val sercoOriginalPrice = PriceMetadata(Supplier.SERCO, "FROM_AGENCY_ID", "TO_AGENCY_ID", 2021, Money(1000).pounds())
     val sercoOriginalPriceEvent = AuditEvent(AuditEventType.JOURNEY_PRICE, LocalDateTime.now(), "Jane", sercoOriginalPrice)
 
-    val geoameyPriceEvent = AuditEvent(
-      AuditEventType.JOURNEY_PRICE,
-      LocalDateTime.now(),
-      "Jane",
-      PriceMetadata(Supplier.GEOAMEY, "FROM_AGENCY_ID", "TO_AGENCY_ID", 2021, Money(1000).pounds())
-    )
-
-    whenever(auditService.auditEventsByType(AuditEventType.JOURNEY_PRICE)).thenReturn(listOf(sercoOriginalPriceEvent, geoameyPriceEvent))
+    whenever(auditService.auditEventsByTypeAndMetaKey(AuditEventType.JOURNEY_PRICE, "SERCO-FROM_AGENCY_ID-TO_AGENCY_ID")).thenReturn(listOf(sercoOriginalPriceEvent))
 
     val sercoPriceHistory = service.priceHistoryForJourney(Supplier.SERCO, "from_agency_id", "to_agency_id")
 
     assertThat(sercoPriceHistory).containsExactly(sercoOriginalPriceEvent)
-    verify(auditService).auditEventsByType(AuditEventType.JOURNEY_PRICE)
+    verify(auditService).auditEventsByTypeAndMetaKey(AuditEventType.JOURNEY_PRICE, "SERCO-FROM_AGENCY_ID-TO_AGENCY_ID")
   }
 
   @Test
@@ -192,19 +185,12 @@ internal class SupplierPricingServiceTest {
     val geoameyPriceChange = geoameyOriginalPrice.copy(newPrice = Money(2000).pounds(), oldPrice = Money(1000).pounds())
     val geoameyPriceChangeEvent = AuditEvent(AuditEventType.JOURNEY_PRICE, LocalDateTime.now().plusDays(1), "Jane", geoameyPriceChange)
 
-    val sercoPriceEvent = AuditEvent(
-      AuditEventType.JOURNEY_PRICE,
-      LocalDateTime.now(),
-      "Jane",
-      PriceMetadata(Supplier.SERCO, "FROM_AGENCY_ID", "TO_AGENCY_ID", 2021, Money(1000).pounds())
-    )
-
-    whenever(auditService.auditEventsByType(AuditEventType.JOURNEY_PRICE)).thenReturn(listOf(geoameyOriginalPriceEvent, geoameyPriceChangeEvent, sercoPriceEvent))
+    whenever(auditService.auditEventsByTypeAndMetaKey(AuditEventType.JOURNEY_PRICE, "GEOAMEY-FROM_AGENCY_ID-TO_AGENCY_ID")).thenReturn(listOf(geoameyOriginalPriceEvent, geoameyPriceChangeEvent))
 
     val geoameyPriceHistory = service.priceHistoryForJourney(Supplier.GEOAMEY, "from_agency_id", "to_agency_id")
 
     assertThat(geoameyPriceHistory).containsExactly(geoameyOriginalPriceEvent, geoameyPriceChangeEvent)
 
-    verify(auditService).auditEventsByType(AuditEventType.JOURNEY_PRICE)
+    verify(auditService).auditEventsByTypeAndMetaKey(AuditEventType.JOURNEY_PRICE, "GEOAMEY-FROM_AGENCY_ID-TO_AGENCY_ID")
   }
 }


### PR DESCRIPTION
**Changes:**

This change is an effort to reduce the time taken reading audit history events in the UI.  This has come about after learning how many price audit events there are.

This change adds a new column which essentially pulls out the key from the metadata which in turn can be queried on directly in the SQL instead of reading into the application and then applying the filter (which is slow).