### PR TITLE
P4-2844 adding new location type coroners court.  This will automatcally be picked up by the UI template.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationType.kt
@@ -10,6 +10,7 @@ enum class LocationType(val label: String) {
   CC("Crown Court"),
   CM("Combined Court"),
   CO("County Court"),
+  CRN("Coroners Court"),
   CRT("Court"),
   HP("Hospital"),
   IM("Immigration"),


### PR DESCRIPTION
**Changes:**

This change introduces a new location type 'Coroners Court' to the LocationType enum for selection in the add and update location screens.  No UI specific changes are needed, the enum is used in the template so it will automatically be available with this change.