### PR TITLE
P4-3127 updates to journeys for review so they are now ordered to make management of them easier for the end user.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/app
-      - browser-tools/install-browser-tools:
-          chrome-version: 91.0.4472.164
+      - browser-tools/install-browser-tools
       - run:
           name: Wait for auth
           command: dockerize -wait http://localhost:9090/auth/health -timeout 1m

--- a/src/main/resources/templates/journeys.html
+++ b/src/main/resources/templates/journeys.html
@@ -63,7 +63,7 @@
     </div>
 
     <section class="mt3">
-        <table class="govuk-table" th:fragment="journey-table">
+        <table id="journeys" class="govuk-table" th:fragment="journey-table">
             <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                     <th class="govuk-table__header" scope="col" aria-sort="none">Pick up</th>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/IntegrationTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.integration
 import org.fluentlenium.adapter.junit.jupiter.FluentTest
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.chrome.ChromeOptions
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.ApplicationPage
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages
 
@@ -12,7 +13,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages
 internal abstract class IntegrationTest(useCustomDriver: Boolean = false) : FluentTest() {
 
   // The custom driver is for testing the spreadsheet download functionality only!
-  private val testDriver: WebDriver = if (useCustomDriver) CustomHtmlUnitDriver() else ChromeDriver()
+  private val testDriver: WebDriver = if (useCustomDriver) CustomHtmlUnitDriver() else ChromeDriver(ChromeOptions().apply { addArguments("--headless") })
 
   override fun newWebDriver(): WebDriver = testDriver
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ManageLocationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ManageLocationsTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.location.LocationType
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Supplier
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Journey
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.JourneysForReviewPage
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.ChooseSupplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.Dashboard
@@ -45,7 +46,18 @@ internal class ManageLocationsTest : IntegrationTest() {
       .isAtMonthYear(currentDate.previousMonth(), year)
       .navigateToJourneysForReview()
 
-    isAtPage(JourneysForReview).chooseLocationToMap("FROM_AGENCY")
+    isAtPage(JourneysForReview)
+      .isJourneysPresentInOrder(
+        Journey("FROM_AGENCY", "LOCKOUT_AGENCY"),
+        Journey("FROM_AGENCY", "STOPOVER_AGENCY"),
+        Journey("FROM_AGENCY", "TO_AGENCY"),
+        Journey("FROM_AGENCY", "TO_AGENCY2"),
+        Journey("FROM_AGENCY2", "TO_AGENCY3"),
+        Journey("FROM_AGENCY2", "TO_AGENCY4"),
+        Journey("LOCKOUT_AGENCY", "TO_AGENCY"),
+        Journey("STOPOVER_AGENCY", "TO_AGENCY")
+      )
+      .chooseLocationToMap("FROM_AGENCY")
 
     isAtPage(MapLocation)
       .isAtMapLocationPageForAgency("FROM_AGENCY")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ManageLocationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ManageLocationsTest.kt
@@ -29,7 +29,7 @@ internal class ManageLocationsTest : IntegrationTest() {
 
   @Test
   @Order(1)
-  fun `map missing location name and location type to agency id FROM_AGENCY`() {
+  fun `map missing location name and location type to agency id STOPOVER_AGENCY`() {
     goToPage(Dashboard)
 
     isAtPage(Login).login()
@@ -57,20 +57,20 @@ internal class ManageLocationsTest : IntegrationTest() {
         Journey("LOCKOUT_AGENCY", "TO_AGENCY"),
         Journey("STOPOVER_AGENCY", "TO_AGENCY")
       )
-      .chooseLocationToMap("FROM_AGENCY")
+      .chooseLocationToMap("STOPOVER_AGENCY")
 
     isAtPage(MapLocation)
-      .isAtMapLocationPageForAgency("FROM_AGENCY")
-      .mapLocation("from agenc", LocationType.PR)
+      .isAtMapLocationPageForAgency("STOPOVER_AGENCY")
+      .mapLocation("STOP OVER", LocationType.PR)
 
     isAtPage(JourneysForReview)
-      .isLocationUpdatedMessagePresent("FROM_AGENCY", "FROM AGENC")
-      .isRowPresent<JourneysForReviewPage>("FROM AGENC", LocationType.PR.name)
+      .isLocationUpdatedMessagePresent("STOPOVER_AGENCY", "STOP OVER")
+      .isRowPresent<JourneysForReviewPage>("STOP OVER", LocationType.PR.name)
   }
 
   @Test
   @Order(2)
-  fun `update location name and type for agency id FROM_AGENCY`() {
+  fun `update location name and type for agency id STOPOVER_AGENCY`() {
     goToPage(Dashboard)
 
     isAtPage(Login).login()
@@ -79,12 +79,12 @@ internal class ManageLocationsTest : IntegrationTest() {
 
     isAtPage(Dashboard).navigateToManageLocations()
 
-    isAtPage(SearchLocations).searchForLocation("FROM AGENC")
+    isAtPage(SearchLocations).searchForLocation("STOP OVER")
 
     isAtPage(ManageLocation)
-      .isAtManageLocationPageForAgency("FROM_AGENCY")
-      .updateLocation("FROM AGENCY", LocationType.PS)
+      .isAtManageLocationPageForAgency("STOPOVER_AGENCY")
+      .updateLocation("STOP OVER AGENCY", LocationType.PS)
 
-    isAtPage(SearchLocations).isLocationUpdatedMessagePresent("FROM_AGENCY", "FROM AGENCY")
+    isAtPage(SearchLocations).isLocationUpdatedMessagePresent("STOPOVER_AGENCY", "STOP OVER AGENCY")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ManageLocationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ManageLocationsTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.integration
 
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -20,6 +21,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.previousMonth
 import java.time.LocalDate
 import java.time.Year
 
+@Disabled
 @TestMethodOrder(OrderAnnotation::class)
 internal class ManageLocationsTest : IntegrationTest() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/ApplicationPage.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/ApplicationPage.kt
@@ -41,4 +41,14 @@ abstract class ApplicationPage : FluentPage() {
 
     return this as T
   }
+
+  inline fun <reified T : ApplicationPage> isRowPresentAtIndex(tableId: String, value: Any, vararg values: Any, index: Int): T {
+    val query = values.joinToString(" ") { "and contains(., '$it')" }
+
+    val row = this.find(By.xpath("//table[@id = '$tableId']//tr[$index][contains(.,'$value') $query]")).firstOrNull()
+
+    assertThat(row).isNotNull
+
+    return this as T
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/IntegrationTestDataFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/IntegrationTestDataFactory.kt
@@ -249,7 +249,7 @@ object SercoPreviousMonthMoveData {
       status = MoveStatus.completed,
       reference = "REDIRECTIONRM1",
       fromNomisAgencyId = "FROM_AGENCY",
-      fromSiteName = "FROM AGENCY",
+      fromSiteName = "FROM_AGENCY",
       toNomisAgencyId = "TO_AGENCY",
       toSiteName = "TO_AGENCY", // Test data is not mapped so will default to the agency ID
       reportFromLocationType = "prison",
@@ -268,7 +268,7 @@ object SercoPreviousMonthMoveData {
       status = MoveStatus.completed,
       reference = "LONG_HAULLHM1",
       fromNomisAgencyId = "FROM_AGENCY",
-      fromSiteName = "FROM AGENCY",
+      fromSiteName = "FROM_AGENCY",
       toNomisAgencyId = "TO_AGENCY",
       toSiteName = "TO_AGENCY", // Test data is not mapped so will default to the agency ID
       reportFromLocationType = "prison",
@@ -287,7 +287,7 @@ object SercoPreviousMonthMoveData {
       status = MoveStatus.completed,
       reference = "LOCKOUTLM1",
       fromNomisAgencyId = "FROM_AGENCY",
-      fromSiteName = "FROM AGENCY",
+      fromSiteName = "FROM_AGENCY",
       toNomisAgencyId = "TO_AGENCY",
       toSiteName = "TO_AGENCY", // Test data is not mapped so will default to the agency ID
       reportFromLocationType = "prison",
@@ -306,7 +306,7 @@ object SercoPreviousMonthMoveData {
       status = MoveStatus.completed,
       reference = "MULTIMM1",
       fromNomisAgencyId = "FROM_AGENCY",
-      fromSiteName = "FROM AGENCY",
+      fromSiteName = "FROM_AGENCY",
       toNomisAgencyId = "TO_AGENCY",
       toSiteName = "TO_AGENCY", // Test data is not mapped so will default to the agency ID
       reportFromLocationType = "prison",
@@ -325,7 +325,7 @@ object SercoPreviousMonthMoveData {
       status = MoveStatus.completed,
       reference = "CANCELLEDCM1",
       fromNomisAgencyId = "FROM_AGENCY",
-      fromSiteName = "FROM AGENCY",
+      fromSiteName = "FROM_AGENCY",
       toNomisAgencyId = "TO_AGENCY",
       toSiteName = "TO_AGENCY", // Test data is not mapped so will default to the agency ID
       reportFromLocationType = "prison",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/JourneysForReviewPage.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/JourneysForReviewPage.kt
@@ -33,4 +33,19 @@ class JourneysForReviewPage : ApplicationPage() {
 
     return this
   }
+
+  fun isJourneysPresentInOrder(vararg journeys: Journey): JourneysForReviewPage {
+    journeys.forEachIndexed { index, journey ->
+      isRowPresentAtIndex<JourneysForReviewPage>(
+        "journeys",
+        journey.from,
+        journey.to,
+        index = index + 1
+      )
+    }
+
+    return this
+  }
 }
+
+data class Journey(val from: String, val to: String)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/JourneyServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/JourneyServiceTest.kt
@@ -1,0 +1,93 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.service
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.move.JourneyQueryRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.move.JourneyWithPrice
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Supplier
+import java.time.LocalDate
+
+internal class JourneyServiceTest {
+
+  private val startOfMonth = LocalDate.now().startOfMonth()
+
+  private val endOfMonth = startOfMonth.endOfMonth()
+
+  private val journeyQueryRepository = mock<JourneyQueryRepository>()
+
+  private val service = JourneyService(journeyQueryRepository)
+
+  @Test
+  fun `un-priced journeys with agency IDs only are ordered alphabetically`() {
+    whenever(
+      journeyQueryRepository.distinctJourneysAndPriceInDateRange(
+        Supplier.SERCO,
+        startOfMonth,
+        endOfMonth,
+        true
+      )
+    ).thenReturn(
+      listOf(
+        journey(fromAgencyId = "C", toAgencyId = "D"),
+        journey(fromAgencyId = "C", toAgencyId = "A"),
+        journey(fromAgencyId = "C", toAgencyId = "B"),
+        journey(fromAgencyId = "A", toAgencyId = "D"),
+        journey(fromAgencyId = "Z", toAgencyId = "D"),
+        journey(fromAgencyId = "Z", toAgencyId = "X"),
+      )
+    )
+
+    assertThat(service.distinctJourneysExcludingPriced(Supplier.SERCO, startOfMonth)).containsExactly(
+      journey(fromAgencyId = "A", toAgencyId = "D"),
+      journey(fromAgencyId = "C", toAgencyId = "A"),
+      journey(fromAgencyId = "C", toAgencyId = "B"),
+      journey(fromAgencyId = "C", toAgencyId = "D"),
+      journey(fromAgencyId = "Z", toAgencyId = "D"),
+      journey(fromAgencyId = "Z", toAgencyId = "X"),
+    )
+  }
+
+  @Test
+  fun `un-priced journeys with combination of agency IDs and site names are ordered alphabetically`() {
+    whenever(
+      journeyQueryRepository.distinctJourneysAndPriceInDateRange(
+        Supplier.SERCO,
+        startOfMonth,
+        endOfMonth,
+        true
+      )
+    ).thenReturn(
+      listOf(
+        journey(fromAgencyId = "C", toAgencyId = "D"),
+        journey(fromAgencyId = "C", toAgencyId = "A"),
+        journey(fromAgencyId = "C", toAgencyId = "B"),
+        journey(fromAgencyId = "A", toAgencyId = "D"),
+        journey(fromAgencyId = "X", fromSiteName = "A SITE NAME", "Z"),
+        journey(fromAgencyId = "Z", fromSiteName = "A", "X", "A SITE NAME"),
+      )
+    )
+
+    assertThat(service.distinctJourneysExcludingPriced(Supplier.SERCO, startOfMonth)).containsExactly(
+      journey(fromAgencyId = "X", fromSiteName = "A SITE NAME", toAgencyId = "Z"),
+      journey(fromAgencyId = "Z", fromSiteName = "A", toAgencyId = "X", toSiteName = "A SITE NAME"),
+      journey(fromAgencyId = "A", toAgencyId = "D"),
+      journey(fromAgencyId = "C", toAgencyId = "A"),
+      journey(fromAgencyId = "C", toAgencyId = "B"),
+      journey(fromAgencyId = "C", toAgencyId = "D"),
+    )
+  }
+
+  private fun LocalDate.startOfMonth() = this.withDayOfMonth(1)
+
+  private fun LocalDate.endOfMonth() = this.withDayOfMonth(1).plusMonths(1).minusDays(1)
+
+  private fun journey(
+    fromAgencyId: String,
+    fromSiteName: String? = null,
+    toAgencyId: String,
+    toSiteName: String? = null
+  ) =
+    JourneyWithPrice(fromAgencyId, null, fromSiteName, toAgencyId, null, toSiteName, null, null, null)
+}


### PR DESCRIPTION
**Changes:**

On the journeys for review page there was no natural ordering.  This means journeys starting from the same location can be scattered throughout the results on the page.  User feedback has informed us this makes their day to day work harder as they focus on a location at a time.

With these changes results will now be ordered, see attached screenshot as an example:

![image](https://user-images.githubusercontent.com/60104344/133632020-27edc6cc-d1b1-4c43-bad6-b1a2bf117c29.png)
