### PR TITLE
P4 3012 refactor bulk price upload to add journeys and prices rather than delete and read all journey prices

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/BulkPriceImportCommand.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/BulkPriceImportCommand.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.commands
+
+import org.slf4j.LoggerFactory
+import org.springframework.shell.standard.ShellComponent
+import org.springframework.shell.standard.ShellMethod
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.EffectiveYear
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportService
+
+@ShellComponent
+class BulkPriceImportCommand(
+  private val importService: ImportService,
+  private val effectiveYear: EffectiveYear,
+) {
+
+  private val logger = LoggerFactory.getLogger(javaClass)
+
+  @ShellMethod("Bulk imports prices for the given supplier and effective year from the (latest) supplier prices spreadsheet in S3.")
+  fun bulkImportPricesFor(supplier: Supplier, year: Int) {
+    if (year < 2019 || year > effectiveYear.current()) throw RuntimeException("Year cannot be earlier than 2019 or greater than ${effectiveYear.current()}.")
+
+    logger.info("Starting import of prices for $supplier for effective year $year.")
+
+    when (supplier) {
+      Supplier.UNKNOWN -> throw RuntimeException("UNKNOWN is not a valid supplier")
+      // TODO update service layer to take in the effective year.
+      else -> importService.importPrices(supplier)
+    }
+
+    logger.info("Finished import of prices for $supplier for effective year $year.")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/BulkPriceImportCommand.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/BulkPriceImportCommand.kt
@@ -23,8 +23,7 @@ class BulkPriceImportCommand(
 
     when (supplier) {
       Supplier.UNKNOWN -> throw RuntimeException("UNKNOWN is not a valid supplier")
-      // TODO update service layer to take in the effective year.
-      else -> importService.importPrices(supplier)
+      else -> importService.importPrices(supplier, year)
     }
 
     logger.info("Finished import of prices for $supplier for effective year $year.")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommands.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommands.kt
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.shell.standard.ShellComponent
 import org.springframework.shell.standard.ShellMethod
-import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportService
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
@@ -19,18 +18,6 @@ class ImportCommands(
 ) {
 
   private val logger = LoggerFactory.getLogger(javaClass)
-
-  @ShellMethod("Imports prices for the given supplier from S3. This command deletes all existing prices for the given supplier.")
-  fun importPrices(supplier: Supplier) {
-    logger.info("Starting import of prices for $supplier.")
-
-    when (supplier) {
-      Supplier.UNKNOWN -> throw RuntimeException("UNKNOWN is not a valid supplier")
-      else -> importService.importPrices(supplier)
-    }
-
-    logger.info("Finished import of prices for $supplier.")
-  }
 
   /**
    * Due to potentially large volumes of data, each day is imported as an individual import to reduce the memory footprint.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/price/PriceImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/price/PriceImporter.kt
@@ -25,15 +25,9 @@ class PriceImporter(
 
     when (supplier) {
       Supplier.SERCO -> {
-        // TODO we no longer want to delete prices
-        priceRepo.deleteBySupplierAndEffectiveYear(Supplier.SERCO, effectiveYear)
-
         sercoPrices.get().use { import(it, Supplier.SERCO, effectiveYear) }
       }
       Supplier.GEOAMEY -> {
-        // TODO we no longer want to delete prices
-        priceRepo.deleteBySupplierAndEffectiveYear(Supplier.GEOAMEY, effectiveYear)
-
         geoameyPrices.get().use { import(it, Supplier.GEOAMEY, effectiveYear) }
       }
       else -> throw RuntimeException("Supplier '$supplier' not supported.")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/price/PriceImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/price/PriceImporter.kt
@@ -25,11 +25,15 @@ class PriceImporter(
 
     when (supplier) {
       Supplier.SERCO -> {
+        // TODO we no longer want to delete prices
         priceRepo.deleteBySupplierAndEffectiveYear(Supplier.SERCO, effectiveYear)
+
         sercoPrices.get().use { import(it, Supplier.SERCO, effectiveYear) }
       }
       Supplier.GEOAMEY -> {
+        // TODO we no longer want to delete prices
         priceRepo.deleteBySupplierAndEffectiveYear(Supplier.GEOAMEY, effectiveYear)
+
         geoameyPrices.get().use { import(it, Supplier.GEOAMEY, effectiveYear) }
       }
       else -> throw RuntimeException("Supplier '$supplier' not supported.")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/EffectiveYear.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/EffectiveYear.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.price
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
+import java.time.LocalDate
+
+/**
+ * The effective year represents the start year’s pricing that should be applied. An effective year starts at the
+ * beginning of September and runs to the end of August the following year. For example, the 1st Sept 2020 to 31st Aug
+ * 2021 would be be 2020.
+ */
+@Component
+class EffectiveYear(private val timeSource: TimeSource) {
+  fun current(): Int = effectiveYearForDate(timeSource.date())
+}
+
+fun effectiveYearForDate(date: LocalDate) = if (date.monthValue >= 9) date.year else date.year - 1
+
+fun nextEffectiveYearForDate(date: LocalDate) = effectiveYearForDate(date) + 1

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/Price.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/Price.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.price
 
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.Location
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 import javax.persistence.Column
@@ -66,7 +65,3 @@ enum class Supplier {
       kotlin.runCatching { valueOf(value!!.uppercase()) }.getOrDefault(UNKNOWN)
   }
 }
-
-fun effectiveYearForDate(date: LocalDate) = if (date.monthValue >= 9) date.year else date.year - 1
-
-fun nextEffectiveYearForDate(date: LocalDate) = effectiveYearForDate(date) + 1

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.importer.report.ReportImporter
 import uk.gov.justice.digital.hmpps.pecs.jpc.move.MovePersister
 import uk.gov.justice.digital.hmpps.pecs.jpc.move.PersonPersister
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
-import uk.gov.justice.digital.hmpps.pecs.jpc.price.effectiveYearForDate
 import java.time.Duration
 import java.time.LocalDate
 
@@ -28,7 +27,7 @@ class ImportService(
   private val logger = LoggerFactory.getLogger(javaClass)
 
   @Transactional
-  fun importPrices(supplier: Supplier) = import { priceImporter.import(supplier, effectiveYearForDate(timeSource.date())) }
+  fun importPrices(supplier: Supplier, year: Int) = import { priceImporter.import(supplier, year) }
 
   // The transaction boundary for this method is being set in the underlying persistence classes on purpose.
   fun importReportsOn(date: LocalDate) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/BulkPriceImportCommandTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/BulkPriceImportCommandTest.kt
@@ -31,28 +31,28 @@ internal class BulkPriceImportCommandTest {
   internal fun `import prices for Serco for 2019 succeeds`() {
     command.bulkImportPricesFor(Supplier.SERCO, 2019)
 
-    verify(importService).importPrices(Supplier.SERCO)
+    verify(importService).importPrices(Supplier.SERCO, 2019)
   }
 
   @Test
   internal fun `import prices for Geoamey for 2019 succeeds`() {
     command.bulkImportPricesFor(Supplier.GEOAMEY, 2019)
 
-    verify(importService).importPrices(Supplier.GEOAMEY)
+    verify(importService).importPrices(Supplier.GEOAMEY, 2019)
   }
 
   @Test
   internal fun `import prices for Serco for the current effective year (2020) succeeds`() {
     command.bulkImportPricesFor(Supplier.SERCO, 2020)
 
-    verify(importService).importPrices(Supplier.SERCO)
+    verify(importService).importPrices(Supplier.SERCO, 2020)
   }
 
   @Test
   internal fun `import prices for Geoamey for the current effective year (2020) succeeds`() {
     command.bulkImportPricesFor(Supplier.GEOAMEY, 2020)
 
-    verify(importService).importPrices(Supplier.GEOAMEY)
+    verify(importService).importPrices(Supplier.GEOAMEY, 2020)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/BulkPriceImportCommandTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/BulkPriceImportCommandTest.kt
@@ -1,0 +1,72 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.commands
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.EffectiveYear
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportService
+
+internal class BulkPriceImportCommandTest {
+
+  private val importService: ImportService = mock()
+
+  private val effectiveYear: EffectiveYear = mock { on { current() } doReturn 2020 }
+
+  private val command: BulkPriceImportCommand = BulkPriceImportCommand(importService, effectiveYear)
+
+  @Test
+  internal fun `import prices for Serco prior to 2019 fails`() {
+    assertThatThrownBy { command.bulkImportPricesFor(Supplier.SERCO, 2018) }.isInstanceOf(RuntimeException::class.java)
+  }
+
+  @Test
+  internal fun `import prices for GEOAmey prior to 2019 fails`() {
+    assertThatThrownBy { command.bulkImportPricesFor(Supplier.GEOAMEY, 2018) }.isInstanceOf(RuntimeException::class.java)
+  }
+
+  @Test
+  internal fun `import prices for Serco for 2019 succeeds`() {
+    command.bulkImportPricesFor(Supplier.SERCO, 2019)
+
+    verify(importService).importPrices(Supplier.SERCO)
+  }
+
+  @Test
+  internal fun `import prices for Geoamey for 2019 succeeds`() {
+    command.bulkImportPricesFor(Supplier.GEOAMEY, 2019)
+
+    verify(importService).importPrices(Supplier.GEOAMEY)
+  }
+
+  @Test
+  internal fun `import prices for Serco for the current effective year (2020) succeeds`() {
+    command.bulkImportPricesFor(Supplier.SERCO, 2020)
+
+    verify(importService).importPrices(Supplier.SERCO)
+  }
+
+  @Test
+  internal fun `import prices for Geoamey for the current effective year (2020) succeeds`() {
+    command.bulkImportPricesFor(Supplier.GEOAMEY, 2020)
+
+    verify(importService).importPrices(Supplier.GEOAMEY)
+  }
+
+  @Test
+  internal fun `import prices for Serco for the effective year 2021 fails`() {
+    assertThatThrownBy { command.bulkImportPricesFor(Supplier.SERCO, 2021) }.isInstanceOf(RuntimeException::class.java)
+  }
+
+  @Test
+  internal fun `import prices for Geoamey for the effective year 2021 fails`() {
+    assertThatThrownBy { command.bulkImportPricesFor(Supplier.GEOAMEY, 2021) }.isInstanceOf(RuntimeException::class.java)
+  }
+
+  @Test
+  internal fun `import prices for Unknown for any valid year fails`() {
+    assertThatThrownBy { command.bulkImportPricesFor(Supplier.UNKNOWN, 2019) }.isInstanceOf(RuntimeException::class.java)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommandsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/ImportCommandsTest.kt
@@ -4,9 +4,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportService
 import java.time.LocalDate
 
@@ -16,25 +14,6 @@ internal class ImportCommandsTest {
   private val date: LocalDate = LocalDate.of(2020, 9, 30)
 
   private val commands: ImportCommands = ImportCommands(importService)
-
-  @Test
-  internal fun `import prices for Serco`() {
-    commands.importPrices(Supplier.SERCO)
-
-    verify(importService).importPrices(Supplier.SERCO)
-  }
-
-  @Test
-  internal fun `import prices for Geoamey`() {
-    commands.importPrices(Supplier.GEOAMEY)
-
-    verify(importService).importPrices(Supplier.GEOAMEY)
-  }
-
-  @Test
-  internal fun `import prices for Unknown fails`() {
-    assertThatThrownBy { commands.importPrices(Supplier.UNKNOWN) }.isInstanceOf(RuntimeException::class.java)
-  }
 
   @Test
   internal fun `import one days reporting data`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/price/PriceImporterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/price/PriceImporterTest.kt
@@ -43,7 +43,6 @@ internal class PriceImporterTest {
 
     verify(locationRepo).findAll()
     verify(sercoPricesProvider).get()
-    verify(priceRepo).deleteBySupplierAndEffectiveYear(Supplier.SERCO, 2019)
     verify(priceRepo, times(2)).count()
     verify(priceRepo).save(any())
   }
@@ -59,7 +58,6 @@ internal class PriceImporterTest {
 
     verify(locationRepo).findAll()
     verify(geoameyPricesProvider).get()
-    verify(priceRepo).deleteBySupplierAndEffectiveYear(Supplier.GEOAMEY, 2019)
     verify(priceRepo, times(2)).count()
     verify(priceRepo).save(any())
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/price/PriceImporterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/importer/price/PriceImporterTest.kt
@@ -20,7 +20,7 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 
-internal class PriceImportTest {
+internal class PriceImporterTest {
 
   private val priceRepo: PriceRepository = mock()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/EffectiveYearTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/EffectiveYearTest.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.price
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+internal class EffectiveYearTest {
+
+  @Test
+  fun `current effective year 2019`() {
+    assertThat(EffectiveYear { september(2019) }.current()).isEqualTo(2019)
+    assertThat(EffectiveYear { august(2020) }.current()).isEqualTo(2019)
+  }
+
+  @Test
+  fun `current effective year 2020`() {
+    assertThat(EffectiveYear { september(2020) }.current()).isEqualTo(2020)
+    assertThat(EffectiveYear { august(2021) }.current()).isEqualTo(2020)
+  }
+
+  @Test
+  fun `current effective year 2021`() {
+    assertThat(EffectiveYear { september(2021) }.current()).isEqualTo(2021)
+    assertThat(EffectiveYear { august(2022) }.current()).isEqualTo(2021)
+  }
+
+  @Test
+  fun `effective year for september 2019 date`() {
+    assertThat(effectiveYearForDate(september(2019).toLocalDate())).isEqualTo(2019)
+  }
+
+  @Test
+  fun `effective year for august 2020 date`() {
+    assertThat(effectiveYearForDate(august(2020).toLocalDate())).isEqualTo(2019)
+  }
+
+  @Test
+  fun `next effective year for september 2019 date`() {
+    assertThat(nextEffectiveYearForDate(september(2019).toLocalDate())).isEqualTo(2020)
+  }
+
+  @Test
+  fun `next effective year for august 2020 date`() {
+    assertThat(nextEffectiveYearForDate(august(2020).toLocalDate())).isEqualTo(2020)
+  }
+
+  private fun september(year: Int) = LocalDateTime.of(year, 9, 1, 0, 0)
+
+  private fun august(year: Int) = LocalDateTime.of(year, 8, 31, 0, 0)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
@@ -47,7 +47,7 @@ internal class ImportServiceTest {
 
   @Test
   internal fun `price importer interactions for Serco`() {
-    importService.importPrices(Supplier.SERCO)
+    importService.importPrices(Supplier.SERCO, 2020)
 
     verify(priceImporter).import(Supplier.SERCO, 2020)
     verifyZeroInteractions(monitoringService)
@@ -55,7 +55,7 @@ internal class ImportServiceTest {
 
   @Test
   internal fun `price importer interactions for GEOAmey`() {
-    importService.importPrices(Supplier.GEOAMEY)
+    importService.importPrices(Supplier.GEOAMEY, 2020)
 
     verify(priceImporter).import(Supplier.GEOAMEY, 2020)
     verifyZeroInteractions(monitoringService)


### PR DESCRIPTION
**Changes:**

- We no longer delete existing prices prior to a bulk price upload to the service.  This is so we do not loose any prices that have been manually added by the users on the front end.
- We now need to specify the effective year when uploading bulk prices.  Prior to this the system determined the current effective year at time the import was executed. This change is needed because the journey back-fill for the current contractual year is likely to **not** be completed by the suppliers in September 2021.

