### PR TITLE
P4-2986 bumping to the latest verions of the DPS Gradle Spring Boot plugin to resolve CVE-2021-27568.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.4"
   kotlin("plugin.spring") version "1.5.20"
   kotlin("plugin.jpa") version "1.5.20"
   kotlin("plugin.allopen") version "1.5.20"


### PR DESCRIPTION
**Changes:**

OWASP related security change to use the latest version of the 3rd party DPS Gradle Spring Boot plugin library.

`./gradlew dependencyCheckAnalyze` has been run locally before and after the change. Red before green afterwards.

Further details related to the CVE can be found here [CVE-2021-27568](https://nvd.nist.gov/vuln/detail/CVE-2021-27568).

_Note: once this is released to production and the job is green we can close the associated JIRA ticket._