### PR TITLE
P4-3084 supressing false positve OWASP lang tag.

### DIFF
--- a/calculate-journey-variable-payments-suppressions.xml
+++ b/calculate-journey-variable-payments-suppressions.xml
@@ -14,4 +14,11 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.xmlgraphics/batik\-i18n@.*$</packageUrl>
         <cve>CVE-2020-7791</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+    file name: lang-tag-1.5.jar
+    ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.nimbusds/lang\-tag@.*$</packageUrl>
+        <cve>CVE-2020-23171</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
**Changes:**

Minor change (suppression) for CVE that does not affect CJVP.  There is no update available for this transitive dependency. 