### PR TITLE
P4 3095 add price warnings feature

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ModelMapDecorator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ModelMapDecorator.kt
@@ -5,6 +5,9 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.effectiveYearForDate
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.endOfMonth
 import java.time.LocalDate
 
+/**
+ * Decorates the ModalMap with extension functions for the most common calls/needs in the controller classes.
+ */
 internal fun ModelMap.getEndOfMonth() = endOfMonth(getStartOfMonth())
 
 internal fun ModelMap.addContractStartAndEndDates() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingService.kt
@@ -46,22 +46,20 @@ class SupplierPricingService(
     return Pair(fromLocation.siteName, toLocation.siteName)
   }
 
-  fun getExistingSiteNamesAndPrice(
+  fun getMaybeSiteNamesAndPrice(
     supplier: Supplier,
     fromAgencyId: String,
     toAgencyId: String,
     effectiveYear: Int
-  ): Triple<String, String, Money> {
-    val (fromLocation, toLocation) = getFromAndToLocationBy(fromAgencyId, toAgencyId)
-    val price = priceRepository.findBySupplierAndFromLocationAndToLocationAndEffectiveYear(
-      supplier,
-      fromLocation,
-      toLocation,
-      effectiveYear
-    )
-      ?: throw RuntimeException("No matching price found for $supplier")
-
-    return Triple(fromLocation.siteName, toLocation.siteName, Money(price.priceInPence))
+  ): Triple<String, String, Money>? {
+    return getFromAndToLocationBy(fromAgencyId, toAgencyId).let { (from, to) ->
+      priceRepository.findBySupplierAndFromLocationAndToLocationAndEffectiveYear(
+        supplier,
+        from,
+        to,
+        effectiveYear
+      )?.let { Triple(from.siteName, to.siteName, Money(it.priceInPence)) }
+    }
   }
 
   fun addPriceForSupplier(

--- a/src/main/resources/templates/add-price.html
+++ b/src/main/resources/templates/add-price.html
@@ -68,7 +68,10 @@
             <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
             <strong class="govuk-warning-text__text">
                 <span class="govuk-warning-text__assistive">Warning</span>
-                <span th:inline="text">Please note the added price will be effective for all instances of this journey undertaken by [[${supplier}]] in the current contractual year [[${contractualYearStart}]] to [[${contractualYearEnd}]].</span>
+                <div th:each="warning: ${warnings}" >
+                  <span th:inline="text" th:text="${warning.text}"></span>
+                  <p></p>
+                </div>
             </strong>
         </div>
         <div class="flex items-center">

--- a/src/main/resources/templates/update-price.html
+++ b/src/main/resources/templates/update-price.html
@@ -86,7 +86,10 @@
           <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
           <strong class="govuk-warning-text__text">
             <span class="govuk-warning-text__assistive">Warning</span>
-            <span th:inline="text">Please note the added price will be effective for all instances of this journey undertaken by [[${supplier}]] in the current contractual year [[${contractualYearStart}]] to [[${contractualYearEnd}]].</span>
+            <div th:each="warning: ${warnings}" >
+              <span th:inline="text" th:text="${warning.text}"></span>
+              <p></p>
+            </div>
           </strong>
         </div>
         <div class="flex items-center">

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/SupplierPricingServiceTest.kt
@@ -124,7 +124,7 @@ internal class SupplierPricingServiceTest {
       )
     ).thenReturn(price)
 
-    val result = service.getExistingSiteNamesAndPrice(Supplier.SERCO, "from", "to", effectiveYear)
+    val result = service.getMaybeSiteNamesAndPrice(Supplier.SERCO, "from", "to", effectiveYear)
 
     assertThat(result).isEqualTo(Triple("from site", "to site", Money.valueOf(100.24)))
     verify(locationRepository).findByNomisAgencyId("FROM")


### PR DESCRIPTION
**Changes:**

This changes the warnings that are display to a user when adding or updating prices depending on the contractual the price is being added or updated.

![add-price-current-warnings](https://user-images.githubusercontent.com/60104344/132849217-6ebfb548-458b-4fbb-bc89-059940e4b507.png)

![add-price-previous-existing-warnings](https://user-images.githubusercontent.com/60104344/132849237-f0382d13-ceb9-472e-8a7c-ea007c24363d.png)

![add-price-previous-warnings](https://user-images.githubusercontent.com/60104344/132849252-0ae4bf54-6649-4071-a6d5-f2da8dd1284b.png)

**Note: the same logic applies in the update screens.**
