### PR TITLE
P4-2966 adding page assertions for the move details upon retrieval.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ViewMoveDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ViewMoveDetailsTest.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.Dashboard
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.FindMove
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.Login
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.MoveDetails
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.moveM4
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 
 internal class ViewMoveDetailsTest : IntegrationTest() {
@@ -20,10 +21,8 @@ internal class ViewMoveDetailsTest : IntegrationTest() {
 
     isAtPage(Dashboard).navigateToFindMoveByReferenceId()
 
-    isAtPage(FindMove).findMoveByReferenceId("STANDARDMOVE2")
+    isAtPage(FindMove).findBy(moveM4())
 
-    isAtPage(MoveDetails).isAtPageForMoveID("M4")
-
-    // TODO assert on details in the page
+    isAtPage(MoveDetails).isAtPageFor(moveM4())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/FindMovePage.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/FindMovePage.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages
 import org.fluentlenium.core.annotation.PageUrl
 import org.fluentlenium.core.domain.FluentWebElement
 import org.openqa.selenium.support.FindBy
+import uk.gov.justice.digital.hmpps.pecs.jpc.move.Move
 
 @PageUrl("http://localhost:8080/find-move")
 class FindMovePage : ApplicationPage() {
@@ -13,8 +14,8 @@ class FindMovePage : ApplicationPage() {
   @FindBy(id = "find-move")
   private lateinit var findMoveSubmit: FluentWebElement
 
-  fun findMoveByReferenceId(moveReferenceId: String) {
-    referenceInput.fill().withText(moveReferenceId)
+  fun findBy(move: Move) {
+    referenceInput.fill().withText(move.reference)
     findMoveSubmit.submit()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/IntegrationTestDataFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/IntegrationTestDataFactory.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages
+
+import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.Person
+import uk.gov.justice.digital.hmpps.pecs.jpc.move.Move
+import uk.gov.justice.digital.hmpps.pecs.jpc.move.MoveStatus
+import uk.gov.justice.digital.hmpps.pecs.jpc.move.MoveType
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+/**
+ * The integration test data comes from the DEV Spring Profile data loaded via the database migration scripts at startup.
+ */
+
+fun moveM4() =
+  Move(
+    moveId = "M4",
+    updatedAt = LocalDateTime.now(),
+    supplier = Supplier.GEOAMEY,
+    moveType = MoveType.STANDARD,
+    status = MoveStatus.completed,
+    reference = "STANDARDMOVE2",
+    fromNomisAgencyId = "PRISON3",
+    fromSiteName = "PRISON THREE",
+    toNomisAgencyId = "PRISON4",
+    toSiteName = "PRISON FOUR",
+    reportFromLocationType = "prison",
+    reportToLocationType = "prison",
+    pickUpDateTime = LocalDateTime.of(2020, 12, 1, 10, 20),
+    dropOffOrCancelledDateTime = LocalDateTime.of(2020, 12, 1, 12, 20),
+    person = Person(
+      personId = "_",
+      updatedAt = LocalDateTime.now(),
+      prisonNumber = "PRISONER2",
+      firstNames = "Clyde Chestnut",
+      lastName = "Barrow",
+      dateOfBirth = LocalDate.of(1909, 3, 24),
+      gender = "male"
+    )
+  )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/MoveDetailsPage.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/MoveDetailsPage.kt
@@ -1,12 +1,27 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages
 
+import org.assertj.core.api.Assertions.assertThat
 import org.fluentlenium.core.annotation.PageUrl
+import uk.gov.justice.digital.hmpps.pecs.jpc.move.Move
+import java.time.format.DateTimeFormatter
 
 @PageUrl("http://localhost:8080/moves/{moveId}")
 class MoveDetailsPage : ApplicationPage() {
 
-  /**
-   * Moves are actually retrieved by their reference number but the URL contains the move ID.
-   */
-  fun isAtPageForMoveID(moveRefId: String) = this.isAt(moveRefId).let { this }
+  fun isAtPageFor(move: Move) {
+    this.isAt(move.moveId).let {
+      val source = this.pageSource()
+
+      assertThat(source).contains(move.person?.prisonNumber)
+      assertThat(source).contains(move.person?.firstNames)
+      assertThat(source).contains(move.person?.lastName)
+      assertThat(source).contains(move.person?.dateOfBirth?.format(DateTimeFormatter.ofPattern("dd MM yyyy")))
+      assertThat(source).contains(move.person?.gender)
+      assertThat(source).contains(move.pickUpDateTime?.format(DateTimeFormatter.ofPattern("dd MMM yyyy, HH:mm")))
+      assertThat(source).contains(move.dropOffOrCancelledDateTime?.format(DateTimeFormatter.ofPattern("dd MMM yyyy, HH:mm")))
+      assertThat(source).contains(move.fromSiteName)
+      assertThat(source).contains(move.toSiteName)
+      assertThat(source).contains(move.moveType?.name)
+    }
+  }
 }


### PR DESCRIPTION
**Changes:**

Fleshing out the integration test for retrieval of a move and viewing its details.

The assertions themselves are fairly crude but provide a reasonable baseline for coverage of this piece of functionality.