### PR TITLE
P4-2967 this is a work in progress - this update verifies a standard move for the present day/month based on seeded test data.  Other move types to follow.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ViewAllMoveTypesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ViewAllMoveTypesTest.kt
@@ -1,18 +1,19 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.integration
 
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Dec2020MoveData.cancelledMoveM60
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Dec2020MoveData.lockoutMoveM40
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Dec2020MoveData.longHaulMoveM30
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Dec2020MoveData.multiMoveM50
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Dec2020MoveData.redirectMoveM20
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Dec2020MoveData.standardMoveM4
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.ChooseSupplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.Dashboard
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.Login
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.MoveDetails
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.MovesByType
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.SelectMonthYear
-import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.cancelledMoveM60
-import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.lockoutMoveM40
-import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.longHaulMoveM30
-import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.multiMoveM50
-import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.redirectMoveM20
-import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.standardMoveM4
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.PresentDayMoveData.standardMoveSM1
 import uk.gov.justice.digital.hmpps.pecs.jpc.move.Move
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import java.time.LocalDate
@@ -22,7 +23,25 @@ import java.time.Year
 internal class ViewAllMoveTypesTest : IntegrationTest() {
 
   @Test
-  fun `go to a previous month and view all available move types`() {
+  fun `view one of each move type for Serco today`() {
+    goToPage(Dashboard)
+
+    isAtPage(Login).login()
+
+    isAtPage(ChooseSupplier).choose(Supplier.SERCO)
+
+    isAtPage(Dashboard)
+      .isAtMonthYear(LocalDate.now().month, Year.now())
+      .navigateToSelectMonthPage()
+
+    listOf(
+      // TODO WIP - at the moment this is only checking a standard move.
+      standardMoveSM1(),
+    ).forEach { move -> verifyDetailsOf(move, LocalDate.now().month, Year.now()) }
+  }
+
+  @Test
+  fun `view one of each move type for GEOAmey in a previous month (Dec 2020)`() {
     goToPage(Dashboard)
 
     isAtPage(Login).login()
@@ -42,14 +61,14 @@ internal class ViewAllMoveTypesTest : IntegrationTest() {
       lockoutMoveM40(),
       multiMoveM50(),
       cancelledMoveM60()
-    ).forEach { move -> verifyDetailsOf(move) }
+    ).forEach { move -> verifyDetailsOf(move, Month.DECEMBER, Year.of(2020)) }
   }
 
-  private fun verifyDetailsOf(move: Move) {
+  private fun verifyDetailsOf(move: Move, month: Month, year: Year) {
     goToPage(Dashboard)
 
     isAtPage(Dashboard)
-      .isAtMonthYear(Month.DECEMBER, Year.of(2020))
+      .isAtMonthYear(month, year)
       .navigateToMovesBy(move.moveType!!)
 
     isAtPage(MovesByType)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ViewMoveDetailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ViewMoveDetailsTest.kt
@@ -1,12 +1,12 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.integration
 
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Dec2020MoveData.standardMoveM4
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.ChooseSupplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.Dashboard
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.FindMove
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.Login
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.MoveDetails
-import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.standardMoveM4
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 
 internal class ViewMoveDetailsTest : IntegrationTest() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/IntegrationTestDataFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/IntegrationTestDataFactory.kt
@@ -34,124 +34,151 @@ private val bonnieElizabeth =
     gender = "female"
   )
 
-fun standardMoveM4() =
-  Move(
-    moveId = "M4",
-    updatedAt = LocalDateTime.now(),
-    supplier = Supplier.GEOAMEY,
-    moveType = MoveType.STANDARD,
-    status = MoveStatus.completed,
-    reference = "STANDARDMOVE2",
-    fromNomisAgencyId = "PRISON3",
-    fromSiteName = "PRISON THREE",
-    toNomisAgencyId = "PRISON4",
-    toSiteName = "PRISON FOUR",
-    reportFromLocationType = "prison",
-    reportToLocationType = "prison",
-    pickUpDateTime = LocalDateTime.of(2020, 12, 1, 10, 20),
-    dropOffOrCancelledDateTime = LocalDateTime.of(2020, 12, 1, 12, 20),
-    person = Person(
-      personId = "_",
+object Dec2020MoveData {
+
+  fun standardMoveM4() =
+    Move(
+      moveId = "M4",
       updatedAt = LocalDateTime.now(),
-      prisonNumber = "PRISONER2",
-      firstNames = "Clyde Chestnut",
-      lastName = "Barrow",
-      dateOfBirth = LocalDate.of(1909, 3, 24),
-      gender = "male"
+      supplier = Supplier.GEOAMEY,
+      moveType = MoveType.STANDARD,
+      status = MoveStatus.completed,
+      reference = "STANDARDMOVE2",
+      fromNomisAgencyId = "PRISON3",
+      fromSiteName = "PRISON THREE",
+      toNomisAgencyId = "PRISON4",
+      toSiteName = "PRISON FOUR",
+      reportFromLocationType = "prison",
+      reportToLocationType = "prison",
+      pickUpDateTime = LocalDateTime.of(2020, 12, 1, 10, 20),
+      dropOffOrCancelledDateTime = LocalDateTime.of(2020, 12, 1, 12, 20),
+      person = Person(
+        personId = "_",
+        updatedAt = LocalDateTime.now(),
+        prisonNumber = "PRISONER2",
+        firstNames = "Clyde Chestnut",
+        lastName = "Barrow",
+        dateOfBirth = LocalDate.of(1909, 3, 24),
+        gender = "male"
+      )
     )
-  )
 
-fun longHaulMoveM30() =
-  Move(
-    moveId = "M30",
-    updatedAt = LocalDateTime.now(),
-    supplier = Supplier.GEOAMEY,
-    moveType = MoveType.LONG_HAUL,
-    status = MoveStatus.completed,
-    reference = "LONGMOVE",
-    fromNomisAgencyId = "PRISON1",
-    fromSiteName = "PRISON ONE",
-    toNomisAgencyId = "BOG",
-    toSiteName = "BOG", // Test data is not mapped so will default to the agency ID
-    reportFromLocationType = "prison",
-    reportToLocationType = "prison",
-    pickUpDateTime = LocalDateTime.of(2020, 12, 3, 12, 0),
-    dropOffOrCancelledDateTime = LocalDateTime.of(2020, 12, 4, 11, 20),
-    person = billyTheKid
-  )
+  fun longHaulMoveM30() =
+    Move(
+      moveId = "M30",
+      updatedAt = LocalDateTime.now(),
+      supplier = Supplier.GEOAMEY,
+      moveType = MoveType.LONG_HAUL,
+      status = MoveStatus.completed,
+      reference = "LONGMOVE",
+      fromNomisAgencyId = "PRISON1",
+      fromSiteName = "PRISON ONE",
+      toNomisAgencyId = "BOG",
+      toSiteName = "BOG", // Test data is not mapped so will default to the agency ID
+      reportFromLocationType = "prison",
+      reportToLocationType = "prison",
+      pickUpDateTime = LocalDateTime.of(2020, 12, 3, 12, 0),
+      dropOffOrCancelledDateTime = LocalDateTime.of(2020, 12, 4, 11, 20),
+      person = billyTheKid
+    )
 
-fun redirectMoveM20() =
-  Move(
-    moveId = "M20",
-    updatedAt = LocalDateTime.now(),
-    supplier = Supplier.GEOAMEY,
-    moveType = MoveType.REDIRECTION,
-    status = MoveStatus.completed,
-    reference = "REDIRMOVE",
-    fromNomisAgencyId = "PRISON1",
-    fromSiteName = "PRISON ONE",
-    toNomisAgencyId = "GNI",
-    toSiteName = "GNI", // Test data is not mapped so will default to the agency ID
-    reportFromLocationType = "prison",
-    reportToLocationType = "prison",
-    pickUpDateTime = LocalDateTime.of(2020, 12, 2, 10, 20),
-    dropOffOrCancelledDateTime = LocalDateTime.of(2020, 12, 2, 14, 20),
-    person = bonnieElizabeth
-  )
+  fun redirectMoveM20() =
+    Move(
+      moveId = "M20",
+      updatedAt = LocalDateTime.now(),
+      supplier = Supplier.GEOAMEY,
+      moveType = MoveType.REDIRECTION,
+      status = MoveStatus.completed,
+      reference = "REDIRMOVE",
+      fromNomisAgencyId = "PRISON1",
+      fromSiteName = "PRISON ONE",
+      toNomisAgencyId = "GNI",
+      toSiteName = "GNI", // Test data is not mapped so will default to the agency ID
+      reportFromLocationType = "prison",
+      reportToLocationType = "prison",
+      pickUpDateTime = LocalDateTime.of(2020, 12, 2, 10, 20),
+      dropOffOrCancelledDateTime = LocalDateTime.of(2020, 12, 2, 14, 20),
+      person = bonnieElizabeth
+    )
 
-fun lockoutMoveM40() =
-  Move(
-    moveId = "M40",
-    updatedAt = LocalDateTime.now(),
-    supplier = Supplier.GEOAMEY,
-    moveType = MoveType.LOCKOUT,
-    status = MoveStatus.completed,
-    reference = "LOCKMOVE",
-    fromNomisAgencyId = "COURT1",
-    fromSiteName = "COURT ONE",
-    toNomisAgencyId = "PRISON1",
-    toSiteName = "PRISON ONE",
-    reportFromLocationType = "prison",
-    reportToLocationType = "prison",
-    pickUpDateTime = LocalDateTime.of(2020, 12, 4, 10, 20),
-    dropOffOrCancelledDateTime = LocalDateTime.of(2020, 12, 5, 10, 20),
-    person = bonnieElizabeth
-  )
+  fun lockoutMoveM40() =
+    Move(
+      moveId = "M40",
+      updatedAt = LocalDateTime.now(),
+      supplier = Supplier.GEOAMEY,
+      moveType = MoveType.LOCKOUT,
+      status = MoveStatus.completed,
+      reference = "LOCKMOVE",
+      fromNomisAgencyId = "COURT1",
+      fromSiteName = "COURT ONE",
+      toNomisAgencyId = "PRISON1",
+      toSiteName = "PRISON ONE",
+      reportFromLocationType = "prison",
+      reportToLocationType = "prison",
+      pickUpDateTime = LocalDateTime.of(2020, 12, 4, 10, 20),
+      dropOffOrCancelledDateTime = LocalDateTime.of(2020, 12, 5, 10, 20),
+      person = bonnieElizabeth
+    )
 
-fun multiMoveM50() =
-  Move(
-    moveId = "M50",
-    updatedAt = LocalDateTime.now(),
-    supplier = Supplier.GEOAMEY,
-    moveType = MoveType.MULTI,
-    status = MoveStatus.completed,
-    reference = "MULTIMOVE",
-    fromNomisAgencyId = "PRISON1",
-    fromSiteName = "PRISON ONE",
-    toNomisAgencyId = "PRISON3",
-    toSiteName = "PRISON THREE",
-    reportFromLocationType = "prison",
-    reportToLocationType = "prison",
-    pickUpDateTime = LocalDateTime.of(2020, 12, 5, 10, 20),
-    dropOffOrCancelledDateTime = LocalDateTime.of(2020, 12, 6, 10, 20),
-    person = billyTheKid
-  )
+  fun multiMoveM50() =
+    Move(
+      moveId = "M50",
+      updatedAt = LocalDateTime.now(),
+      supplier = Supplier.GEOAMEY,
+      moveType = MoveType.MULTI,
+      status = MoveStatus.completed,
+      reference = "MULTIMOVE",
+      fromNomisAgencyId = "PRISON1",
+      fromSiteName = "PRISON ONE",
+      toNomisAgencyId = "PRISON3",
+      toSiteName = "PRISON THREE",
+      reportFromLocationType = "prison",
+      reportToLocationType = "prison",
+      pickUpDateTime = LocalDateTime.of(2020, 12, 5, 10, 20),
+      dropOffOrCancelledDateTime = LocalDateTime.of(2020, 12, 6, 10, 20),
+      person = billyTheKid
+    )
 
-fun cancelledMoveM60() =
-  Move(
-    moveId = "M60",
-    updatedAt = LocalDateTime.now(),
-    supplier = Supplier.GEOAMEY,
-    moveType = MoveType.CANCELLED,
-    status = MoveStatus.completed,
-    reference = "CANCELLED_BEFORE_3PM",
-    fromNomisAgencyId = "PRISON1",
-    fromSiteName = "PRISON ONE",
-    toNomisAgencyId = "GNI",
-    toSiteName = "GNI", // Test data is not mapped so will default to the agency ID
-    reportFromLocationType = "prison",
-    reportToLocationType = "prison",
-    pickUpDateTime = null,
-    dropOffOrCancelledDateTime = LocalDateTime.of(2020, 12, 6, 14, 59),
-    person = billyTheKid
-  )
+  fun cancelledMoveM60() =
+    Move(
+      moveId = "M60",
+      updatedAt = LocalDateTime.now(),
+      supplier = Supplier.GEOAMEY,
+      moveType = MoveType.CANCELLED,
+      status = MoveStatus.completed,
+      reference = "CANCELLED_BEFORE_3PM",
+      fromNomisAgencyId = "PRISON1",
+      fromSiteName = "PRISON ONE",
+      toNomisAgencyId = "GNI",
+      toSiteName = "GNI", // Test data is not mapped so will default to the agency ID
+      reportFromLocationType = "prison",
+      reportToLocationType = "prison",
+      pickUpDateTime = null,
+      dropOffOrCancelledDateTime = LocalDateTime.of(2020, 12, 6, 14, 59),
+      person = billyTheKid
+    )
+}
+
+object PresentDayMoveData {
+
+  private val today = LocalDate.now()
+
+  fun standardMoveSM1() =
+    Move(
+      moveId = "SM1",
+      updatedAt = today.atStartOfDay(),
+      supplier = Supplier.SERCO,
+      moveType = MoveType.STANDARD,
+      status = MoveStatus.completed,
+      reference = "STANDARDSM1",
+      fromNomisAgencyId = "SFROM", // Test data is not mapped so will default to the agency ID
+      fromSiteName = "SFROM",
+      toNomisAgencyId = "STO",
+      toSiteName = "STO", // Test data is not mapped so will default to the agency ID
+      reportFromLocationType = "prison",
+      reportToLocationType = "prison",
+      pickUpDateTime = today.atStartOfDay().plusHours(10),
+      dropOffOrCancelledDateTime = today.atStartOfDay().plusHours(12),
+      person = billyTheKid
+    )
+}


### PR DESCRIPTION
**Changes:**

Initial piece of follow up work in relation to a previous PR seen [here](https://github.com/ministryofjustice/calculate-journey-variable-payments/pull/304).

At the moment this adds coverage for a standard move on the present day only.  Other moves types to follow.