### PR TITLE
P4-2841 updates to 3rd party dependencies and OWSAP resolution, thereare some deprecation warnings but will look at separately.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.1.7"
-  kotlin("plugin.spring") version "1.4.32"
-  kotlin("plugin.jpa") version "1.4.32"
-  kotlin("plugin.allopen") version "1.4.32"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.0"
+  kotlin("plugin.spring") version "1.5.10"
+  kotlin("plugin.jpa") version "1.5.10"
+  kotlin("plugin.allopen") version "1.5.10"
 }
 
 allOpen {
@@ -19,10 +19,10 @@ dependencies {
   implementation("com.github.kittinunf.result:result:4.0.0")
   implementation("com.github.kittinunf.result:result-coroutines:4.0.0")
   implementation("com.beust:klaxon:5.5")
-  implementation("com.amazonaws:aws-java-sdk-s3:1.11.1001")
+  implementation("com.amazonaws:aws-java-sdk-s3:1.12.3")
   implementation("io.sentry:sentry-spring-boot-starter:4.3.0")
-  implementation("net.javacrumbs.shedlock:shedlock-spring:4.23.0")
-  implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.23.0")
+  implementation("net.javacrumbs.shedlock:shedlock-spring:4.24.0")
+  implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.24.0")
   implementation("nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:2.5.3")
   implementation("org.apache.poi:poi-ooxml:5.0.0")
 
@@ -40,21 +40,21 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
-  implementation("org.springframework.session:spring-session-jdbc:2.4.3")
+  implementation("org.springframework.session:spring-session-jdbc:2.5.0")
   implementation("org.springframework.shell:spring-shell-starter:2.0.1.RELEASE")
   implementation("org.thymeleaf.extras:thymeleaf-extras-springsecurity5:3.0.4.RELEASE")
   implementation(kotlin("script-runtime"))
 
-  testImplementation("org.mockito:mockito-inline:3.9.0")
+  testImplementation("org.mockito:mockito-inline:3.11.0")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("org.springframework.security:spring-security-test")
   testImplementation("com.squareup.okhttp3:mockwebserver:4.9.1")
   testImplementation("com.squareup.okhttp3:okhttp:4.9.1")
   testImplementation("org.testcontainers:postgresql:1.15.3")
 
-  runtimeOnly("org.flywaydb:flyway-core:7.8.1")
+  runtimeOnly("org.flywaydb:flyway-core:7.10.0")
   runtimeOnly("com.h2database:h2")
-  runtimeOnly("org.postgresql:postgresql:42.2.19")
+  runtimeOnly("org.postgresql:postgresql:42.2.20")
 }
 
 tasks {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-rc-2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/SecurityConfiguration.kt
@@ -18,6 +18,7 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User
 import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.JwtDecoders
 import org.springframework.security.web.access.AccessDeniedHandler
 import org.springframework.session.FindByIndexNameSessionRepository
@@ -96,7 +97,7 @@ class SecurityConfiguration<S : Session> : WebSecurityConfigurerAdapter() {
 
     return OAuth2UserService { userRequest ->
       val user = delegate.loadUser(userRequest)
-      val jwt = JwtDecoders.fromIssuerLocation(issuer).decode(userRequest.accessToken.tokenValue)
+      val jwt = (JwtDecoders.fromIssuerLocation(issuer) as JwtDecoder).decode(userRequest.accessToken.tokenValue)
 
       DefaultOAuth2User(
         jwt.getClaimAsStringList("authorities").stream().map { SimpleGrantedAuthority(it) }.toList(),


### PR DESCRIPTION
**Changes:**

House keeping.

This is the first PR to move to v1.5 of Kotlin and resolve OWASP build failure (3rd party dependency updates).

I am splitting this into a few PR's as there are some deprecation warnings as a result of moving to a later version of Kotlin.  For now this will fix the OWASP,
