### PR TITLE
P4-3044 updating transitive dependency to resolve OWASP CVE-2021-3551…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,9 @@ dependencies {
     implementation("org.apache.pdfbox:pdfbox:2.0.24") {
       because("previous transitive version 2.0.23 pulled from Apache POI 5.0.0 has CVE")
     }
+    implementation("org.apache.commons:commons-compress:1.21") {
+      because("previous transitive version 1.20 pulled from Apache POI 5.0.0 has CVE")
+    }
   }
 
   implementation("org.flywaydb:flyway-core:7.10.0")


### PR DESCRIPTION
**Changes:**

Small transitive dependency change to resolve OWASP OWASP CVE-2021-35517, CVE-2021-35516, CVE-2021-35515, CVE-2021-36090.

There is no update available for the Apache POI library that pulls in the transitive dependency.  All unit tests and integration tests are passing as a result of the change.