### PR TITLE
P4-3084 non-functional changes, rename changes only for consistency. References of 'uplift' changed to 'adjustment' for price adjustments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ import-prices --supplier SERCO/GEOAMEY --year 2020
 import-reports --from YYYY-MM-DD --to YYYY-MM-DD
 ```
 ```
-# Bulk price uplift
+# Bulk price adjustments
 
-uplift --supplier SERCO/GEOAMEY --effective-year 2021 --multiplier 1.12 --force
+bulk-price-adjustment --supplier SERCO/GEOAMEY --effective-year 2021 --multiplier 1.12 --force
 ```
 Typing help in the shell will also list the available commands.  TAB autocomplete is also available.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditEventType.kt
@@ -4,7 +4,7 @@ enum class AuditEventType(val label: String) {
   DOWNLOAD_SPREADSHEET("Download spreadsheet"),
   DOWNLOAD_SPREADSHEET_FAILURE("Download spreadsheet failure"),
   JOURNEY_PRICE("Journey price"),
-  JOURNEY_PRICE_BULK_UPLIFT("Journey price bulk uplift"),
+  JOURNEY_PRICE_BULK_ADJUSTMENT("Journey price bulk adjustment"),
   LOCATION("Location"),
   LOG_IN("Log in"),
   LOG_OUT("Log out"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditableEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/AuditableEvent.kt
@@ -80,21 +80,21 @@ data class AuditableEvent(
       )
     }
 
-    fun upliftPrice(price: Price, original: Money, multiplier: Double, authentication: Authentication? = null): AuditableEvent {
+    fun adjustPrice(price: Price, original: Money, multiplier: Double, authentication: Authentication? = null): AuditableEvent {
       return AuditableEvent(
         type = AuditEventType.JOURNEY_PRICE,
         username = authentication?.name ?: terminal,
-        metadata = PriceMetadata.uplift(price, original, multiplier)
+        metadata = PriceMetadata.adjustment(price, original, multiplier)
       )
     }
 
-    fun journeyPriceBulkUpliftEvent(
+    fun journeyPriceBulkPriceAdjustmentEvent(
       supplier: Supplier,
       effectiveYear: Int,
       multiplier: Double,
       authentication: Authentication? = null
     ) = createEvent(
-      AuditEventType.JOURNEY_PRICE_BULK_UPLIFT,
+      AuditEventType.JOURNEY_PRICE_BULK_ADJUSTMENT,
       authentication,
       mapOf("supplier" to supplier, "effective_year" to effectiveYear, "multiplier" to multiplier),
       true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/PriceMetadata.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/PriceMetadata.kt
@@ -68,7 +68,7 @@ data class PriceMetadata(
       return PriceMetadata(old, new)
     }
 
-    fun uplift(new: Price, old: Money, multiplier: Double) = PriceMetadata(old, new, multiplier)
+    fun adjustment(new: Price, old: Money, multiplier: Double) = PriceMetadata(old, new, multiplier)
 
     fun map(event: AuditEvent): PriceMetadata {
       return if (event.eventType == AuditEventType.JOURNEY_PRICE)
@@ -83,7 +83,7 @@ data class PriceMetadata(
 
   fun isUpdate() = oldPrice != null && multiplier == null
 
-  fun isUplift() = multiplier != null
+  fun isAdjustment() = multiplier != null
 
   override fun toJsonString(): String = Klaxon().toJsonString(this)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/BulkPriceUpdateCommands.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/commands/BulkPriceUpdateCommands.kt
@@ -9,10 +9,10 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.service.AnnualPriceAdjustmentsServi
 class BulkPriceUpdateCommands(
   private val annualPriceAdjustmentsService: AnnualPriceAdjustmentsService
 ) {
-  @ShellMethod("Performs a price uplift for the given supplier, effective year and the supplied multiplier.")
-  fun uplift(supplier: Supplier, effectiveYear: Int, multiplier: Double, force: Boolean = false) {
+  @ShellMethod("Performs a bulk price adjustment for the given supplier, effective year and the supplied multiplier.")
+  fun bulkPriceAdjustment(supplier: Supplier, effectiveYear: Int, multiplier: Double, force: Boolean = false) {
     if (force)
-      annualPriceAdjustmentsService.uplift(supplier, effectiveYear, multiplier)
+      annualPriceAdjustmentsService.adjust(supplier, effectiveYear, multiplier)
     else
       throw RuntimeException("Force is required for this operation to complete.")
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/AnnualPriceAdjuster.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/AnnualPriceAdjuster.kt
@@ -26,9 +26,9 @@ class AnnualPriceAdjuster(
   internal fun isInProgressFor(supplier: Supplier) = priceAdjustmentRepository.existsPriceAdjustmentBySupplier(supplier)
 
   /**
-   * Prices for the supplied effective year are calculated based on prices for the previous year with the supplied multiplier.
+   * Price adjustments for the supplied effective year are calculated based on prices for the previous year with the supplied multiplier.
    */
-  internal fun uplift(
+  internal fun adjust(
     id: UUID,
     supplier: Supplier,
     effectiveYear: Int,
@@ -89,12 +89,12 @@ class AnnualPriceAdjuster(
         .takeUnless { priceIsTheSame(it, previousYearPrice.price().times(multiplier)) }
         ?.apply { priceInPence = previousYearPrice.price().times(multiplier).pence }
         ?.also {
-          auditService.create(AuditableEvent.upliftPrice(it, previousYearPrice.price(), multiplier))
+          auditService.create(AuditableEvent.adjustPrice(it, previousYearPrice.price(), multiplier))
         }
     }
 
     return newPriceAdjustmentFor(previousYearPrice, effectiveYear, multiplier).also {
-      auditService.create(AuditableEvent.upliftPrice(it, previousYearPrice.price(), multiplier))
+      auditService.create(AuditableEvent.adjustPrice(it, previousYearPrice.price(), multiplier))
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/PriceMetadataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/auditing/PriceMetadataTest.kt
@@ -39,7 +39,7 @@ internal class PriceMetadataTest {
     assertThat(metadata.newPrice).isEqualTo(1.0)
     assertThat(metadata.oldPrice).isEqualTo(2.0)
     assertThat(metadata.isUpdate()).isTrue
-    assertThat(metadata.isUplift()).isFalse
+    assertThat(metadata.isAdjustment()).isFalse
     assertThat(metadata.key()).isEqualTo("GEOAMEY-FROM_AGENCY_ID-TO_AGENCY_ID")
   }
 
@@ -53,8 +53,8 @@ internal class PriceMetadataTest {
   }
 
   @Test
-  fun `price uplift`() {
-    val metadata = PriceMetadata.uplift(
+  fun `price adjustment`() {
+    val metadata = PriceMetadata.adjustment(
       new = Price(supplier = Supplier.SERCO, fromLocation = fromLocation, toLocation = toLocation, effectiveYear = 2020, priceInPence = 200),
       old = Money(100),
       multiplier = 2.0
@@ -68,6 +68,6 @@ internal class PriceMetadataTest {
     assertThat(metadata.oldPrice).isEqualTo(1.0)
     assertThat(metadata.multiplier).isEqualTo(2.0)
     assertThat(metadata.isUpdate()).isFalse
-    assertThat(metadata.isUplift()).isTrue
+    assertThat(metadata.isAdjustment()).isTrue
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/AnnualPriceAdjusterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/AnnualPriceAdjusterTest.kt
@@ -43,7 +43,7 @@ internal class AnnualPriceAdjusterTest {
   }
 
   @Test
-  fun `attempted lock for GEOAmey uplift is successful`() {
+  fun `attempted lock for GEOAmey adjustment is successful`() {
     val expectedPriceAdjustment = PriceAdjustment(supplier = Supplier.GEOAMEY, addedAt = timeSource.dateTime())
     whenever(priceAdjustmentRepository.saveAndFlush(any())).thenReturn(expectedPriceAdjustment)
 
@@ -60,7 +60,7 @@ internal class AnnualPriceAdjusterTest {
   }
 
   @Test
-  fun `attempted lock required for Serco uplift is successful`() {
+  fun `attempted lock required for Serco adjustment is successful`() {
     val expectedPriceAdjustment = PriceAdjustment(supplier = Supplier.SERCO, addedAt = timeSource.dateTime())
     whenever(priceAdjustmentRepository.saveAndFlush(any())).thenReturn(expectedPriceAdjustment)
 
@@ -77,7 +77,7 @@ internal class AnnualPriceAdjusterTest {
   }
 
   @Test
-  fun `previous years prices are successfully uplifted for Serco`() {
+  fun `previous years prices are successfully adjusted for Serco`() {
     val lockId = fakeLock()
 
     val previousYearPrice = Price(supplier = Supplier.SERCO, fromLocation = fromLocation, toLocation = toLocation, priceInPence = 10000, effectiveYear = 2019)
@@ -85,7 +85,7 @@ internal class AnnualPriceAdjusterTest {
     whenever(priceRepository.findBySupplierAndEffectiveYear(Supplier.SERCO, 2019)).thenReturn(Stream.of(previousYearPrice))
     whenever(priceRepository.findBySupplierAndFromLocationAndToLocationAndEffectiveYear(any(), any(), any(), any())).thenReturn(null)
 
-    val adjusted = priceAdjuster.uplift(lockId, Supplier.SERCO, 2020, 1.5)
+    val adjusted = priceAdjuster.adjust(lockId, Supplier.SERCO, 2020, 1.5)
 
     assertThat(adjusted).isEqualTo(1)
 
@@ -93,10 +93,10 @@ internal class AnnualPriceAdjusterTest {
   }
 
   @Test
-  fun `failed uplift for Serco due to price adjustment lock not being in place`() {
+  fun `failed adjustment for Serco due to price adjustment lock not being in place`() {
     val lockId = fakeLock(false)
 
-    assertThatThrownBy { priceAdjuster.uplift(lockId, Supplier.SERCO, 2020, 1.0) }
+    assertThatThrownBy { priceAdjuster.adjust(lockId, Supplier.SERCO, 2020, 1.0) }
       .isInstanceOf(RuntimeException::class.java)
       .hasMessage("Unable to upflift lock is not present for SERCO.")
 
@@ -104,14 +104,14 @@ internal class AnnualPriceAdjusterTest {
   }
 
   @Test
-  fun `previous years prices are successfully uplifted for GEOAmey`() {
+  fun `previous years prices are successfully adjusted for GEOAmey`() {
     val lockId = fakeLock()
 
     val previousYearPrice = Price(supplier = Supplier.GEOAMEY, fromLocation = fromLocation, toLocation = toLocation, priceInPence = 10000, effectiveYear = 2020)
 
     whenever(priceRepository.findBySupplierAndEffectiveYear(Supplier.GEOAMEY, 2020)).thenReturn(Stream.of(previousYearPrice))
 
-    val adjusted = priceAdjuster.uplift(lockId, Supplier.GEOAMEY, 2021, 2.0)
+    val adjusted = priceAdjuster.adjust(lockId, Supplier.GEOAMEY, 2021, 2.0)
 
     assertThat(adjusted).isEqualTo(1)
 
@@ -119,10 +119,10 @@ internal class AnnualPriceAdjusterTest {
   }
 
   @Test
-  fun `failed uplift for GEOAmey due to price adjustment lock not being in place`() {
+  fun `failed adjustment for GEOAmey due to price adjustment lock not being in place`() {
     val lockId = fakeLock(false)
 
-    assertThatThrownBy { priceAdjuster.uplift(lockId, Supplier.GEOAMEY, 2020, 1.0) }
+    assertThatThrownBy { priceAdjuster.adjust(lockId, Supplier.GEOAMEY, 2020, 1.0) }
       .isInstanceOf(RuntimeException::class.java)
       .hasMessage("Unable to upflift lock is not present for GEOAMEY.")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AuditServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AuditServiceTest.kt
@@ -294,18 +294,18 @@ internal class AuditServiceTest {
   private inline fun <reified T> jsonTo(json: String): T = Klaxon().parse<T>(json)!!
 
   @Test
-  internal fun `create journey price bulk uplift audit event`() {
-    service.create(AuditableEvent.journeyPriceBulkUpliftEvent(Supplier.SERCO, 2020, 1.5))
-    service.create(AuditableEvent.journeyPriceBulkUpliftEvent(Supplier.GEOAMEY, 2021, 2.0))
+  internal fun `create journey price bulk adjustment audit event`() {
+    service.create(AuditableEvent.journeyPriceBulkPriceAdjustmentEvent(Supplier.SERCO, 2020, 1.5))
+    service.create(AuditableEvent.journeyPriceBulkPriceAdjustmentEvent(Supplier.GEOAMEY, 2021, 2.0))
 
     verifyEvent(
-      AuditEventType.JOURNEY_PRICE_BULK_UPLIFT,
+      AuditEventType.JOURNEY_PRICE_BULK_ADJUSTMENT,
       "_TERMINAL_",
       mapOf("supplier" to Supplier.SERCO, "effective_year" to 2020, "multiplier" to 1.5)
     )
 
     verifyEvent(
-      AuditEventType.JOURNEY_PRICE_BULK_UPLIFT,
+      AuditEventType.JOURNEY_PRICE_BULK_ADJUSTMENT,
       "_TERMINAL_",
       mapOf("supplier" to Supplier.GEOAMEY, "effective_year" to 2021, "multiplier" to 2.0)
     )
@@ -323,9 +323,9 @@ internal class AuditServiceTest {
   }
 
   @Test
-  internal fun `create authenticated journey price uplift audit event`() {
+  internal fun `create authenticated journey price adjustment audit event`() {
     service.create(
-      AuditableEvent.upliftPrice(
+      AuditableEvent.adjustPrice(
         price = Price(
           supplier = Supplier.SERCO,
           fromLocation = Location(LocationType.CC, "TEST2", "TEST2"),
@@ -357,9 +357,9 @@ internal class AuditServiceTest {
   }
 
   @Test
-  internal fun `create un-authenticated journey price uplift audit event`() {
+  internal fun `create un-authenticated journey price adjustment audit event`() {
     service.create(
-      AuditableEvent.upliftPrice(
+      AuditableEvent.adjustPrice(
         price = Price(
           supplier = Supplier.SERCO,
           fromLocation = Location(LocationType.CC, "TEST2", "TEST2"),


### PR DESCRIPTION
**Changes:**

Non-functional change.

Refactoring naming to be consistent around price adjustments.  All references to 'uplift' now refer to 'adjustment' instead.