### PR TITLE
P4 3147 refactoring integration test data

### DIFF
--- a/src/main/kotlin/db/migration/data/dev/R__2_5_Integration_test_data.kt
+++ b/src/main/kotlin/db/migration/data/dev/R__2_5_Integration_test_data.kt
@@ -50,12 +50,12 @@ class R__2_5_Integration_test_data : BaseJavaMigration() {
       "SM3" to "PR3"
     ).forEach {
       create(
-        move(moveId = it.key, profileId = it.value, fromAgencyId = "FROM_AGENCY", toAgencyId = "TO_AGENCY"),
+        move(moveId = it.key, profileId = it.value, fromAgencyId = "PRISON1", toAgencyId = "PRISON2"),
         template
       ).also { move ->
         create(moveStartEvent(move), template)
         create(moveCompleteEvent(move), template)
-        create(journey(move, fromAgencyId = "FROM_AGENCY", toAgencyId = "TO_AGENCY"), template).also { journey ->
+        create(journey(move, fromAgencyId = "PRISON1", toAgencyId = "PRISON2"), template).also { journey ->
           create(journeyStartEvent(journey), template)
           create(journeyCompleteEvent(journey), template)
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/AnnualBulkPriceAdjustmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/AnnualBulkPriceAdjustmentTest.kt
@@ -16,7 +16,7 @@ internal class AnnualBulkPriceAdjustmentTest : IntegrationTest() {
 
     isAtPage(Login).login()
 
-    isAtPage(ChooseSupplier).choose(Supplier.GEOAMEY)
+    isAtPage(ChooseSupplier).choose(Supplier.SERCO)
 
     isAtPage(Dashboard).navigateToManageJourneyPrice()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ManageLocationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ManageLocationsTest.kt
@@ -15,60 +15,64 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.ManageLocat
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.MapLocation
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.SearchLocations
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.SelectMonthYear
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.previousMonth
 import java.time.LocalDate
-import java.time.Month
 import java.time.Year
 
 @TestMethodOrder(OrderAnnotation::class)
 internal class ManageLocationsTest : IntegrationTest() {
 
+  private val currentDate = LocalDate.now()
+
+  private val year = Year.now()
+
   @Test
   @Order(1)
-  fun `map missing location name and location type to agency id WYI`() {
+  fun `map missing location name and location type to agency id FROM_AGENCY`() {
     goToPage(Dashboard)
 
     isAtPage(Login).login()
 
-    isAtPage(ChooseSupplier).choose(Supplier.GEOAMEY)
+    isAtPage(ChooseSupplier).choose(Supplier.SERCO)
 
     isAtPage(Dashboard)
-      .isAtMonthYear(LocalDate.now().month, Year.now())
+      .isAtMonthYear(currentDate.month, year)
       .navigateToSelectMonthPage()
 
-    isAtPage(SelectMonthYear).navigateToDashboardFor("dec 2020")
+    isAtPage(SelectMonthYear).navigateToDashboardFor(currentDate.previousMonth(), year)
 
     isAtPage(Dashboard)
-      .isAtMonthYear(Month.DECEMBER, Year.of(2020))
+      .isAtMonthYear(currentDate.previousMonth(), year)
       .navigateToJourneysForReview()
 
-    isAtPage(JourneysForReview).chooseLocationToMap("WYI")
+    isAtPage(JourneysForReview).chooseLocationToMap("FROM_AGENCY")
 
     isAtPage(MapLocation)
-      .isAtMapLocationPageForAgency("WYI")
-      .mapLocation("a prison", LocationType.PR)
+      .isAtMapLocationPageForAgency("FROM_AGENCY")
+      .mapLocation("from agenc", LocationType.PR)
 
     isAtPage(JourneysForReview)
-      .isLocationUpdatedMessagePresent("WYI", "A PRISON")
-      .isRowPresent<JourneysForReviewPage>("A PRISON", LocationType.PR.name)
+      .isLocationUpdatedMessagePresent("FROM_AGENCY", "FROM AGENC")
+      .isRowPresent<JourneysForReviewPage>("FROM AGENC", LocationType.PR.name)
   }
 
   @Test
   @Order(2)
-  fun `update location name and type for agency id WYI`() {
+  fun `update location name and type for agency id FROM_AGENCY`() {
     goToPage(Dashboard)
 
     isAtPage(Login).login()
 
-    isAtPage(ChooseSupplier).choose(Supplier.GEOAMEY)
+    isAtPage(ChooseSupplier).choose(Supplier.SERCO)
 
     isAtPage(Dashboard).navigateToManageLocations()
 
-    isAtPage(SearchLocations).searchForLocation("A PRISON")
+    isAtPage(SearchLocations).searchForLocation("FROM AGENC")
 
     isAtPage(ManageLocation)
-      .isAtManageLocationPageForAgency("WYI")
-      .updateLocation("A POLICE STATION", LocationType.PS)
+      .isAtManageLocationPageForAgency("FROM_AGENCY")
+      .updateLocation("FROM AGENCY", LocationType.PS)
 
-    isAtPage(SearchLocations).isLocationUpdatedMessagePresent("WYI", "A POLICE STATION")
+    isAtPage(SearchLocations).isLocationUpdatedMessagePresent("FROM_AGENCY", "FROM AGENCY")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ManagePricesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ManagePricesTest.kt
@@ -16,30 +16,34 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.ManageJourn
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.ManageJourneyPriceCatalogue
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.SelectMonthYear
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.UpdatePrice
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.previousMonth
 import java.time.LocalDate
-import java.time.Month
 import java.time.Year
 
 @TestMethodOrder(OrderAnnotation::class)
 internal class ManagePricesTest : IntegrationTest() {
 
+  private val currentDate = LocalDate.now()
+
+  private val year = Year.now()
+
   @Test
   @Order(1)
-  fun `missing price is added for GEOAmey journey from Prison One to Prison Two`() {
+  fun `missing price is added for Serco journey from Prison One to Prison Two`() {
     goToPage(Dashboard)
 
     isAtPage(Login).login()
 
-    isAtPage(ChooseSupplier).choose(Supplier.GEOAMEY)
+    isAtPage(ChooseSupplier).choose(Supplier.SERCO)
 
     isAtPage(Dashboard)
-      .isAtMonthYear(LocalDate.now().month, Year.now())
+      .isAtMonthYear(currentDate.month, Year.now())
       .navigateToSelectMonthPage()
 
-    isAtPage(SelectMonthYear).navigateToDashboardFor("dec 2020")
+    isAtPage(SelectMonthYear).navigateToDashboardFor(currentDate.previousMonth(), year)
 
     isAtPage(Dashboard)
-      .isAtMonthYear(Month.DECEMBER, Year.of(2020))
+      .isAtMonthYear(currentDate.previousMonth(), year)
       .navigateToJourneysForReview()
 
     isAtPage(JourneysForReview).addPriceForJourney("PRISON1", "PRISON2")
@@ -53,16 +57,16 @@ internal class ManagePricesTest : IntegrationTest() {
 
   @Test
   @Order(2)
-  fun `price is updated for GEOAmey journey from Prison One to Prison Two`() {
+  fun `price is updated for Serco journey from Prison One to Prison Two`() {
     goToPage(Dashboard)
 
     isAtPage(Login).login()
 
-    isAtPage(ChooseSupplier).choose(Supplier.GEOAMEY)
+    isAtPage(ChooseSupplier).choose(Supplier.SERCO)
 
     isAtPage(Dashboard).navigateToSelectMonthPage()
 
-    isAtPage(SelectMonthYear).navigateToDashboardFor("dec 2020")
+    isAtPage(SelectMonthYear).navigateToDashboardFor(currentDate.previousMonth(), year)
 
     isAtPage(Dashboard).navigateToManageJourneyPrice()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ViewAllMoveTypesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ViewAllMoveTypesTest.kt
@@ -21,20 +21,19 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.SercoPreviousMont
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.SercoPreviousMonthMoveData.multiMoveMM1
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.SercoPreviousMonthMoveData.redirectMoveRM1
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.SercoPreviousMonthMoveData.standardMoveSM1
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.previousMonth
 import java.time.LocalDate
 import java.time.Month
 import java.time.Year
 
 internal class ViewAllMoveTypesTest : IntegrationTest() {
 
-  private val defaultSupplierSerco = Supplier.SERCO
-
-  private val date = LocalDate.now()
+  private val currentDate = LocalDate.now()
 
   private val year = Year.now()
 
   @Test
-  fun `view one of each move type for Serco today`() {
+  fun `view one of each move type for Serco in previous month`() {
     goToPage(Dashboard)
 
     isAtPage(Login).login()
@@ -42,10 +41,10 @@ internal class ViewAllMoveTypesTest : IntegrationTest() {
     isAtPage(ChooseSupplier).choose(Supplier.SERCO)
 
     isAtPage(Dashboard)
-      .isAtMonthYear(date.month, year)
+      .isAtMonthYear(currentDate.month, year)
       .navigateToSelectMonthPage()
 
-    isAtPage(SelectMonthYear).navigateToDashboardFor("${date.previousMonth().name} ${year.value}")
+    isAtPage(SelectMonthYear).navigateToDashboardFor(currentDate.previousMonth(), year)
 
     listOf(
       standardMoveSM1(),
@@ -54,13 +53,11 @@ internal class ViewAllMoveTypesTest : IntegrationTest() {
       lockoutMoveLM1(),
       multiMoveMM1(),
       cancelledMoveCM1()
-    ).forEach { move -> verifyDetailsOf(move, date.previousMonth(), Year.now()) }
+    ).forEach { move -> verifyDetailsOf(move, currentDate.previousMonth(), Year.now()) }
   }
 
-  private fun LocalDate.previousMonth() = this.minusMonths(1).month
-
   @Test
-  fun `view one of each move type for GEOAmey in a previous month (Dec 2020)`() {
+  fun `view one of each move type for GEOAmey in Dec 2020`() {
     goToPage(Dashboard)
 
     isAtPage(Login).login()
@@ -68,10 +65,10 @@ internal class ViewAllMoveTypesTest : IntegrationTest() {
     isAtPage(ChooseSupplier).choose(Supplier.GEOAMEY)
 
     isAtPage(Dashboard)
-      .isAtMonthYear(date.month, year)
+      .isAtMonthYear(currentDate.month, year)
       .navigateToSelectMonthPage()
 
-    isAtPage(SelectMonthYear).navigateToDashboardFor("dec 2020")
+    isAtPage(SelectMonthYear).navigateToDashboardFor(Month.DECEMBER, Year.of(2020))
 
     listOf(
       standardMoveM4(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ViewAllMoveTypesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ViewAllMoveTypesTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.integration
 
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.move.Move
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Supplier
@@ -16,18 +15,23 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.Login
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.MoveDetails
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.MovesByType
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.SelectMonthYear
-import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.PresentDayMoveData.cancelledMoveCM1
-import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.PresentDayMoveData.lockoutMoveLM1
-import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.PresentDayMoveData.longHaulMoveLHM1
-import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.PresentDayMoveData.multiMoveMM1
-import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.PresentDayMoveData.redirectMoveRM1
-import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.PresentDayMoveData.standardMoveSM1
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.SercoPreviousMonthMoveData.cancelledMoveCM1
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.SercoPreviousMonthMoveData.lockoutMoveLM1
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.SercoPreviousMonthMoveData.longHaulMoveLHM1
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.SercoPreviousMonthMoveData.multiMoveMM1
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.SercoPreviousMonthMoveData.redirectMoveRM1
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.SercoPreviousMonthMoveData.standardMoveSM1
 import java.time.LocalDate
 import java.time.Month
 import java.time.Year
 
-@Disabled
 internal class ViewAllMoveTypesTest : IntegrationTest() {
+
+  private val defaultSupplierSerco = Supplier.SERCO
+
+  private val date = LocalDate.now()
+
+  private val year = Year.now()
 
   @Test
   fun `view one of each move type for Serco today`() {
@@ -38,8 +42,10 @@ internal class ViewAllMoveTypesTest : IntegrationTest() {
     isAtPage(ChooseSupplier).choose(Supplier.SERCO)
 
     isAtPage(Dashboard)
-      .isAtMonthYear(LocalDate.now().month, Year.now())
+      .isAtMonthYear(date.month, year)
       .navigateToSelectMonthPage()
+
+    isAtPage(SelectMonthYear).navigateToDashboardFor("${date.previousMonth().name} ${year.value}")
 
     listOf(
       standardMoveSM1(),
@@ -48,8 +54,10 @@ internal class ViewAllMoveTypesTest : IntegrationTest() {
       lockoutMoveLM1(),
       multiMoveMM1(),
       cancelledMoveCM1()
-    ).forEach { move -> verifyDetailsOf(move, LocalDate.now().month, Year.now()) }
+    ).forEach { move -> verifyDetailsOf(move, date.previousMonth(), Year.now()) }
   }
+
+  private fun LocalDate.previousMonth() = this.minusMonths(1).month
 
   @Test
   fun `view one of each move type for GEOAmey in a previous month (Dec 2020)`() {
@@ -60,7 +68,7 @@ internal class ViewAllMoveTypesTest : IntegrationTest() {
     isAtPage(ChooseSupplier).choose(Supplier.GEOAMEY)
 
     isAtPage(Dashboard)
-      .isAtMonthYear(LocalDate.now().month, Year.now())
+      .isAtMonthYear(date.month, year)
       .navigateToSelectMonthPage()
 
     isAtPage(SelectMonthYear).navigateToDashboardFor("dec 2020")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/IntegrationTestDataFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/IntegrationTestDataFactory.kt
@@ -214,18 +214,18 @@ object Dec2020MoveData {
     )
 }
 
-object PresentDayMoveData {
+object SercoPreviousMonthMoveData {
 
-  private val today = LocalDate.now()
+  private val startOfPreviousMonth = LocalDate.now().minusMonths(1).withDayOfMonth(1)
 
-  private val startHoursOffset = 10L
+  private const val startHoursOffset = 10L
 
-  private val endHoursOffset = 12L
+  private const val endHoursOffset = 12L
 
   fun standardMoveSM1() =
     Move(
       moveId = "SM1",
-      updatedAt = today.atStartOfDay(),
+      updatedAt = startOfPreviousMonth.atStartOfDay(),
       supplier = Supplier.SERCO,
       moveType = MoveType.STANDARD,
       status = MoveStatus.completed,
@@ -236,15 +236,15 @@ object PresentDayMoveData {
       toSiteName = "TO_AGENCY", // Test data is not mapped so will default to the agency ID
       reportFromLocationType = "prison",
       reportToLocationType = "prison",
-      pickUpDateTime = today.atStartOfDay().plusHours(startHoursOffset),
-      dropOffOrCancelledDateTime = today.atStartOfDay().plusHours(endHoursOffset),
+      pickUpDateTime = startOfPreviousMonth.atStartOfDay().plusHours(startHoursOffset),
+      dropOffOrCancelledDateTime = startOfPreviousMonth.atStartOfDay().plusHours(endHoursOffset),
       person = billyTheKid
     )
 
   fun redirectMoveRM1() =
     Move(
       moveId = "RM1",
-      updatedAt = today.atStartOfDay(),
+      updatedAt = startOfPreviousMonth.atStartOfDay(),
       supplier = Supplier.SERCO,
       moveType = MoveType.REDIRECTION,
       status = MoveStatus.completed,
@@ -255,15 +255,15 @@ object PresentDayMoveData {
       toSiteName = "TO_AGENCY", // Test data is not mapped so will default to the agency ID
       reportFromLocationType = "prison",
       reportToLocationType = "prison",
-      pickUpDateTime = today.atStartOfDay().plusHours(startHoursOffset),
-      dropOffOrCancelledDateTime = today.atStartOfDay().plusHours(endHoursOffset),
+      pickUpDateTime = startOfPreviousMonth.atStartOfDay().plusHours(startHoursOffset),
+      dropOffOrCancelledDateTime = startOfPreviousMonth.atStartOfDay().plusHours(endHoursOffset),
       person = ronnieBiggs
     )
 
   fun longHaulMoveLHM1() =
     Move(
       moveId = "LHM1",
-      updatedAt = today.atStartOfDay(),
+      updatedAt = startOfPreviousMonth.atStartOfDay(),
       supplier = Supplier.SERCO,
       moveType = MoveType.LONG_HAUL,
       status = MoveStatus.completed,
@@ -274,15 +274,15 @@ object PresentDayMoveData {
       toSiteName = "TO_AGENCY", // Test data is not mapped so will default to the agency ID
       reportFromLocationType = "prison",
       reportToLocationType = "prison",
-      pickUpDateTime = today.atStartOfDay().plusHours(startHoursOffset),
-      dropOffOrCancelledDateTime = today.atStartOfDay().plusHours(endHoursOffset).plusDays(1),
+      pickUpDateTime = startOfPreviousMonth.atStartOfDay().plusHours(startHoursOffset),
+      dropOffOrCancelledDateTime = startOfPreviousMonth.atStartOfDay().plusHours(endHoursOffset).plusDays(1),
       person = fredBloggs
     )
 
   fun lockoutMoveLM1() =
     Move(
       moveId = "LM1",
-      updatedAt = today.atStartOfDay(),
+      updatedAt = startOfPreviousMonth.atStartOfDay(),
       supplier = Supplier.SERCO,
       moveType = MoveType.LOCKOUT,
       status = MoveStatus.completed,
@@ -293,15 +293,15 @@ object PresentDayMoveData {
       toSiteName = "TO_AGENCY", // Test data is not mapped so will default to the agency ID
       reportFromLocationType = "prison",
       reportToLocationType = "prison",
-      pickUpDateTime = today.atStartOfDay().plusHours(startHoursOffset),
-      dropOffOrCancelledDateTime = today.atStartOfDay().plusHours(endHoursOffset).plusDays(1),
+      pickUpDateTime = startOfPreviousMonth.atStartOfDay().plusHours(startHoursOffset),
+      dropOffOrCancelledDateTime = startOfPreviousMonth.atStartOfDay().plusHours(endHoursOffset).plusDays(1),
       person = janeBloggs
     )
 
   fun multiMoveMM1() =
     Move(
       moveId = "MM1",
-      updatedAt = today.atStartOfDay(),
+      updatedAt = startOfPreviousMonth.atStartOfDay(),
       supplier = Supplier.SERCO,
       moveType = MoveType.MULTI,
       status = MoveStatus.completed,
@@ -312,15 +312,15 @@ object PresentDayMoveData {
       toSiteName = "TO_AGENCY", // Test data is not mapped so will default to the agency ID
       reportFromLocationType = "prison",
       reportToLocationType = "prison",
-      pickUpDateTime = today.atStartOfDay().plusHours(startHoursOffset),
-      dropOffOrCancelledDateTime = today.atStartOfDay().plusHours(endHoursOffset).plusDays(1),
+      pickUpDateTime = startOfPreviousMonth.atStartOfDay().plusHours(startHoursOffset),
+      dropOffOrCancelledDateTime = startOfPreviousMonth.atStartOfDay().plusHours(endHoursOffset).plusDays(1),
       person = donaldDuck
     )
 
   fun cancelledMoveCM1() =
     Move(
       moveId = "CM1",
-      updatedAt = today.atStartOfDay(),
+      updatedAt = startOfPreviousMonth.atStartOfDay(),
       supplier = Supplier.SERCO,
       moveType = MoveType.CANCELLED,
       status = MoveStatus.completed,
@@ -331,8 +331,10 @@ object PresentDayMoveData {
       toSiteName = "TO_AGENCY", // Test data is not mapped so will default to the agency ID
       reportFromLocationType = "prison",
       reportToLocationType = "prison",
-      pickUpDateTime = today.atStartOfDay().plusHours(startHoursOffset),
-      dropOffOrCancelledDateTime = today.atStartOfDay().plusHours(endHoursOffset),
+      pickUpDateTime = startOfPreviousMonth.atStartOfDay().plusHours(startHoursOffset),
+      dropOffOrCancelledDateTime = startOfPreviousMonth.atStartOfDay().plusHours(endHoursOffset),
       person = professorMoriarty
     )
 }
+
+internal fun LocalDate.previousMonth() = this.minusMonths(1).month

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/IntegrationTestDataFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/IntegrationTestDataFactory.kt
@@ -11,7 +11,6 @@ import java.time.LocalDateTime
 /**
  * The integration test data comes from the DEV Spring Profile data loaded via the database migration scripts at startup.
  */
-
 private val billyTheKid =
   Person(
     personId = "_",
@@ -230,10 +229,10 @@ object SercoPreviousMonthMoveData {
       moveType = MoveType.STANDARD,
       status = MoveStatus.completed,
       reference = "STANDARDSM1",
-      fromNomisAgencyId = "FROM_AGENCY",
-      fromSiteName = "FROM_AGENCY", // Test data is not mapped so will default to the agency ID
-      toNomisAgencyId = "TO_AGENCY",
-      toSiteName = "TO_AGENCY", // Test data is not mapped so will default to the agency ID
+      fromNomisAgencyId = "PRISON1",
+      fromSiteName = "PRISON ONE",
+      toNomisAgencyId = "PRISON2",
+      toSiteName = "PRISON TWO",
       reportFromLocationType = "prison",
       reportToLocationType = "prison",
       pickUpDateTime = startOfPreviousMonth.atStartOfDay().plusHours(startHoursOffset),
@@ -250,7 +249,7 @@ object SercoPreviousMonthMoveData {
       status = MoveStatus.completed,
       reference = "REDIRECTIONRM1",
       fromNomisAgencyId = "FROM_AGENCY",
-      fromSiteName = "FROM_AGENCY", // Test data is not mapped so will default to the agency ID
+      fromSiteName = "FROM AGENCY",
       toNomisAgencyId = "TO_AGENCY",
       toSiteName = "TO_AGENCY", // Test data is not mapped so will default to the agency ID
       reportFromLocationType = "prison",
@@ -269,7 +268,7 @@ object SercoPreviousMonthMoveData {
       status = MoveStatus.completed,
       reference = "LONG_HAULLHM1",
       fromNomisAgencyId = "FROM_AGENCY",
-      fromSiteName = "FROM_AGENCY", // Test data is not mapped so will default to the agency ID
+      fromSiteName = "FROM AGENCY",
       toNomisAgencyId = "TO_AGENCY",
       toSiteName = "TO_AGENCY", // Test data is not mapped so will default to the agency ID
       reportFromLocationType = "prison",
@@ -288,7 +287,7 @@ object SercoPreviousMonthMoveData {
       status = MoveStatus.completed,
       reference = "LOCKOUTLM1",
       fromNomisAgencyId = "FROM_AGENCY",
-      fromSiteName = "FROM_AGENCY", // Test data is not mapped so will default to the agency ID
+      fromSiteName = "FROM AGENCY",
       toNomisAgencyId = "TO_AGENCY",
       toSiteName = "TO_AGENCY", // Test data is not mapped so will default to the agency ID
       reportFromLocationType = "prison",
@@ -307,7 +306,7 @@ object SercoPreviousMonthMoveData {
       status = MoveStatus.completed,
       reference = "MULTIMM1",
       fromNomisAgencyId = "FROM_AGENCY",
-      fromSiteName = "FROM_AGENCY", // Test data is not mapped so will default to the agency ID
+      fromSiteName = "FROM AGENCY",
       toNomisAgencyId = "TO_AGENCY",
       toSiteName = "TO_AGENCY", // Test data is not mapped so will default to the agency ID
       reportFromLocationType = "prison",
@@ -326,7 +325,7 @@ object SercoPreviousMonthMoveData {
       status = MoveStatus.completed,
       reference = "CANCELLEDCM1",
       fromNomisAgencyId = "FROM_AGENCY",
-      fromSiteName = "FROM_AGENCY", // Test data is not mapped so will default to the agency ID
+      fromSiteName = "FROM AGENCY",
       toNomisAgencyId = "TO_AGENCY",
       toSiteName = "TO_AGENCY", // Test data is not mapped so will default to the agency ID
       reportFromLocationType = "prison",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/SelectMonthYearPage.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/SelectMonthYearPage.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages
 import org.fluentlenium.core.annotation.PageUrl
 import org.fluentlenium.core.domain.FluentWebElement
 import org.openqa.selenium.support.FindBy
+import java.time.Month
+import java.time.Year
 
 @PageUrl("http://localhost:8080/select-month")
 class SelectMonthYearPage : ApplicationPage() {
@@ -13,8 +15,8 @@ class SelectMonthYearPage : ApplicationPage() {
   @FindBy(id = "submit-month-year")
   private lateinit var goToMonthYearButton: FluentWebElement
 
-  fun navigateToDashboardFor(monthYear: String) {
-    this.monthYearField.fill().withText(monthYear)
+  fun navigateToDashboardFor(month: Month, year: Year) {
+    this.monthYearField.fill().withText("${month.name} ${year.value}")
     goToMonthYearButton.submit()
   }
 }


### PR DESCRIPTION
**Changes:**

The fixture data for the integration tests was due a bit of a rethink having noticed some temporal related issues in the CI pipeline.

Previously the move fixture data was actually being set up for the present day.  Whilst the application technically won't grumble about this it is not how it works in practice.  All move data loaded into the real application is historic with the most recent data being the previous days moves.

Move data is priced on a month by month basis.  Any moves that start on the last day of the month and go into the next month fall within the following months prices.  To avoid this complication and ease integration testing I have changed it so the move fixture data starts on the first day of the previous month and stays within that month.

The integration tests are now steered more towards using the Serco fixture data (though not entirely).  The GEO data is at a fixed point in time which will likely cause issues in the future as new functionality is added (for example preventing historic prices changes when more than two years old).