### PR TITLE
P4-3084 resolving issue with the (DB) transaction boundary being at the wrong level for price adjustments.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AnnualPriceAdjustmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AnnualPriceAdjustmentsService.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditableEvent
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.AnnualPriceAdjuster
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.EffectiveYear
@@ -16,7 +15,6 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
  * Generally speaking (but not always) annual adjustments take place at the start of a new effective year e.g. September.
  */
 @Service
-@Transactional
 class AnnualPriceAdjustmentsService(
   private val annualPriceAdjuster: AnnualPriceAdjuster,
   private val monitoringService: MonitoringService,
@@ -45,23 +43,28 @@ class AnnualPriceAdjustmentsService(
    */
   private fun doUplift(supplier: Supplier, effectiveYear: Int, multiplier: Double) = runBlocking {
     launch {
-      annualPriceAdjuster.uplift(
-        supplier,
-        effectiveYear,
-        multiplier,
-        {
-          logger.error(
-            "Failed price uplift for $supplier for effective year $effectiveYear and multiplier $multiplier.",
-            it
-          )
+      Result.runCatching {
+        val lockId = annualPriceAdjuster.attemptLockForPriceAdjustment(supplier)
 
-          monitoringService.capture("Failed price uplift for $supplier for effective year $effectiveYear and multiplier $multiplier.")
-        },
-        {
-          logger.info("Succeeded price uplift for $supplier for effective year $effectiveYear and multiplier $multiplier. Total prices uplifted $it.")
-          auditService.create(AuditableEvent.journeyPriceBulkUpliftEvent(supplier, effectiveYear, multiplier))
+        annualPriceAdjuster.uplift(
+          lockId,
+          supplier,
+          effectiveYear,
+          multiplier
+        ).also {
+          annualPriceAdjuster.releaseLockForPriceAdjustment(lockId)
         }
-      )
+      }.onFailure {
+        logger.error(
+          "Failed price uplift for $supplier for effective year $effectiveYear and multiplier $multiplier.",
+          it
+        )
+
+        monitoringService.capture("Failed price uplift for $supplier for effective year $effectiveYear and multiplier $multiplier.")
+      }.onSuccess {
+        logger.info("Succeeded price uplift for $supplier for effective year $effectiveYear and multiplier $multiplier. Total prices uplifted $it.")
+        auditService.create(AuditableEvent.journeyPriceBulkUpliftEvent(supplier, effectiveYear, multiplier))
+      }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/AnnualPriceAdjusterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/AnnualPriceAdjusterTest.kt
@@ -2,16 +2,19 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.price
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.Location
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.AuditService
 import java.time.LocalDateTime
+import java.util.UUID
 import java.util.stream.Stream
 
 internal class AnnualPriceAdjusterTest {
@@ -21,9 +24,9 @@ internal class AnnualPriceAdjusterTest {
   private val timeSource = TimeSource { LocalDateTime.of(2021, 7, 22, 0, 0) }
   private val auditService: AuditService = mock()
   private val priceAdjuster = AnnualPriceAdjuster(priceRepository, priceAdjustmentRepository, auditService, timeSource)
-  private val upliftCaptor = argumentCaptor<PriceAdjustment>()
-  private val fromLocation: Location = mock()
-  private val toLocation: Location = mock()
+  private val priceAdjusterCaptor = argumentCaptor<PriceAdjustment>()
+  private val fromLocation: Location = mock { on { nomisAgencyId } doReturn "from_agency" }
+  private val toLocation: Location = mock { on { nomisAgencyId } doReturn "to_agency" }
 
   @Test
   fun `adjustment is not in progress for supplier`() {
@@ -40,67 +43,98 @@ internal class AnnualPriceAdjusterTest {
   }
 
   @Test
+  fun `attempted lock for GEOAmey uplift is successful`() {
+    val expectedPriceAdjustment = PriceAdjustment(supplier = Supplier.GEOAMEY, addedAt = timeSource.dateTime())
+    whenever(priceAdjustmentRepository.saveAndFlush(any())).thenReturn(expectedPriceAdjustment)
+
+    val actualLockId = priceAdjuster.attemptLockForPriceAdjustment(Supplier.GEOAMEY)
+
+    verify(priceAdjustmentRepository).saveAndFlush(priceAdjusterCaptor.capture())
+
+    with(priceAdjusterCaptor.firstValue) {
+      assertThat(supplier).isEqualTo(Supplier.GEOAMEY)
+      assertThat(addedAt).isEqualTo(timeSource.dateTime())
+    }
+
+    assertThat(actualLockId).isEqualTo(expectedPriceAdjustment.id)
+  }
+
+  @Test
+  fun `attempted lock required for Serco uplift is successful`() {
+    val expectedPriceAdjustment = PriceAdjustment(supplier = Supplier.SERCO, addedAt = timeSource.dateTime())
+    whenever(priceAdjustmentRepository.saveAndFlush(any())).thenReturn(expectedPriceAdjustment)
+
+    val actualLockId = priceAdjuster.attemptLockForPriceAdjustment(Supplier.SERCO)
+
+    verify(priceAdjustmentRepository).saveAndFlush(priceAdjusterCaptor.capture())
+
+    with(priceAdjusterCaptor.firstValue) {
+      assertThat(supplier).isEqualTo(Supplier.SERCO)
+      assertThat(addedAt).isEqualTo(timeSource.dateTime())
+    }
+
+    assertThat(actualLockId).isEqualTo(expectedPriceAdjustment.id)
+  }
+
+  @Test
   fun `previous years prices are successfully uplifted for Serco`() {
+    val lockId = fakeLock()
+
     val previousYearPrice = Price(supplier = Supplier.SERCO, fromLocation = fromLocation, toLocation = toLocation, priceInPence = 10000, effectiveYear = 2019)
 
     whenever(priceRepository.findBySupplierAndEffectiveYear(Supplier.SERCO, 2019)).thenReturn(Stream.of(previousYearPrice))
     whenever(priceRepository.findBySupplierAndFromLocationAndToLocationAndEffectiveYear(any(), any(), any(), any())).thenReturn(null)
 
-    priceAdjuster.uplift(Supplier.SERCO, 2020, 1.5, {}, { count -> assertThat(count).isEqualTo(1) })
+    val adjusted = priceAdjuster.uplift(lockId, Supplier.SERCO, 2020, 1.5)
 
-    verify(priceAdjustmentRepository).saveAndFlush(upliftCaptor.capture())
-
-    with(upliftCaptor.firstValue) {
-      assertThat(supplier).isEqualTo(Supplier.SERCO)
-      assertThat(addedAt).isEqualTo(timeSource.dateTime())
-    }
+    assertThat(adjusted).isEqualTo(1)
 
     verify(priceRepository).findBySupplierAndEffectiveYear(Supplier.SERCO, 2019)
-    verify(priceAdjustmentRepository).deleteBySupplier(Supplier.SERCO)
   }
 
   @Test
-  fun `failed uplift for Serco`() {
-    val exception = RuntimeException("something went wrong for Serco uplift")
+  fun `failed uplift for Serco due to price adjustment lock not being in place`() {
+    val lockId = fakeLock(false)
 
-    whenever(priceAdjustmentRepository.saveAndFlush(any())).thenThrow(exception)
+    assertThatThrownBy { priceAdjuster.uplift(lockId, Supplier.SERCO, 2020, 1.0) }
+      .isInstanceOf(RuntimeException::class.java)
+      .hasMessage("Unable to upflift lock is not present for SERCO.")
 
-    priceAdjuster.uplift(Supplier.SERCO, 2020, 1.0, { thrown -> assertThat(thrown).isEqualTo(exception) }, {})
-
-    verify(priceAdjustmentRepository).saveAndFlush(any())
     verifyZeroInteractions(priceRepository)
-    verify(priceAdjustmentRepository).deleteBySupplier(Supplier.SERCO)
   }
 
   @Test
   fun `previous years prices are successfully uplifted for GEOAmey`() {
+    val lockId = fakeLock()
+
     val previousYearPrice = Price(supplier = Supplier.GEOAMEY, fromLocation = fromLocation, toLocation = toLocation, priceInPence = 10000, effectiveYear = 2020)
 
     whenever(priceRepository.findBySupplierAndEffectiveYear(Supplier.GEOAMEY, 2020)).thenReturn(Stream.of(previousYearPrice))
 
-    priceAdjuster.uplift(Supplier.GEOAMEY, 2021, 2.0, {}, { count -> assertThat(count).isEqualTo(1) })
+    val adjusted = priceAdjuster.uplift(lockId, Supplier.GEOAMEY, 2021, 2.0)
 
-    verify(priceAdjustmentRepository).saveAndFlush(upliftCaptor.capture())
-
-    with(upliftCaptor.firstValue) {
-      assertThat(supplier).isEqualTo(Supplier.GEOAMEY)
-      assertThat(addedAt).isEqualTo(timeSource.dateTime())
-    }
+    assertThat(adjusted).isEqualTo(1)
 
     verify(priceRepository).findBySupplierAndEffectiveYear(Supplier.GEOAMEY, 2020)
-    verify(priceAdjustmentRepository).deleteBySupplier(Supplier.GEOAMEY)
   }
 
   @Test
-  fun `failed uplift for GEOAmey`() {
-    val exception = RuntimeException("something went wrong for GEOAmey uplift")
+  fun `failed uplift for GEOAmey due to price adjustment lock not being in place`() {
+    val lockId = fakeLock(false)
 
-    whenever(priceAdjustmentRepository.saveAndFlush(any())).thenThrow(exception)
+    assertThatThrownBy { priceAdjuster.uplift(lockId, Supplier.GEOAMEY, 2020, 1.0) }
+      .isInstanceOf(RuntimeException::class.java)
+      .hasMessage("Unable to upflift lock is not present for GEOAMEY.")
 
-    priceAdjuster.uplift(Supplier.GEOAMEY, 2020, 1.0, { thrown -> assertThat(thrown).isEqualTo(exception) }, {})
-
-    verify(priceAdjustmentRepository).saveAndFlush(any())
+    verify(priceAdjustmentRepository).existsById(lockId)
     verifyZeroInteractions(priceRepository)
-    verify(priceAdjustmentRepository).deleteBySupplier(Supplier.GEOAMEY)
+  }
+
+  private fun fakeLock(present: Boolean = true): UUID {
+    val lockId = UUID.randomUUID()
+
+    whenever(priceAdjustmentRepository.existsById(lockId)).thenReturn(present)
+
+    return lockId
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AnnualPriceAdjustmentsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AnnualPriceAdjustmentsServiceTest.kt
@@ -13,10 +13,12 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.auditing.AuditableEvent
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.AnnualPriceAdjuster
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.EffectiveYear
+import uk.gov.justice.digital.hmpps.pecs.jpc.price.PriceAdjustment
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.PriceAdjustmentRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.PriceRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.price.Supplier
 import java.time.LocalDate
+import java.util.UUID
 
 internal class AnnualPriceAdjustmentsServiceTest {
 
@@ -26,34 +28,40 @@ internal class AnnualPriceAdjustmentsServiceTest {
   private val effectiveYear = EffectiveYear(timeSource)
   private val monitoringService: MonitoringService = mock()
   private val auditService: AuditService = mock()
-  private val annualPriceAdjuster: AnnualPriceAdjuster = AnnualPriceAdjuster(priceRepository, priceAdjustmentRepository, auditService, timeSource)
+  private val annualPriceAdjuster: AnnualPriceAdjuster =
+    AnnualPriceAdjuster(priceRepository, priceAdjustmentRepository, auditService, timeSource)
   private val annualPriceAdjusterSpy: AnnualPriceAdjuster = mock { spy(annualPriceAdjuster) }
 
   @Test
   internal fun `price uplift for Serco`() {
+    val lockId = fakeLockForFor(Supplier.SERCO)
+
     AnnualPriceAdjustmentsService(annualPriceAdjusterSpy, monitoringService, auditService, effectiveYear).uplift(
       Supplier.SERCO,
       2020,
       1.0
     )
 
-    verify(annualPriceAdjusterSpy).uplift(eq(Supplier.SERCO), eq(2020), eq(1.0), any(), any())
+    verify(annualPriceAdjusterSpy).uplift(eq(lockId), eq(Supplier.SERCO), eq(2020), eq(1.0))
   }
 
   @Test
   internal fun `price uplift for GEOAmey`() {
+    val lockId = fakeLockForFor(Supplier.GEOAMEY)
+
     AnnualPriceAdjustmentsService(annualPriceAdjusterSpy, monitoringService, auditService, effectiveYear).uplift(
       Supplier.GEOAMEY,
       2021,
       2.0
     )
 
-    verify(annualPriceAdjusterSpy).uplift(eq(Supplier.GEOAMEY), eq(2021), eq(2.0), any(), any())
+    verify(annualPriceAdjusterSpy).uplift(eq(lockId), eq(Supplier.GEOAMEY), eq(2021), eq(2.0))
   }
 
   @Test
   internal fun `monitoring service captures failed price uplift`() {
-    whenever(priceAdjustmentRepository.saveAndFlush(any())).thenThrow(RuntimeException("something went wrong"))
+    whenever(priceAdjustmentRepository.saveAndFlush(any())).thenReturn(PriceAdjustment(supplier = Supplier.GEOAMEY))
+    whenever(annualPriceAdjusterSpy.uplift(any(), eq(Supplier.GEOAMEY), eq(2021), eq(2.0))).thenThrow(RuntimeException("something went wrong"))
 
     AnnualPriceAdjustmentsService(annualPriceAdjuster, monitoringService, auditService, effectiveYear).uplift(
       Supplier.GEOAMEY,
@@ -66,6 +74,10 @@ internal class AnnualPriceAdjustmentsServiceTest {
 
   @Test
   internal fun `auditing service captures successful price uplift`() {
+    fakeLockForFor(Supplier.GEOAMEY)
+    whenever(priceAdjustmentRepository.saveAndFlush(any())).thenReturn(PriceAdjustment(supplier = Supplier.GEOAMEY))
+    whenever(priceAdjustmentRepository.existsById(any())).thenReturn(true)
+
     AnnualPriceAdjustmentsService(annualPriceAdjuster, monitoringService, auditService, effectiveYear).uplift(
       Supplier.GEOAMEY,
       2021,
@@ -89,6 +101,15 @@ internal class AnnualPriceAdjustmentsServiceTest {
         effectiveYear.current() - 1,
         2.0
       )
-    }.isInstanceOf(RuntimeException::class.java).hasMessage("Price uplifts cannot be before the current effective year ${effectiveYear.current()}.")
+    }.isInstanceOf(RuntimeException::class.java)
+      .hasMessage("Price uplifts cannot be before the current effective year ${effectiveYear.current()}.")
+  }
+
+  private fun fakeLockForFor(supplier: Supplier): UUID {
+    val lockId = UUID.randomUUID()
+
+    whenever(annualPriceAdjusterSpy.attemptLockForPriceAdjustment(supplier)).thenReturn(lockId)
+
+    return lockId
   }
 }


### PR DESCRIPTION
**Changes:**

**_Note: this is part one of two PR's next one for refactoring, will be changing references to uplift to become adjustment based._**

Testing from the front end for locking down price changes highlighted a bug in the locking logic to prevent price changes from happening if a bulk price adjustment is in progress.

This was a (DB) transaction boundary issue which this change resolves.