### PR TITLE
P4-2848 changes to audit spreadsheet download failures.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditEventType.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.auditing
 
 enum class AuditEventType(val label: String) {
   DOWNLOAD_SPREADSHEET("Download spreadsheet"),
+  DOWNLOAD_SPREADSHEET_FAILURE("Download spreadsheet failure"),
   JOURNEY_PRICE("Journey price"),
   JOURNEY_PRICE_BULK_UPDATE("Journey price bulk update"),
   LOCATION("Location"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditableEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditableEvent.kt
@@ -53,6 +53,13 @@ data class AuditableEvent(
         mapOf("month" to date.format(DateTimeFormatter.ofPattern("yyyy-MM")), "supplier" to supplier)
       )
 
+    fun downloadSpreadsheetFailure(date: LocalDate, supplier: Supplier, authentication: Authentication) =
+      createEvent(
+        AuditEventType.DOWNLOAD_SPREADSHEET_FAILURE,
+        authentication,
+        mapOf("month" to date.format(DateTimeFormatter.ofPattern("yyyy-MM")), "supplier" to supplier)
+
+      )
     fun addPrice(newPrice: Price): AuditableEvent {
       return AuditableEvent(
         type = AuditEventType.JOURNEY_PRICE,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SpreadsheetService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SpreadsheetService.kt
@@ -20,8 +20,13 @@ class SpreadsheetService(
   fun spreadsheet(authentication: Authentication, supplier: Supplier, startDate: LocalDate): File? {
     logger.info("Generating spreadsheet for supplier '$supplier', moves from '$startDate''")
 
-    return pricesSpreadsheetGenerator.generate(supplier, startDate).also {
-      auditService.create(AuditableEvent.downloadSpreadsheetEvent(startDate, supplier, authentication))
+    return Result.runCatching {
+      pricesSpreadsheetGenerator.generate(supplier, startDate).also {
+        auditService.create(AuditableEvent.downloadSpreadsheetEvent(startDate, supplier, authentication))
+      }
+    }.getOrElse { exception ->
+      auditService.create(AuditableEvent.downloadSpreadsheetFailure(startDate, supplier, authentication))
+      throw exception
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AuditServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AuditServiceTest.kt
@@ -93,6 +93,19 @@ internal class AuditServiceTest {
   }
 
   @Test
+  internal fun `create download spreadsheet failure audit event`() {
+    service.create(
+      AuditableEvent.downloadSpreadsheetFailure(
+        LocalDate.of(2021, 6, 7),
+        Supplier.GEOAMEY,
+        authentication
+      )
+    )
+
+    verifyEvent(AuditEventType.DOWNLOAD_SPREADSHEET_FAILURE, authentication.name, mapOf("month" to "2021-06", "supplier" to "GEOAMEY"))
+  }
+
+  @Test
   internal fun `create new location audit event`() {
     service.create(AuditableEvent.mapLocation(Location(LocationType.AP, "TEST2", "TEST 2 NAME")))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SpreadsheetServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SpreadsheetServiceTest.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.service
 
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.springframework.security.core.Authentication
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditableEvent
@@ -37,6 +39,40 @@ internal class SpreadsheetServiceTest {
       AuditableEvent.downloadSpreadsheetEvent(
         LocalDate.of(2021, 2, 22),
         supplier,
+        authentication
+      )
+    )
+  }
+
+  @Test
+  internal fun `failure to download Serco spreadsheet is audited`() {
+    whenever(pricesSpreadsheetGenerator.generate(Supplier.SERCO, LocalDate.of(2021, 6, 7))).thenThrow(RuntimeException("spreadsheet download failed for Serco"))
+
+    assertThatThrownBy { service.spreadsheet(authentication, Supplier.SERCO, LocalDate.of(2021, 6, 7)) }
+      .isInstanceOf(RuntimeException::class.java)
+      .hasMessage("spreadsheet download failed for Serco")
+
+    verify(auditService).create(
+      AuditableEvent.downloadSpreadsheetFailure(
+        LocalDate.of(2021, 6, 7),
+        Supplier.SERCO,
+        authentication
+      )
+    )
+  }
+
+  @Test
+  internal fun `failure to download GEOAmey spreadsheet is audited`() {
+    whenever(pricesSpreadsheetGenerator.generate(Supplier.GEOAMEY, LocalDate.of(2021, 6, 6))).thenThrow(RuntimeException("spreadsheet download failed for GEOAmey"))
+
+    assertThatThrownBy { service.spreadsheet(authentication, Supplier.GEOAMEY, LocalDate.of(2021, 6, 6)) }
+      .isInstanceOf(RuntimeException::class.java)
+      .hasMessage("spreadsheet download failed for GEOAmey")
+
+    verify(auditService).create(
+      AuditableEvent.downloadSpreadsheetFailure(
+        LocalDate.of(2021, 6, 6),
+        Supplier.GEOAMEY,
         authentication
       )
     )


### PR DESCRIPTION
**Changes:**

These changes make it easier to keep track of spreadsheet download failures at the user level.  Prior to this we would we receive an alert but not know who had attempted it. 