### PR TITLE
Update Dockerfile to pull down OS patches faster to reduce Trivvy scan failures.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ FROM openjdk:11-slim
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 RUN apt-get update && \
+    apt-get -y upgrade && \
     apt-get install -y libfreetype6 && \
     apt-get install -y libfontconfig1 && \
     apt-get install -y curl && \


### PR DESCRIPTION
**Changes:**

Small update to Dockerfile to reduce chances of Trivvy scan security failures.  The change will pull down OS updates when built to reduce potential wait time for image container is based on to be updated instead.