### PR TITLE
P4-3042 fixing bug whereby multiple journey prices (for same journey different year) being returned when trying to update. Was missing use of a query parameter.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingService.kt
@@ -50,7 +50,7 @@ class SupplierPricingService(
     effectiveYear: Int
   ): Triple<String, String, Money> {
     val (fromLocation, toLocation) = getFromAndToLocationBy(fromAgencyId, toAgencyId)
-    val price = priceRepository.findBySupplierAndFromLocationAndToLocation(supplier, fromLocation, toLocation)
+    val price = priceRepository.findBySupplierAndFromLocationAndToLocationAndEffectiveYear(supplier, fromLocation, toLocation, effectiveYear)
       ?: throw RuntimeException("No matching price found for $supplier")
 
     return Triple(fromLocation.siteName, toLocation.siteName, Money(price.priceInPence))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingServiceTest.kt
@@ -87,10 +87,11 @@ internal class SupplierPricingServiceTest {
     whenever(locationRepository.findByNomisAgencyId("FROM")).thenReturn(fromLocation)
     whenever(locationRepository.findByNomisAgencyId("TO")).thenReturn(toLocation)
     whenever(
-      priceRepository.findBySupplierAndFromLocationAndToLocation(
+      priceRepository.findBySupplierAndFromLocationAndToLocationAndEffectiveYear(
         Supplier.SERCO,
         fromLocation,
-        toLocation
+        toLocation,
+        effectiveYear
       )
     ).thenReturn(price)
 
@@ -99,7 +100,7 @@ internal class SupplierPricingServiceTest {
     assertThat(result).isEqualTo(Triple("from site", "to site", Money.valueOf(100.24)))
     verify(locationRepository).findByNomisAgencyId("FROM")
     verify(locationRepository).findByNomisAgencyId("TO")
-    verify(priceRepository).findBySupplierAndFromLocationAndToLocation(Supplier.SERCO, fromLocation, toLocation)
+    verify(priceRepository).findBySupplierAndFromLocationAndToLocationAndEffectiveYear(Supplier.SERCO, fromLocation, toLocation, effectiveYear)
   }
 
   @Test


### PR DESCRIPTION
**Changes:**

Small change where a query parameter was not being used to limit the journey price returned during update price, getting multiple instead of a single price.  This has only just been noticed in preprod testing (not in production) due to price uplifts being run in preprod.