### PR TITLE
P4-3050 small change to auth url in integration test to match that of change to the actual auth service.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/LoginPage.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/LoginPage.kt
@@ -4,7 +4,7 @@ import org.fluentlenium.core.annotation.PageUrl
 import org.fluentlenium.core.domain.FluentWebElement
 import org.openqa.selenium.support.FindBy
 
-@PageUrl("http://localhost:9090/auth/login")
+@PageUrl("http://localhost:9090/auth/sign-in")
 class LoginPage : ApplicationPage() {
 
   @FindBy(css = "input[type='submit']")


### PR DESCRIPTION
**Changes:**

The login URL for auth has changed to 'sign'in' (note this only affects the integration tests).

The integration tests need to be updated to use the new URL.  This only affects one class and the change is small

This ..

```
@PageUrl("http://localhost:9090/auth/login")
class LoginPage : ApplicationPage() {
```

Becomes ...

```
@PageUrl("http://localhost:9090/auth/sign-in")
class LoginPage : ApplicationPage() {
```

