### PR TITLE
P4-2875 initial commit for PII obfuscation when running locally.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/ImporterConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/ImporterConfiguration.kt
@@ -1,22 +1,34 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.config
 
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.ResourceLoader
+import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.ObfuscatingReportImporter
+import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.ReportImporter
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.PriceRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.MonitoringService
 import java.time.Clock
 import java.time.LocalDateTime
 
 @Configuration
 class ImporterConfiguration {
 
+  private val logger = LoggerFactory.getLogger(javaClass)
+
   @Autowired
   private lateinit var resourceLoader: ResourceLoader
 
   @Autowired
   private lateinit var priceRepository: PriceRepository
+
+  @Autowired
+  private lateinit var reportingProvider: ReportingProvider
+
+  @Autowired
+  private lateinit var monitoringString: MonitoringService
 
   @Bean
   fun jpcTemplateProvider(@Value("\${export-files.template}") templateFileLocation: String): JPCTemplateProvider {
@@ -29,4 +41,15 @@ class ImporterConfiguration {
   @Bean
   fun supplierPrices() =
     SupplierPrices { supplier, year -> priceRepository.findBySupplierAndEffectiveYear(supplier, year) }
+
+  @Bean
+  fun reportImporter(@Value("\${SENTRY_ENVIRONMENT:}") env: String): ReportImporter {
+    return if (env.trim().toUpperCase() == "LOCAL") {
+      logger.warn("Running importer in PII obfuscation mode")
+      ObfuscatingReportImporter(reportingProvider, monitoringString)
+    } else {
+      logger.warn("Running importer in PII mode")
+      ReportImporter(reportingProvider, monitoringString)
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/ObfuscatingReportImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/ObfuscatingReportImporter.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.importer.report
+
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.ReportingProvider
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.MonitoringService
+import java.time.LocalDate
+import java.util.Random
+
+/**
+ * Obfuscates people data loaded from reporting JSON files.
+ */
+class ObfuscatingReportImporter(
+  provider: ReportingProvider,
+  monitoringService: MonitoringService
+) : ReportImporter(provider, monitoringService) {
+
+  override fun importPeopleOn(date: LocalDate): Sequence<Person> {
+    return super.importPeopleOn(date).map { person ->
+      person.copy(
+        prisonNumber = randomString(10),
+        firstNames = randomString(20),
+        lastName = randomString(20),
+        dateOfBirth = LocalDate.of(1800, 1, 1),
+        ethnicity = "Other"
+      )
+    }.asSequence()
+  }
+
+  private fun randomString(length: Int) = ('a'..'z').randomString(length)
+
+  private fun ClosedRange<Char>.randomString(length: Int) =
+    (1..length)
+      .map { (Random().nextInt(endInclusive.toInt() - start.toInt()) + start.toInt()).toChar() }
+      .joinToString("")
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/ReportImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/ReportImporter.kt
@@ -2,15 +2,13 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.importer.report
 
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.ReportingProvider
 import uk.gov.justice.digital.hmpps.pecs.jpc.move.Move
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.MonitoringService
 import java.time.LocalDate
 import kotlin.streams.toList
 
-@Component
-class ReportImporter(
+open class ReportImporter(
   @Autowired private val provider: ReportingProvider,
   @Autowired private val monitoringService: MonitoringService
 ) {
@@ -30,7 +28,7 @@ class ReportImporter(
     )
   }
 
-  fun importPeopleOn(date: LocalDate) = importPeople(date, date)
+  open fun importPeopleOn(date: LocalDate) = importPeople(date, date)
 
   private fun importPeople(from: LocalDate, to: LocalDate): Sequence<Person> {
     val peopleContent = getContents("people", from, to)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/ObfuscatingReportImporterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/report/ObfuscatingReportImporterTest.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.importer.report
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.ReportingProvider
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.MonitoringService
+import java.time.LocalDate
+
+@ExtendWith(SpringExtension::class)
+@Import(TestConfig::class)
+@ActiveProfiles("test")
+internal class ObfuscatingReportImporterTest() {
+
+  @MockBean
+  private lateinit var monitoringService: MonitoringService
+
+  @Test
+  fun `personal identifiable information is obfuscated`() {
+    val prisonNumber = "PRISON1"
+    val firstName = "Fred"
+    val lastName = "Blogs"
+    val ethnicity = "European"
+
+    val obfuscatedPerson = ObfuscatingReportImporter(
+      personProvider(
+        prisonNumber = prisonNumber,
+        firstName = firstName,
+        lastName = lastName,
+        ethnicity = ethnicity
+      ),
+      monitoringService
+    ).importPeopleOn(LocalDate.now()).toList().first()
+
+    assertThat(obfuscatedPerson.dateOfBirth).isEqualTo(LocalDate.of(1800, 1, 1))
+    assertThat(obfuscatedPerson.prisonNumber?.trim()?.toUpperCase()).isNotEqualTo(prisonNumber.trim().toUpperCase())
+    assertThat(obfuscatedPerson.firstNames?.trim()?.toUpperCase()).isNotEqualTo(firstName.trim().toUpperCase())
+    assertThat(obfuscatedPerson.lastName?.trim()?.toUpperCase()).isNotEqualTo(lastName.trim().toUpperCase())
+    assertThat(obfuscatedPerson.ethnicity).isEqualTo("Other")
+  }
+
+  private fun personProvider(prisonNumber: String, firstName: String, lastName: String, ethnicity: String) = ReportingProvider {
+    """{"id":"PE1","updated_at": "2020-06-16T10:20:30+01:00", "prison_number":"$prisonNumber","latest_nomis_booking_id":null,"gender":"male","age":100, "ethnicity" : "White American", "first_names" : "$firstName", "last_name": "$lastName", "date_of_birth" : "1980-12-25"}""".trimIndent()
+  }
+}


### PR DESCRIPTION
**Changes:**

This introduces the ability to obfuscate PII when running the reports import process.  In its current form it will obfuscate when running a backfill process using the CLI tooling locally.  It does not affect the test data migrations.

The driver for this change is so we can use live (PII) data locally but obfuscated to aid with performance tuning.

**Additional Info:**

This has been tested locally.