### PR TITLE
P4 3086 add new columns for price adjustment

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/AnnualPriceAdjuster.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/AnnualPriceAdjuster.kt
@@ -48,11 +48,13 @@ class AnnualPriceAdjuster(
    *
    * Returns the ID of the lock (if successfully created).
    */
-  internal fun attemptLockForPriceAdjustment(supplier: Supplier) =
+  internal fun attemptLockForPriceAdjustment(supplier: Supplier, multiplier: Double, effectiveYear: Int) =
     priceAdjustmentRepository.saveAndFlush(
       PriceAdjustment(
         supplier = supplier,
-        addedAt = timeSource.dateTime()
+        addedAt = timeSource.dateTime(),
+        multiplier = multiplier,
+        effectiveYear = effectiveYear
       )
     ).id
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceAdjustment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceAdjustment.kt
@@ -38,5 +38,11 @@ data class PriceAdjustment(
   val supplier: Supplier,
 
   @Column(name = "added_at", nullable = false)
-  val addedAt: LocalDateTime = LocalDateTime.now()
+  val addedAt: LocalDateTime = LocalDateTime.now(),
+
+  @Column(name = "effective_year", nullable = false)
+  val effectiveYear: Int,
+
+  @Column(name = "multiplier", nullable = false)
+  val multiplier: Double
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceAdjustmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceAdjustmentRepository.kt
@@ -6,7 +6,5 @@ import java.util.UUID
 interface PriceAdjustmentRepository : JpaRepository<PriceAdjustment, UUID> {
   fun findBySupplier(supplier: Supplier): PriceAdjustment?
 
-  fun deleteBySupplier(supplier: Supplier)
-
   fun existsPriceAdjustmentBySupplier(supplier: Supplier): Boolean
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AnnualPriceAdjustmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AnnualPriceAdjustmentsService.kt
@@ -43,7 +43,7 @@ class AnnualPriceAdjustmentsService(
   private fun doAdjustment(supplier: Supplier, effectiveYear: Int, multiplier: Double) = runBlocking {
     launch {
       Result.runCatching {
-        val lockId = annualPriceAdjuster.attemptLockForPriceAdjustment(supplier)
+        val lockId = annualPriceAdjuster.attemptLockForPriceAdjustment(supplier, multiplier, effectiveYear)
 
         annualPriceAdjuster.adjust(
           lockId,

--- a/src/main/resources/db/migration/ddl/V1_12__add_multiplier_and_effective_year_columns_to_price_adjustments.sql
+++ b/src/main/resources/db/migration/ddl/V1_12__add_multiplier_and_effective_year_columns_to_price_adjustments.sql
@@ -1,0 +1,5 @@
+alter table price_adjustments add column if not exists multiplier double precision;
+alter table price_adjustments add column if not exists effective_year integer;
+
+alter table price_adjustments alter column multiplier set not null;
+alter table price_adjustments alter column effective_year set not null;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/AnnualPriceAdjusterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/AnnualPriceAdjusterTest.kt
@@ -44,16 +44,18 @@ internal class AnnualPriceAdjusterTest {
 
   @Test
   fun `attempted lock for GEOAmey adjustment is successful`() {
-    val expectedPriceAdjustment = PriceAdjustment(supplier = Supplier.GEOAMEY, addedAt = timeSource.dateTime())
+    val expectedPriceAdjustment = PriceAdjustment(supplier = Supplier.GEOAMEY, addedAt = timeSource.dateTime(), multiplier = 1.5, effectiveYear = 2020)
     whenever(priceAdjustmentRepository.saveAndFlush(any())).thenReturn(expectedPriceAdjustment)
 
-    val actualLockId = priceAdjuster.attemptLockForPriceAdjustment(Supplier.GEOAMEY)
+    val actualLockId = priceAdjuster.attemptLockForPriceAdjustment(Supplier.GEOAMEY, 1.5, 2020)
 
     verify(priceAdjustmentRepository).saveAndFlush(priceAdjusterCaptor.capture())
 
     with(priceAdjusterCaptor.firstValue) {
       assertThat(supplier).isEqualTo(Supplier.GEOAMEY)
       assertThat(addedAt).isEqualTo(timeSource.dateTime())
+      assertThat(multiplier).isEqualTo(1.5)
+      assertThat(effectiveYear).isEqualTo(2020)
     }
 
     assertThat(actualLockId).isEqualTo(expectedPriceAdjustment.id)
@@ -61,16 +63,18 @@ internal class AnnualPriceAdjusterTest {
 
   @Test
   fun `attempted lock required for Serco adjustment is successful`() {
-    val expectedPriceAdjustment = PriceAdjustment(supplier = Supplier.SERCO, addedAt = timeSource.dateTime())
+    val expectedPriceAdjustment = PriceAdjustment(supplier = Supplier.SERCO, addedAt = timeSource.dateTime(), multiplier = 2.0, effectiveYear = 2021)
     whenever(priceAdjustmentRepository.saveAndFlush(any())).thenReturn(expectedPriceAdjustment)
 
-    val actualLockId = priceAdjuster.attemptLockForPriceAdjustment(Supplier.SERCO)
+    val actualLockId = priceAdjuster.attemptLockForPriceAdjustment(Supplier.SERCO, 2.0, 2021)
 
     verify(priceAdjustmentRepository).saveAndFlush(priceAdjusterCaptor.capture())
 
     with(priceAdjusterCaptor.firstValue) {
       assertThat(supplier).isEqualTo(Supplier.SERCO)
       assertThat(addedAt).isEqualTo(timeSource.dateTime())
+      assertThat(multiplier).isEqualTo(2.0)
+      assertThat(effectiveYear).isEqualTo(2021)
     }
 
     assertThat(actualLockId).isEqualTo(expectedPriceAdjustment.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceAdjustmentRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceAdjustmentRepositoryTest.kt
@@ -21,7 +21,7 @@ internal class PriceAdjustmentRepositoryTest {
   fun `can create price adjustment for Serco and retrieve by supplier`() {
     assertThat(repository.findBySupplier(Supplier.SERCO)).isNull()
 
-    val persisted = repository.save(PriceAdjustment(supplier = Supplier.SERCO))
+    val persisted = repository.save(PriceAdjustment(supplier = Supplier.SERCO, multiplier = 1.5, effectiveYear = 2020))
 
     entityManager.flush()
 
@@ -32,7 +32,7 @@ internal class PriceAdjustmentRepositoryTest {
   fun `price adjustment is in progress for Serco and exists by supplier`() {
     assertThat(repository.existsPriceAdjustmentBySupplier(Supplier.SERCO)).isFalse
 
-    repository.save(PriceAdjustment(supplier = Supplier.SERCO))
+    repository.save(PriceAdjustment(supplier = Supplier.SERCO, multiplier = 1.2, effectiveYear = 2021))
 
     entityManager.flush()
 
@@ -43,7 +43,7 @@ internal class PriceAdjustmentRepositoryTest {
   fun `can create price adjustment for GEOAmey and retrieve by supplier`() {
     assertThat(repository.findBySupplier(Supplier.GEOAMEY)).isNull()
 
-    val persisted = repository.save(PriceAdjustment(supplier = Supplier.GEOAMEY))
+    val persisted = repository.save(PriceAdjustment(supplier = Supplier.GEOAMEY, multiplier = 2.0, effectiveYear = 2022))
 
     entityManager.flush()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceAdjustmentRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/price/PriceAdjustmentRepositoryTest.kt
@@ -1,11 +1,13 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.price
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.test.context.ActiveProfiles
+import java.util.UUID
 
 @ActiveProfiles("test")
 @DataJpaTest
@@ -14,16 +16,11 @@ internal class PriceAdjustmentRepositoryTest {
   @Autowired
   lateinit var repository: PriceAdjustmentRepository
 
-  @Autowired
-  lateinit var entityManager: TestEntityManager
-
   @Test
   fun `can create price adjustment for Serco and retrieve by supplier`() {
     assertThat(repository.findBySupplier(Supplier.SERCO)).isNull()
 
-    val persisted = repository.save(PriceAdjustment(supplier = Supplier.SERCO, multiplier = 1.5, effectiveYear = 2020))
-
-    entityManager.flush()
+    val persisted = repository.saveAndFlush(PriceAdjustment(supplier = Supplier.SERCO, multiplier = 1.5, effectiveYear = 2020))
 
     assertThat(repository.findBySupplier(Supplier.SERCO)).isEqualTo(persisted)
   }
@@ -32,9 +29,7 @@ internal class PriceAdjustmentRepositoryTest {
   fun `price adjustment is in progress for Serco and exists by supplier`() {
     assertThat(repository.existsPriceAdjustmentBySupplier(Supplier.SERCO)).isFalse
 
-    repository.save(PriceAdjustment(supplier = Supplier.SERCO, multiplier = 1.2, effectiveYear = 2021))
-
-    entityManager.flush()
+    repository.saveAndFlush(PriceAdjustment(supplier = Supplier.SERCO, multiplier = 1.2, effectiveYear = 2021))
 
     assertThat(repository.existsPriceAdjustmentBySupplier(Supplier.SERCO)).isTrue
   }
@@ -43,10 +38,18 @@ internal class PriceAdjustmentRepositoryTest {
   fun `can create price adjustment for GEOAmey and retrieve by supplier`() {
     assertThat(repository.findBySupplier(Supplier.GEOAMEY)).isNull()
 
-    val persisted = repository.save(PriceAdjustment(supplier = Supplier.GEOAMEY, multiplier = 2.0, effectiveYear = 2022))
-
-    entityManager.flush()
+    val persisted = repository.saveAndFlush(PriceAdjustment(supplier = Supplier.GEOAMEY, multiplier = 2.0, effectiveYear = 2022))
 
     assertThat(repository.findBySupplier(Supplier.GEOAMEY)).isEqualTo(persisted)
+  }
+
+  @Test
+  fun `can only have one price adjustment for a supplier at any given point in time`() {
+    assertThat(repository.findBySupplier(Supplier.SERCO)).isNull()
+
+    val priceAdjustment = repository.saveAndFlush(PriceAdjustment(supplier = Supplier.SERCO, multiplier = 1.5, effectiveYear = 2020))
+
+    assertThatThrownBy { repository.saveAndFlush(priceAdjustment.copy(id = UUID.randomUUID())) }
+      .isInstanceOf(DataIntegrityViolationException::class.java)
   }
 }


### PR DESCRIPTION
**Changes:**

Small change to add extra columns to the price adjustment for alerting purposes.

An example of this would be a bulk price adjustment is in progress and we want to display a message on the UI to inform the end users.