### PR TITLE
P4-3155 changes to include the application survey feeback link on all pages from the dashboard onwards.

### DIFF
--- a/helm_deploy/calculate-journey-variable-payments/templates/_envs.tpl
+++ b/helm_deploy/calculate-journey-variable-payments/templates/_envs.tpl
@@ -130,4 +130,10 @@ env:
   - name: BASM_API_BASE_URL
     value: "{{ .Values.env.BASM_API_BASE_URL }}"
 
+  - name: FEEDBACK_URL
+    valueFrom:
+      secretKeyRef:
+        name: "{{ .Values.feedback.secret_name }}"
+        key: feedback_url
+
 {{- end -}}

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,6 +14,9 @@ db:
 sentry:
   secret_name: calculate-journey-variable-payments-sentry
 
+feedback:
+  secret_name: calculate-journey-variable-payments-feedback
+
 ingress:
   enabled: true
   enable_whitelist: false

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,6 +14,9 @@ db:
 sentry:
   secret_name: calculate-journey-variable-payments-sentry
 
+feedback:
+  secret_name: calculate-journey-variable-payments-feedback
+
 ingress:
   enabled: true
   enable_whitelist: false

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -14,6 +14,9 @@ db:
 sentry:
   secret_name: calculate-journey-variable-payments-sentry
 
+feedback:
+  secret_name: calculate-journey-variable-payments-feedback
+
 ingress:
   enabled: true
   enable_whitelist: false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/GlobalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/GlobalController.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.controller
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ModelAttribute
+
+/**
+ * Applies global level access/information to all controllers where such things are needed.
+ */
+@ControllerAdvice
+class GlobalController {
+
+  @Value("\${FEEDBACK_URL:#}")
+  private lateinit var feedbackUrl: String
+
+  @ModelAttribute("feedbackUrl")
+  fun feedbackUrl() = feedbackUrl.ifBlank { '#' }
+}

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -723,3 +723,23 @@
 .govuk-notification-banner--success .govuk-notification-banner__link:focus {
   color:#0b0c0c
 }
+
+.app-feedback-prompt {
+  margin-left: auto;
+  margin-right: auto;
+  background: #1d70b8;
+  max-width: 960px;
+}
+.app-feedback-prompt__content {
+  color:#fff;
+  font-weight:700;
+  margin:0;
+  padding:25px
+}
+.app-feedback-prompt__content a,
+.app-feedback-prompt__content a:active,
+.app-feedback-prompt__content a:hover,
+.app-feedback-prompt__content a:link,
+.app-feedback-prompt__content a:visited {
+  color:#fff
+}

--- a/src/main/resources/templates/layout/base.html
+++ b/src/main/resources/templates/layout/base.html
@@ -71,6 +71,12 @@
 
         <div layout:fragment="content"></div>
 
+        <div class="govuk-width-container app-feedback-prompt">
+          <div class="app-feedback-prompt__content">
+            <p>Help us improve this service — <a th:href="${feedbackUrl}" th:target="${feedbackUrl=='#' ? '_self' : '_blank'}" rel="noopener noreferrer">give us your feedback</a></p>
+          </div>
+        </div>
+
         <footer class="govuk-footer mt4 " role="contentinfo">
             <div class="govuk-width-container ">
                 <div class="govuk-footer__meta">

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/AnnualPriceAdjustmentsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/AnnualPriceAdjustmentsControllerTest.kt
@@ -63,6 +63,8 @@ class AnnualPriceAdjustmentsControllerTest(@Autowired private val wac: WebApplic
       .andExpect { model { attribute("contractualYearStart", effectiveYearForDate(effectiveDate).toString()) } }
       .andExpect { model { attribute("contractualYearEnd", (effectiveYearForDate(effectiveDate) + 1).toString()) } }
       .andExpect { model { attributeExists("history") } }
+      // including check for the feedback URL
+      .andExpect { model { attribute("feedbackUrl", "#") } }
       .andExpect { status { isOk() } }
 
     verify(adjustmentsService).adjustmentsHistoryFor(Supplier.SERCO)


### PR DESCRIPTION
**Changes:**

Add an application wide feedback link to the bottom of all pages from the dashboard on-wards.  Note for development and pre-prod the links will not go anywhere.  This pulls in an env variable from the Kubernettes config (which you cannot see in this PR).

![image](https://user-images.githubusercontent.com/60104344/133108381-8a83f1b0-2a9a-4fc3-a8b0-686a8d415ef7.png)
