### PR TITLE
P4 3122 only show adjustment history if prior to current effective year

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/AnnualPriceAdjustmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/AnnualPriceAdjustmentsController.kt
@@ -15,6 +15,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.auditing.AnnualPriceAdjustmentMetadata
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.auditing.AuditEvent
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.auditing.AuditableEvent
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.EffectiveYear
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.AnnualPriceAdjustmentsService
 import java.time.LocalDateTime
@@ -29,7 +30,8 @@ import javax.validation.constraints.Pattern
 @SessionAttributes(DATE_ATTRIBUTE, SUPPLIER_ATTRIBUTE)
 @PreAuthorize("hasRole('PECS_MAINTAIN_PRICE')")
 class AnnualPriceAdjustmentsController(
-  private val annualPriceAdjustmentsService: AnnualPriceAdjustmentsService
+  private val annualPriceAdjustmentsService: AnnualPriceAdjustmentsService,
+  private val actualEffectiveYear: EffectiveYear
 ) {
 
   private val logger = LoggerFactory.getLogger(javaClass)
@@ -37,6 +39,13 @@ class AnnualPriceAdjustmentsController(
   @GetMapping(ANNUAL_PRICE_ADJUSTMENT)
   fun index(model: ModelMap, @ModelAttribute(name = SUPPLIER_ATTRIBUTE) supplier: Supplier): Any {
     logger.info("getting annual price adjustment")
+
+    if (model.getEffectiveYear().isBefore(actualEffectiveYear)) {
+      model.addContractStartAndEndDates()
+      model.addAttribute("history", priceAdjustmentHistoryFor(supplier))
+
+      return "annual-price-adjustment-history"
+    }
 
     model.apply {
       addContractStartAndEndDates()
@@ -46,6 +55,8 @@ class AnnualPriceAdjustmentsController(
 
     return "annual-price-adjustment"
   }
+
+  private fun Int.isBefore(effectiveYear: EffectiveYear): Boolean = this < effectiveYear.current()
 
   @PostMapping(ANNUAL_PRICE_ADJUSTMENT)
   fun applyAnnualPriceAdjustment(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/AnnualPriceAdjustmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/AnnualPriceAdjustmentsController.kt
@@ -40,7 +40,7 @@ class AnnualPriceAdjustmentsController(
   fun index(model: ModelMap, @ModelAttribute(name = SUPPLIER_ATTRIBUTE) supplier: Supplier): Any {
     logger.info("getting annual price adjustment")
 
-    if (model.getEffectiveYear().isBefore(actualEffectiveYear)) {
+    if (model.getSelectedEffectiveYear().isBefore(actualEffectiveYear)) {
       model.addContractStartAndEndDates()
       model.addAttribute("history", priceAdjustmentHistoryFor(supplier))
 
@@ -80,7 +80,7 @@ class AnnualPriceAdjustmentsController(
       return "annual-price-adjustment"
     }
 
-    annualPriceAdjustmentsService.adjust(supplier, model.getEffectiveYear(), mayBeRate, authentication, form.details!!)
+    annualPriceAdjustmentsService.adjust(supplier, model.getSelectedEffectiveYear(), mayBeRate, authentication, form.details!!)
 
     return "manage-journey-price-catalogue"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ManageJourneyPriceCatalogueController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ManageJourneyPriceCatalogueController.kt
@@ -56,7 +56,7 @@ class ManageJourneyPriceCatalogueController(@Autowired val journeyService: Journ
       return RedirectView(SEARCH_JOURNEYS_URL)
     }
 
-    val effectiveYear = model.getEffectiveYear()
+    val effectiveYear = model.getSelectedEffectiveYear()
     val journeys = journeyService.prices(supplier, pickUpLocation, dropOffLocation, effectiveYear)
 
     model.addAttribute("contractualYearStart", "$effectiveYear")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ModelMapDecorator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ModelMapDecorator.kt
@@ -8,13 +8,13 @@ import java.time.LocalDate
 internal fun ModelMap.getEndOfMonth() = endOfMonth(getStartOfMonth())
 
 internal fun ModelMap.addContractStartAndEndDates() {
-  getEffectiveYear().also {
+  getSelectedEffectiveYear().also {
     this.addAttribute("contractualYearStart", "$it")
     this.addAttribute("contractualYearEnd", "${it + 1}")
   }
 }
 
-internal fun ModelMap.getEffectiveYear() = effectiveYearForDate(getStartOfMonth())
+internal fun ModelMap.getSelectedEffectiveYear() = effectiveYearForDate(getStartOfMonth())
 
 internal fun ModelMap.getStartOfMonth() =
   this.getAttribute(DATE_ATTRIBUTE)?.let { it as LocalDate }

--- a/src/main/resources/templates/annual-price-adjustment-history.html
+++ b/src/main/resources/templates/annual-price-adjustment-history.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+
+<head>
+  <title>Calculate Journey Variable Payments - GOV.UK</title>
+</head>
+
+<body>
+
+<div class="govuk-width-container" layout:fragment="content">
+  <div th:insert="fragments/contractual-year.html :: contractualYear"></div>
+
+  <a href="/manage-journey-price-catalogue" class="govuk-back-link">Back</a>
+
+  <h2 class="govuk-heading-l">Price adjustment history</h2>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Date</th>
+      <th scope="col" class="govuk-table__header">Time</th>
+      <th scope="col" class="govuk-table__header">Action</th>
+      <th scope="col" class="govuk-table__header">By</th>
+      <th scope="col" class="govuk-table__header">Notes</th>
+    </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <tr class="govuk-table__row" th:each="event: ${history}">
+      <td class="govuk-table__cell" scope="row" th:inline="text">[[${#temporals.format(event.datetime, 'dd MMMM yyyy')}]]</td>
+      <td class="govuk-table__cell" scope="row" th:inline="text">[[${#temporals.format(event.datetime, 'HH:mm a')}]]</td>
+      <td class="govuk-table__cell" scope="row" th:inline="text">[[${event.action}]]</td>
+      <td class="govuk-table__cell" scope="row" th:inline="text">[[${event.by}]]</td>
+      <td class="govuk-table__cell" scope="row" th:inline="text">[[${event.details}]]</td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+
+</body>
+
+</html>

--- a/src/main/resources/templates/annual-price-adjustment.html
+++ b/src/main/resources/templates/annual-price-adjustment.html
@@ -82,7 +82,7 @@
       </form>
     </div>
     <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="price-adjustment-history">
-      <h2 class="govuk-heading-l">Price history</h2>
+      <h2 class="govuk-heading-l">Price adjustment history</h2>
       <table class="govuk-table">
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ManagePricesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ManagePricesTest.kt
@@ -60,6 +60,10 @@ internal class ManagePricesTest : IntegrationTest() {
 
     isAtPage(ChooseSupplier).choose(Supplier.GEOAMEY)
 
+    isAtPage(Dashboard).navigateToSelectMonthPage()
+
+    isAtPage(SelectMonthYear).navigateToDashboardFor("dec 2020")
+
     isAtPage(Dashboard).navigateToManageJourneyPrice()
 
     isAtPage(ManageJourneyPriceCatalogue).navigateToFindJourneys()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingServiceTest.kt
@@ -146,7 +146,7 @@ internal class SupplierPricingServiceTest {
         Supplier.SERCO,
         fromLocation,
         toLocation,
-        2020
+        effectiveYear
       )
     ).thenReturn(price)
     whenever(priceRepository.save(any())).thenReturn(price)
@@ -172,7 +172,7 @@ internal class SupplierPricingServiceTest {
         Supplier.SERCO,
         fromLocation,
         toLocation,
-        2020
+        effectiveYear
       )
     ).thenReturn(price)
     whenever(priceRepository.save(any())).thenReturn(price)


### PR DESCRIPTION
**Changes:**

Price adjustments can only be run for the current effective year or later.  Anything prior to this upon navigation to the price adjustments page the user will only see the price adjustments history.

Example screenshot below:

![image](https://user-images.githubusercontent.com/60104344/131687780-613b41c3-6095-4b68-80fa-698e0bf743a5.png)
