### PR TITLE
P4-3008 moving logic for price adjustment for new prices (not updates) into the Price entity.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/Price.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/Price.kt
@@ -53,6 +53,16 @@ data class Price(
   fun journey() = "${fromLocation.nomisAgencyId}-${toLocation.nomisAgencyId}"
 
   fun price() = Money(priceInPence)
+
+  /**
+   * Returns a new instance of the price with the provided adjustments.  The locations remain the same.
+   */
+  fun adjusted(amount: Money, effectiveYear: Int, addedAt: LocalDateTime) = this.copy(
+    id = UUID.randomUUID(),
+    priceInPence = amount.pence,
+    effectiveYear = effectiveYear,
+    addedAt = addedAt
+  )
 }
 
 enum class Supplier {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceUplifter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceUplifter.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.price
 
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 
@@ -15,8 +14,6 @@ class PriceUplifter(
   private val priceUpliftRepository: SupplierPriceUpliftRepository,
   private val timeSource: TimeSource
 ) {
-
-  private val logger = LoggerFactory.getLogger(javaClass)
 
   /**
    * Any exception thrown calling this function will passed onto the onFailure lambda function.
@@ -67,8 +64,8 @@ class PriceUplifter(
       previousYearPrice.fromLocation,
       previousYearPrice.toLocation,
       effectiveYear
-    )?.apply { this.priceInPence = previousYearPrice.price().times(multiplier).pence } ?: previousYearPrice.copy(
-      priceInPence = previousYearPrice.price().times(multiplier).pence,
+    )?.apply { this.priceInPence = previousYearPrice.price().times(multiplier).pence } ?: previousYearPrice.adjusted(
+      amount = previousYearPrice.price().times(multiplier),
       effectiveYear = effectiveYear,
       addedAt = timeSource.dateTime()
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceTest.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.price
 
+import com.nhaarman.mockitokotlin2.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
 internal class PriceTest {
-
   @Test
   fun `Aug 31st is in previous year's effective date`() {
     val aug31_20201 = LocalDate.of(2021, 8, 31)
@@ -16,5 +16,30 @@ internal class PriceTest {
   fun `Sept 1st is in this year's effective date`() {
     val sept1_2021 = LocalDate.of(2021, 9, 1)
     assertThat(effectiveYearForDate(sept1_2021)).isEqualTo(2021)
+  }
+
+  @Test
+  fun `new instance is created with relevant attributes changed upon price adjustment`() {
+    val originalPrice = Price(supplier = Supplier.SERCO, fromLocation = mock(), toLocation = mock(), effectiveYear = 2020, priceInPence = 1000, addedAt = LocalDate.of(2020, 7, 27).atStartOfDay())
+    val adjustedPrice = originalPrice.adjusted(amount = Money(2000), effectiveYear = 2021, addedAt = LocalDate.of(2021, 7, 27).atStartOfDay())
+
+    with(originalPrice) {
+      assertThat(this).isNotSameAs(adjustedPrice)
+      assertThat(this).isNotEqualTo(adjustedPrice)
+
+      assertThat(id).isNotEqualTo(adjustedPrice.id)
+      assertThat(priceInPence).isNotEqualTo(adjustedPrice.priceInPence)
+      assertThat(effectiveYear).isNotEqualTo(adjustedPrice.effectiveYear)
+      assertThat(addedAt).isNotEqualTo(adjustedPrice.addedAt)
+
+      assertThat(fromLocation).isEqualTo(adjustedPrice.fromLocation)
+      assertThat(toLocation).isEqualTo(adjustedPrice.toLocation)
+    }
+
+    with(adjustedPrice) {
+      assertThat(priceInPence).isEqualTo(2000)
+      assertThat(effectiveYear).isEqualTo(2021)
+      assertThat(addedAt).isEqualTo(LocalDate.of(2021, 7, 27).atStartOfDay())
+    }
   }
 }


### PR DESCRIPTION
**Changes:**

Small refactoring to move the actual price uplift (adjustment) change into the actual entity to ensure only the relevant attributes are changed.