### PR TITLE
P4 3206 price exceptions domain

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/Price.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/Price.kt
@@ -19,6 +19,9 @@ import javax.persistence.OneToMany
 import javax.persistence.Table
 import javax.validation.constraints.NotNull
 
+/**
+ * A price represents an agreed contractual amount with a supplier for a given journey (from A to B) in an effective year.
+ */
 @Entity
 @Table(
   name = "PRICES",
@@ -82,7 +85,7 @@ data class Price(
   )
 
   /**
-   * Duplicates months will be ignored. You must remove first.
+   * Duplicate months will be ignored. You must remove first.
    */
   fun addException(month: Month, amount: Money): Price {
     exceptions.putIfAbsent(month.value, PriceException(price = this, month = month.value, priceInPence = amount.pence))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/Price.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/Price.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.domain.price
 
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.location.Location
 import java.time.LocalDateTime
+import java.time.Month
 import java.util.UUID
+import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.EnumType
@@ -12,6 +14,8 @@ import javax.persistence.Id
 import javax.persistence.Index
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
+import javax.persistence.MapKey
+import javax.persistence.OneToMany
 import javax.persistence.Table
 import javax.validation.constraints.NotNull
 
@@ -48,8 +52,12 @@ data class Price(
   val addedAt: LocalDateTime = LocalDateTime.now(),
 
   @Column(name = "effective_year", nullable = false)
-  val effectiveYear: Int
+  val effectiveYear: Int,
 ) {
+
+  @OneToMany(mappedBy = "price", fetch = FetchType.EAGER, cascade = [CascadeType.ALL])
+  @MapKey(name = "month")
+  private val exceptions: MutableMap<Int, PriceException> = mutableMapOf()
 
   init {
     failOnZeroOrLessPrice()
@@ -72,6 +80,23 @@ data class Price(
     effectiveYear = effectiveYear,
     addedAt = addedAt
   )
+
+  /**
+   * Duplicates months will be ignored. You must remove first.
+   */
+  fun addException(month: Month, amount: Money): Price {
+    exceptions.putIfAbsent(month.value, PriceException(price = this, month = month.value, priceInPence = amount.pence))
+
+    return this
+  }
+
+  fun removeException(month: Month): Price {
+    exceptions.remove(month.value)
+
+    return this
+  }
+
+  fun exceptions() = exceptions.values.toSet()
 }
 
 enum class Supplier {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/PriceException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/PriceException.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.domain.price
 
+import java.time.Month
 import java.util.UUID
 import javax.persistence.Column
 import javax.persistence.Entity
@@ -10,7 +11,12 @@ import javax.persistence.ManyToOne
 import javax.persistence.Table
 
 /**
- * A price within any given effective year can have a maximum of twelve exceptions, one for each month of the year.
+ * A price exception provides the ability to override a price in a given effective year for a period of one month. This
+ * allows for short term price changes if the supplier has to use a different route due to circumstances beyond their
+ * control. An example of this could be road closures due to road works so they have to go via a longer route.
+ *
+ * There can be upto twelve price exceptions (one for each month) for a price in any given year, this is however highly
+ * unlikely.
  */
 @Entity
 @Table(
@@ -41,9 +47,14 @@ data class PriceException(
 
   init {
     failOnZeroOrLessPrice()
+    failOnInvalidMonth()
   }
 
   private fun failOnZeroOrLessPrice() {
-    if (priceInPence < 1) throw IllegalArgumentException("Price in pence must be greater than zero.")
+    if (priceInPence < 1) throw IllegalArgumentException("Price exception amount must be greater than zero.")
+  }
+
+  private fun failOnInvalidMonth() {
+    Month.of(month)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/PriceException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/PriceException.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.domain.price
+
+import java.util.UUID
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Index
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+/**
+ * A price within any given effective year can have a maximum of twelve exceptions, one for each month of the year.
+ */
+@Entity
+@Table(
+  name = "PRICE_EXCEPTIONS",
+  indexes = [
+    Index(
+      name = "price_id_month_index",
+      columnList = "price_id, month",
+      unique = true
+    )
+  ]
+)
+data class PriceException(
+  @Id
+  @Column(name = "price_exception_id", nullable = false)
+  val id: UUID = UUID.randomUUID(),
+
+  @ManyToOne
+  @JoinColumn(name = "price_id", nullable = false)
+  val price: Price,
+
+  @Column(name = "month", nullable = false)
+  val month: Int,
+
+  @Column(name = "price_in_pence", nullable = false)
+  var priceInPence: Int,
+) {
+
+  init {
+    failOnZeroOrLessPrice()
+  }
+
+  private fun failOnZeroOrLessPrice() {
+    if (priceInPence < 1) throw IllegalArgumentException("Price in pence must be greater than zero.")
+  }
+}

--- a/src/main/resources/db/migration/ddl/V1_13__add_table_price_exceptions.sql
+++ b/src/main/resources/db/migration/ddl/V1_13__add_table_price_exceptions.sql
@@ -1,0 +1,10 @@
+create table if not exists price_exceptions
+(
+    price_exception_id uuid not null constraint price_exceptions_pkey primary key,
+    price_id           uuid not null,
+    month              int not null,
+    price_in_pence     int not null,
+    constraint PRICE_ID_FK foreign key (price_id) references prices
+);
+
+create unique index if not exists price_id_month_index ON price_exceptions (price_id, month);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/PriceExceptionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/PriceExceptionTest.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.domain.price
+
+import com.nhaarman.mockitokotlin2.mock
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import java.time.DateTimeException
+
+internal class PriceExceptionTest {
+
+  @Test
+  fun `price exception amount must be greater than zero`() {
+    assertDoesNotThrow { PriceException(price = mock(), month = 1, priceInPence = 1) }
+
+    assertThatThrownBy { PriceException(price = mock(), month = 1, priceInPence = 0) }.isInstanceOf(IllegalArgumentException::class.java)
+    assertThatThrownBy { PriceException(price = mock(), month = 1, priceInPence = -1) }.isInstanceOf(IllegalArgumentException::class.java)
+  }
+
+  @Test
+  fun `price exception allowed month values`() {
+    for (month in 1..12) {
+      assertDoesNotThrow { PriceException(price = mock(), month = month, priceInPence = 1) }
+    }
+
+    assertThatThrownBy { PriceException(price = mock(), month = 0, priceInPence = 1) }.isInstanceOf(DateTimeException::class.java)
+    assertThatThrownBy { PriceException(price = mock(), month = 13, priceInPence = 1) }.isInstanceOf(DateTimeException::class.java)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/PriceRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/PriceRepositoryTest.kt
@@ -1,0 +1,88 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.domain.price
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.location.Location
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.location.LocationRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.location.LocationType
+import java.time.Month
+
+@ActiveProfiles("test")
+@DataJpaTest
+internal class PriceRepositoryTest {
+
+  @Autowired
+  lateinit var locationRepo: LocationRepository
+
+  @Autowired
+  lateinit var priceRepo: PriceRepository
+
+  private val fromLocation = Location(
+    nomisAgencyId = "FROM_AGENCY",
+    locationType = LocationType.PR,
+    siteName = "FROM AGENCY"
+  )
+
+  private val toLocation = Location(
+    nomisAgencyId = "TO_AGENCY",
+    locationType = LocationType.PR,
+    siteName = "TO AGENCY"
+  )
+
+  @BeforeEach
+  fun prepareLocations() {
+    locationRepo.saveAndFlush(fromLocation)
+    locationRepo.saveAndFlush(toLocation)
+  }
+
+  @Test
+  fun `can save and retrieve price`() {
+    val price = Price(
+      supplier = Supplier.SERCO,
+      fromLocation = fromLocation,
+      toLocation = toLocation,
+      priceInPence = 1000,
+      effectiveYear = 2021
+    )
+
+    assertThat(priceRepo.findById(priceRepo.saveAndFlush(price).id)).hasValue(price)
+  }
+
+  @Test
+  fun `can add and retrieve price exception`() {
+    val priceWithoutException = Price(
+      supplier = Supplier.SERCO,
+      fromLocation = fromLocation,
+      toLocation = toLocation,
+      priceInPence = 1000,
+      effectiveYear = 2021
+    )
+
+    assertThat(priceRepo.saveAndFlush(priceWithoutException).exceptions()).isEmpty()
+
+    val priceWithException = priceWithoutException.copy().apply { addException(Month.JANUARY, Money(1)) }
+
+    assertThat(priceRepo.saveAndFlush(priceWithException).exceptions()).isNotEmpty
+  }
+
+  @Test
+  fun `can remove price exception from price`() {
+    val priceWithException = Price(
+      supplier = Supplier.SERCO,
+      fromLocation = fromLocation,
+      toLocation = toLocation,
+      priceInPence = 1000,
+      effectiveYear = 2021
+    ).apply { addException(Month.JANUARY, Money(1)) }
+
+    assertThat(priceRepo.saveAndFlush(priceWithException).exceptions()).isNotEmpty
+
+    val priceWithoutException = priceRepo.findById(priceWithException.id).get().apply { removeException(Month.JANUARY) }
+
+    assertThat(priceRepo.saveAndFlush(priceWithoutException).exceptions()).isEmpty()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/PriceRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/PriceRepositoryTest.kt
@@ -53,7 +53,7 @@ internal class PriceRepositoryTest {
   }
 
   @Test
-  fun `can add and retrieve price exception`() {
+  fun `can add and retrieve price exceptions for each month of the contractual year`() {
     val priceWithoutException = Price(
       supplier = Supplier.SERCO,
       fromLocation = fromLocation,
@@ -64,9 +64,28 @@ internal class PriceRepositoryTest {
 
     assertThat(priceRepo.saveAndFlush(priceWithoutException).exceptions()).isEmpty()
 
-    val priceWithException = priceWithoutException.copy().apply { addException(Month.JANUARY, Money(1)) }
+    val priceWithExceptions = priceWithoutException.copy().apply {
+      Month.values().forEach {
+        addException(it, Money(it.value))
+      }
+    }
 
-    assertThat(priceRepo.saveAndFlush(priceWithException).exceptions()).isNotEmpty
+    assertThat(
+      priceRepo.saveAndFlush(priceWithExceptions).exceptions().map { Pair(Month.of(it.month), it.priceInPence) }
+    ).containsExactlyInAnyOrder(
+      Pair(Month.SEPTEMBER, 9),
+      Pair(Month.OCTOBER, 10),
+      Pair(Month.NOVEMBER, 11),
+      Pair(Month.DECEMBER, 12),
+      Pair(Month.JANUARY, 1),
+      Pair(Month.FEBRUARY, 2),
+      Pair(Month.MARCH, 3),
+      Pair(Month.APRIL, 4),
+      Pair(Month.MAY, 5),
+      Pair(Month.JUNE, 6),
+      Pair(Month.JULY, 7),
+      Pair(Month.AUGUST, 8)
+    )
   }
 
   @Test


### PR DESCRIPTION
**Changes:**

Introduces the concept of price exceptions at the domain level. This is purely in the backend. As of yet there is no supporting service or front end to add or remove these, this will be added later.

A price exception allows for supplier journey prices to be overridden for a fixed period of a month in a given effective year.  For a given price there can be up to 12 price exceptions in that year (though this is extremely unlikely).

Addition and removal of exceptions is handled by its aggregate root entity 'Price'.
