### PR TITLE
P4-2841 bumping up Sentry a major version.  Tested to makesure no side effects.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
   implementation("com.github.kittinunf.result:result-coroutines:4.0.0")
   implementation("com.beust:klaxon:5.5")
   implementation("com.amazonaws:aws-java-sdk-s3:1.12.3")
-  implementation("io.sentry:sentry-spring-boot-starter:4.3.0")
+  implementation("io.sentry:sentry-spring-boot-starter:5.0.1")
   implementation("net.javacrumbs.shedlock:shedlock-spring:4.24.0")
   implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.24.0")
   implementation("nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:2.5.3")


### PR DESCRIPTION
**Changes:**

Bumping Sentry monitoring API up a major version number.

I have tested this via the application CLI to ensure messages can still be sent by the application.