### PR TITLE
P4-3176 tightening up validation around price submissions. There was a bug in the front end controller allowing zero prices through.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/AnnualPriceAdjustmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/AnnualPriceAdjustmentsController.kt
@@ -95,7 +95,7 @@ class AnnualPriceAdjustmentsController(
       .sortedByDescending { lh -> lh.datetime }
 
   data class AnnualPriceAdjustmentForm(
-    @get: Pattern(regexp = "^[0-9]{1,5}(\\.[0-9]{0,4})?\$", message = "Invalid rate")
+    @get: Pattern(regexp = "^[0-9](\\.[0-9]{0,4})?\$", message = "Invalid rate")
     val rate: String?,
 
     @get: NotEmpty(message = "Enter details upto 255 characters")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingController.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.service.SupplierPricingService
 import java.time.LocalDate
 import javax.validation.Valid
 import javax.validation.constraints.NotNull
+import javax.validation.constraints.Pattern
 
 @Controller
 @SessionAttributes(
@@ -37,7 +38,7 @@ class MaintainSupplierPricingController(@Autowired val supplierPricingService: S
   data class PriceForm(
     @get: NotNull(message = "Invalid message id")
     val moveId: String,
-    @get: NotNull(message = "Add a price")
+    @get: Pattern(regexp = "^[0-9]{1,4}(\\.[0-9]{0,2})?\$", message = "Invalid rate")
     val price: String,
     val from: String?,
     val to: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/Price.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/Price.kt
@@ -50,6 +50,15 @@ data class Price(
   @Column(name = "effective_year", nullable = false)
   val effectiveYear: Int
 ) {
+
+  init {
+    failOnZeroOrLessPrice()
+  }
+
+  private fun failOnZeroOrLessPrice() {
+    if (priceInPence < 1) throw IllegalArgumentException("Price in pence must be greater than zero.")
+  }
+
   fun journey() = "${fromLocation.nomisAgencyId}-${toLocation.nomisAgencyId}"
 
   fun price() = Money(priceInPence)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AnnualPriceAdjustmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AnnualPriceAdjustmentsService.kt
@@ -42,6 +42,8 @@ class AnnualPriceAdjustmentsService(
       throw RuntimeException("Price adjustments cannot be before the current effective year ${actualEffectiveYear.current()}.")
     }
 
+    if (multiplier >= 10) throw RuntimeException("Max allowed multiplier exceeded.")
+
     logger.info("Starting price adjustment for $supplier for effective year $suppliedEffective using multiplier $multiplier.")
 
     doAdjustment(supplier, suppliedEffective, multiplier, authentication, details)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/PriceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/PriceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.domain.price
 
 import com.nhaarman.mockitokotlin2.mock
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -20,8 +21,19 @@ internal class PriceTest {
 
   @Test
   fun `new instance is created with relevant attributes changed upon price adjustment`() {
-    val originalPrice = Price(supplier = Supplier.SERCO, fromLocation = mock(), toLocation = mock(), effectiveYear = 2020, priceInPence = 1000, addedAt = LocalDate.of(2020, 7, 27).atStartOfDay())
-    val adjustedPrice = originalPrice.adjusted(amount = Money(2000), effectiveYear = 2021, addedAt = LocalDate.of(2021, 7, 27).atStartOfDay())
+    val originalPrice = Price(
+      supplier = Supplier.SERCO,
+      fromLocation = mock(),
+      toLocation = mock(),
+      effectiveYear = 2020,
+      priceInPence = 1000,
+      addedAt = LocalDate.of(2020, 7, 27).atStartOfDay()
+    )
+    val adjustedPrice = originalPrice.adjusted(
+      amount = Money(2000),
+      effectiveYear = 2021,
+      addedAt = LocalDate.of(2021, 7, 27).atStartOfDay()
+    )
 
     with(originalPrice) {
       assertThat(this).isNotSameAs(adjustedPrice)
@@ -41,5 +53,41 @@ internal class PriceTest {
       assertThat(effectiveYear).isEqualTo(2021)
       assertThat(addedAt).isEqualTo(LocalDate.of(2021, 7, 27).atStartOfDay())
     }
+  }
+
+  @Test
+  fun `cannot create price less than one pence`() {
+    Price(
+      supplier = Supplier.SERCO,
+      fromLocation = mock(),
+      toLocation = mock(),
+      effectiveYear = 2020,
+      priceInPence = 1,
+      addedAt = LocalDate.of(2020, 7, 27).atStartOfDay()
+    )
+
+    assertThatThrownBy {
+      Price(
+        supplier = Supplier.SERCO,
+        fromLocation = mock(),
+        toLocation = mock(),
+        effectiveYear = 2020,
+        priceInPence = 0,
+        addedAt = LocalDate.of(2020, 7, 27).atStartOfDay()
+      )
+    }
+      .isInstanceOf(IllegalArgumentException::class.java)
+
+    assertThatThrownBy {
+      Price(
+        supplier = Supplier.SERCO,
+        fromLocation = mock(),
+        toLocation = mock(),
+        effectiveYear = 2020,
+        priceInPence = -1,
+        addedAt = LocalDate.of(2020, 7, 27).atStartOfDay()
+      )
+    }
+      .isInstanceOf(IllegalArgumentException::class.java)
   }
 }


### PR DESCRIPTION
**Changes:**

Updating the frontend and backend validation to tighten up the logic around price submission/changes.  A zero price will cause the spreadsheet download to fail.

Also put some (sensible?) limits on the max values allowed for prices and price adjustments.

What his boils down to is as follows:

Min  journey price 0.01
Max journey price 9999.99
Max adjustment rate 9.9999
