### PR TITLE
P4-2947 bumping transitive dependency to resolve OWASP CVE's CVE-2021-31812, CVE-2021-31811.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,8 +30,8 @@ dependencies {
     implementation("org.apache.xmlgraphics:batik-all:1.14") {
       because("previous transitive version 1.13 pulled from Apache POI 5.0.0 has CVE")
     }
-    implementation("org.apache.pdfbox:pdfbox:2.0.23") {
-      because("previous transitive version 2.0.22 pulled from Apache POI 5.0.0 has CVE")
+    implementation("org.apache.pdfbox:pdfbox:2.0.24") {
+      because("previous transitive version 2.0.23 pulled from Apache POI 5.0.0 has CVE")
     }
   }
 


### PR DESCRIPTION
**Changes:**

Small change to resolve OWASP CVE's CVE-2021-31812, CVE-2021-31811.

Only option at moment is to bump transitive dependencies as main library (Apache POI) that pulls it in has yet to be updated.