### PR TITLE
P4-3084 changes to prevent supplier level price changes if a price adjustment is in currently in progress.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceAdjustmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceAdjustmentRepository.kt
@@ -7,4 +7,6 @@ interface PriceAdjustmentRepository : JpaRepository<PriceAdjustment, UUID> {
   fun findBySupplier(supplier: Supplier): PriceAdjustment?
 
   fun deleteBySupplier(supplier: Supplier)
+
+  fun existsPriceAdjustmentBySupplier(supplier: Supplier): Boolean
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/AnnualPriceAdjusterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/AnnualPriceAdjusterTest.kt
@@ -26,6 +26,20 @@ internal class AnnualPriceAdjusterTest {
   private val toLocation: Location = mock()
 
   @Test
+  fun `adjustment is not in progress for supplier`() {
+    whenever(priceAdjustmentRepository.existsPriceAdjustmentBySupplier(Supplier.SERCO)).thenReturn(false)
+
+    assertThat(priceAdjuster.isInProgressFor(Supplier.SERCO))
+  }
+
+  @Test
+  fun `adjustment is in progress for supplier`() {
+    whenever(priceAdjustmentRepository.existsPriceAdjustmentBySupplier(Supplier.GEOAMEY)).thenReturn(true)
+
+    assertThat(priceAdjuster.isInProgressFor(Supplier.GEOAMEY))
+  }
+
+  @Test
   fun `previous years prices are successfully uplifted for Serco`() {
     val previousYearPrice = Price(supplier = Supplier.SERCO, fromLocation = fromLocation, toLocation = toLocation, priceInPence = 10000, effectiveYear = 2019)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceAdjustmentRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceAdjustmentRepositoryTest.kt
@@ -29,6 +29,17 @@ internal class PriceAdjustmentRepositoryTest {
   }
 
   @Test
+  fun `price adjustment is in progress for Serco and exists by supplier`() {
+    assertThat(repository.existsPriceAdjustmentBySupplier(Supplier.SERCO)).isFalse
+
+    repository.save(PriceAdjustment(supplier = Supplier.SERCO))
+
+    entityManager.flush()
+
+    assertThat(repository.existsPriceAdjustmentBySupplier(Supplier.SERCO)).isTrue
+  }
+
+  @Test
   fun `can create price adjustment for GEOAmey and retrieve by supplier`() {
     assertThat(repository.findBySupplier(Supplier.GEOAMEY)).isNull()
 


### PR DESCRIPTION
**Changes:**

If an attempt is made to add or change a price whilst a bulk price adjustment is in progress for a given supplier then a runtime exception will be thrown preventing the add/update from taking place.

The error itself is caught by the application level exception handler which in turn directs the user to the general error page.

As it stands this change should be sufficient as a first cut.  Strictly speaking it will be the commercial team (who are responsible for price changes) asking us to run the bulk price adjustment in the first place until the front end screens for bulk price adjustments are available to them.
