### PR TITLE
P4-3219 update to include price exceptions in the outputted spreadsheet prices tab.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/Price.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/Price.kt
@@ -100,6 +100,8 @@ data class Price(
   }
 
   fun exceptions() = exceptions.values.toSet()
+
+  fun exceptionFor(month: Month) = exceptions[month.value]
 }
 
 enum class Supplier {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/PriceException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/PriceException.kt
@@ -57,4 +57,6 @@ data class PriceException(
   private fun failOnInvalidMonth() {
     Month.of(month)
   }
+
+  fun price() = Money(priceInPence)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/spreadsheet/outbound/PriceSheet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/spreadsheet/outbound/PriceSheet.kt
@@ -51,6 +51,7 @@ abstract class PriceSheet(
     TOTAL_JOURNEY_COUNT("Total journey count", 5000),
     TOTAL_PRICE("Total price"),
     UNIT_PRICE("Unit price"),
+    UNIT_PRICE_EXCEPTION("Unit price exception"),
     VEHICLE_REG("Vehicle reg")
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/spreadsheet/outbound/SupplierPricesSheet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/spreadsheet/outbound/SupplierPricesSheet.kt
@@ -6,15 +6,16 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Price
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.spreadsheet.outbound.PriceSheet.DataColumn.DROP_OFF
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.spreadsheet.outbound.PriceSheet.DataColumn.PICK_UP
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.spreadsheet.outbound.PriceSheet.DataColumn.UNIT_PRICE
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.spreadsheet.outbound.PriceSheet.DataColumn.UNIT_PRICE_EXCEPTION
 import java.util.stream.Stream
 
 /**
  * Sheet to represent the actual JPC supplier prices used for all of the calculations in the outputted spreadsheet.
  */
-internal class SupplierPricesSheet(workbook: Workbook, header: Header) : PriceSheet(
+internal class SupplierPricesSheet(workbook: Workbook, private val header: Header) : PriceSheet(
   sheet = workbook.createSheet("JPC Price book"),
   header = header,
-  dataColumns = listOf(PICK_UP, DROP_OFF, UNIT_PRICE)
+  dataColumns = listOf(PICK_UP, DROP_OFF, UNIT_PRICE, UNIT_PRICE_EXCEPTION)
 ) {
   override fun writeMove(move: Move) {}
 
@@ -24,6 +25,9 @@ internal class SupplierPricesSheet(workbook: Workbook, header: Header) : PriceSh
       row.addCell(0, it.fromLocation.siteName)
       row.addCell(1, it.toLocation.siteName)
       row.addCell(2, it.price().pounds(), fillWhitePound)
+      row.addCell(3, it.exceptionFor(header.startOfMonth())?.price()?.pounds(), fillWhitePound)
     }
   }
+
+  private fun Header.startOfMonth() = this.dateRange.start.month
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/PriceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/PriceTest.kt
@@ -9,6 +9,7 @@ import java.time.Month
 import java.time.Month.DECEMBER
 import java.time.Month.FEBRUARY
 import java.time.Month.JANUARY
+import java.time.Month.MARCH
 
 internal class PriceTest {
   @Test
@@ -117,6 +118,26 @@ internal class PriceTest {
       Pair(FEBRUARY, 2),
       Pair(DECEMBER, 12)
     )
+  }
+
+  @Test
+  fun `retrieve a price exception from price`() {
+    val price = Price(
+      supplier = Supplier.SERCO,
+      fromLocation = mock(),
+      toLocation = mock(),
+      priceInPence = 1000,
+      effectiveYear = 2021
+    ).addException(JANUARY, Money(1))
+      .addException(DECEMBER, Money(12))
+      .addException(FEBRUARY, Money(2))
+
+    with(price) {
+      assertThat(exceptionFor(JANUARY)?.let { Pair(Month.of(it.month), it.priceInPence) }).isEqualTo(Pair(JANUARY, 1))
+      assertThat(exceptionFor(FEBRUARY)?.let { Pair(Month.of(it.month), it.priceInPence) }).isEqualTo(Pair(FEBRUARY, 2))
+      assertThat(exceptionFor(DECEMBER)?.let { Pair(Month.of(it.month), it.priceInPence) }).isEqualTo(Pair(DECEMBER, 12))
+      assertThat(exceptionFor(MARCH)).isNull()
+    }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/spreadsheet/outbound/SupplierPricesSheetTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/spreadsheet/outbound/SupplierPricesSheetTest.kt
@@ -7,8 +7,10 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.location.Location
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.location.LocationType
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.move.defaultMoveDate10Sep2020
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Money
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Price
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Supplier
+import java.time.Month
 import java.util.UUID
 import java.util.stream.Stream
 
@@ -33,7 +35,7 @@ internal class SupplierPricesSheetTest {
           location("TO SITE A"),
           20059,
           effectiveYear = 2020
-        ),
+        ).addException(Month.FEBRUARY, Money(20060)),
         Price(
           UUID.randomUUID(),
           Supplier.SERCO,
@@ -41,14 +43,14 @@ internal class SupplierPricesSheetTest {
           location("TO SITE B"),
           10024,
           effectiveYear = 2020
-        )
+        ).addException(Month.SEPTEMBER, Money(20024))
       )
     )
 
     assertOnSheetName(supplierPricesSheet, "JPC Price book")
-    assertOnColumnDataHeadings(supplierPricesSheet, "Pick up", "Drop off", "Unit price")
+    assertOnColumnDataHeadings(supplierPricesSheet, "Pick up", "Drop off", "Unit price", "Unit price exception")
     assertOnPriceRow(supplierPricesSheet.sheet.getRow(9), PriceRow("FROM SITE A", "TO SITE A", 200.59))
-    assertOnPriceRow(supplierPricesSheet.sheet.getRow(10), PriceRow("FROM SITE B", "TO SITE B", 100.24))
+    assertOnPriceRow(supplierPricesSheet.sheet.getRow(10), PriceRow("FROM SITE B", "TO SITE B", 100.24, 200.24))
   }
 
   private fun assertOnPriceRow(row: Row, priceRow: PriceRow) {
@@ -60,5 +62,5 @@ internal class SupplierPricesSheetTest {
 
   fun location(siteName: String) = Location(LocationType.CC, "x", siteName)
 
-  internal data class PriceRow(val fromSite: String, val toSite: String, val price: Double)
+  internal data class PriceRow(val fromSite: String, val toSite: String, val price: Double, val priceException: Double? = null)
 }


### PR DESCRIPTION
**Changes:**

Price exceptions are included in the JPC price book tab of the outputted spreadsheet where applicable for the month at which the spreadsheet is generated.

![image](https://user-images.githubusercontent.com/60104344/134912165-4bd077e5-c372-4522-aa9b-e8f09fbe7920.png)
