### PR TITLE
P4-3011 changes to audit price uplifts at the individual price level i.e. each price adjustment is audited as well as the process as a whole.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditEventType.kt
@@ -4,7 +4,7 @@ enum class AuditEventType(val label: String) {
   DOWNLOAD_SPREADSHEET("Download spreadsheet"),
   DOWNLOAD_SPREADSHEET_FAILURE("Download spreadsheet failure"),
   JOURNEY_PRICE("Journey price"),
-  JOURNEY_PRICE_BULK_UPDATE("Journey price bulk update"),
+  JOURNEY_PRICE_BULK_UPLIFT("Journey price bulk uplift"),
   LOCATION("Location"),
   LOG_IN("Log in"),
   LOG_OUT("Log out"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditableEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditableEvent.kt
@@ -76,13 +76,22 @@ data class AuditableEvent(
       )
     }
 
-    fun journeyPriceBulkUpdateEvent(
+    fun upliftPrice(price: Price, original: Money, multiplier: Double, authentication: Authentication? = null): AuditableEvent {
+      return AuditableEvent(
+        type = AuditEventType.JOURNEY_PRICE,
+        username = authentication?.name ?: terminal,
+        metadata = PriceMetadata.uplift(price, original, multiplier)
+      )
+    }
+
+    fun journeyPriceBulkUpliftEvent(
       supplier: Supplier,
       effectiveYear: Int,
-      multiplier: Double
+      multiplier: Double,
+      authentication: Authentication? = null
     ) = createEvent(
-      AuditEventType.JOURNEY_PRICE_BULK_UPDATE,
-      null,
+      AuditEventType.JOURNEY_PRICE_BULK_UPLIFT,
+      authentication,
       mapOf("supplier" to supplier, "effective_year" to effectiveYear, "multiplier" to multiplier),
       true
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AnnualPriceAdjustmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AnnualPriceAdjustmentsService.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.price.AnnualPriceAdjuster
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 
 /**
- * Service to handle annual price adjustments for suppliers in relation to inflationary changes.
+ * Service to handle annual price adjustments for suppliers.
  *
  * Generally speaking (but not always) annual adjustments take place at the start of a new effective year e.g. September.
  */
@@ -43,7 +43,7 @@ class AnnualPriceAdjustmentsService(
         },
         {
           logger.info("Succeeded price uplift for $supplier for effective year $effectiveYear and multiplier $multiplier. Total prices uplifted $it.")
-          auditService.create(AuditableEvent.journeyPriceBulkUpdateEvent(supplier, effectiveYear, multiplier))
+          auditService.create(AuditableEvent.journeyPriceBulkUpliftEvent(supplier, effectiveYear, multiplier))
         }
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BulkPricesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BulkPricesService.kt
@@ -47,6 +47,6 @@ class BulkPricesService(
 
     logger.info("$total $supplier prices added for effective year ${nextEffectiveYearForDate(now)}")
 
-    auditService.create(AuditableEvent.journeyPriceBulkUpdateEvent(supplier, nextEffectiveYearForDate(now), multiplier))
+    auditService.create(AuditableEvent.journeyPriceBulkUpliftEvent(supplier, nextEffectiveYearForDate(now), multiplier))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/PriceMetadataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/PriceMetadataTest.kt
@@ -39,6 +39,7 @@ internal class PriceMetadataTest {
     assertThat(metadata.newPrice).isEqualTo(1.0)
     assertThat(metadata.oldPrice).isEqualTo(2.0)
     assertThat(metadata.isUpdate()).isTrue
+    assertThat(metadata.isUplift()).isFalse
     assertThat(metadata.key()).isEqualTo("GEOAMEY-FROM_AGENCY_ID-TO_AGENCY_ID")
   }
 
@@ -49,5 +50,24 @@ internal class PriceMetadataTest {
     }
       .isInstanceOf(IllegalArgumentException::class.java)
       .hasMessage("Old price and new price are the same '${Money.valueOf(1.0)}'.")
+  }
+
+  @Test
+  fun `price uplift`() {
+    val metadata = PriceMetadata.uplift(
+      new = Price(supplier = Supplier.SERCO, fromLocation = fromLocation, toLocation = toLocation, effectiveYear = 2020, priceInPence = 200),
+      old = Money(100),
+      multiplier = 2.0
+    )
+
+    assertThat(metadata.supplier).isEqualTo(Supplier.SERCO)
+    assertThat(metadata.fromNomisId).isEqualTo("FROM_AGENCY_ID")
+    assertThat(metadata.toNomisId).isEqualTo("TO_AGENCY_ID")
+    assertThat(metadata.effectiveYear).isEqualTo(2020)
+    assertThat(metadata.newPrice).isEqualTo(2.0)
+    assertThat(metadata.oldPrice).isEqualTo(1.0)
+    assertThat(metadata.multiplier).isEqualTo(2.0)
+    assertThat(metadata.isUpdate()).isFalse
+    assertThat(metadata.isUplift()).isTrue
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AnnualPriceAdjustmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AnnualPriceAdjustmentsServiceTest.kt
@@ -22,9 +22,9 @@ internal class AnnualPriceAdjustmentsServiceTest {
   private val priceRepository: PriceRepository = mock()
   private val timeSource = TimeSource { LocalDateTime.now() }
   private val monitoringService: MonitoringService = mock()
-  private val annualPriceAdjuster: AnnualPriceAdjuster = AnnualPriceAdjuster(priceRepository, priceAdjustmentRepository, timeSource)
-  private val annualPriceAdjusterSpy: AnnualPriceAdjuster = mock { spy(annualPriceAdjuster) }
   private val auditService: AuditService = mock()
+  private val annualPriceAdjuster: AnnualPriceAdjuster = AnnualPriceAdjuster(priceRepository, priceAdjustmentRepository, auditService, timeSource)
+  private val annualPriceAdjusterSpy: AnnualPriceAdjuster = mock { spy(annualPriceAdjuster) }
 
   @Test
   internal fun `price uplift for Serco`() {
@@ -71,7 +71,7 @@ internal class AnnualPriceAdjustmentsServiceTest {
 
     verify(auditService).create(
       AuditableEvent(
-        AuditEventType.JOURNEY_PRICE_BULK_UPDATE,
+        AuditEventType.JOURNEY_PRICE_BULK_UPLIFT,
         "_TERMINAL_",
         mapOf("supplier" to Supplier.GEOAMEY, "effective_year" to 2021, "multiplier" to 2.0)
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BulkPricesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/BulkPricesServiceTest.kt
@@ -43,7 +43,7 @@ internal class BulkPricesServiceTest {
     verify(priceRepository, times(2)).save(priceCaptor.capture())
     verify(auditService).create(
       AuditableEvent(
-        AuditEventType.JOURNEY_PRICE_BULK_UPDATE,
+        AuditEventType.JOURNEY_PRICE_BULK_UPLIFT,
         "_TERMINAL_",
         mapOf("supplier" to Supplier.SERCO, "effective_year" to 2021, "multiplier" to 1.5)
       )
@@ -67,7 +67,7 @@ internal class BulkPricesServiceTest {
     verify(priceRepository, times(2)).save(priceCaptor.capture())
     verify(auditService).create(
       AuditableEvent(
-        AuditEventType.JOURNEY_PRICE_BULK_UPDATE,
+        AuditEventType.JOURNEY_PRICE_BULK_UPLIFT,
         "_TERMINAL_",
         mapOf("supplier" to Supplier.GEOAMEY, "effective_year" to 2022, "multiplier" to 2.0)
       )


### PR DESCRIPTION
**Changes:**

This is part 1 of two changes around price auditing.  This one is for price uplifts only.

This now audits each individual price adjustment (uplift) as well as the overall price uplift process.

Part 2 will be adding auditing for bulk price uploads.