### PR TITLE
P4-3155 adding missing font for feedback link in page footer.

### DIFF
--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -725,6 +725,7 @@
 }
 
 .app-feedback-prompt {
+  font-family:"GDS Transport",arial,sans-serif;
   margin-left: auto;
   margin-right: auto;
   background: #1d70b8;


### PR DESCRIPTION
**Changes:**

Adding missing GDS transport font for the feedback link/footer.