### PR TITLE
P4-3209 add front end validtion to prevent adding a price exception the same price as the actual price.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingController.kt
@@ -270,6 +270,8 @@ class MaintainSupplierPricingController(
       model.getSelectedEffectiveYear()
     )!!
 
+    if (existingPrice.amount == price) result.rejectValue("exceptionPrice", "Invalid price")
+
     if (result.hasErrors()) {
       model.apply {
         addAttribute("form", PriceForm(form.moveId, existingPrice.amount.toString(), existingPrice.fromAgency, existingPrice.toAgency))

--- a/src/main/resources/templates/update-price.html
+++ b/src/main/resources/templates/update-price.html
@@ -124,7 +124,10 @@
     </div>
 
     <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="price-exceptions" th:if="${priceExceptionFeatureEnabled}">
-      <h2 class="govuk-heading-l">Price exceptions</h2>
+      <div>
+        <h2 class="govuk-heading-l">Price exceptions</h2>
+        <p class="govuk-heading-s govuk-body govuk-!-font-weight-regular">Add an agreed price exception more or less to that of the yearly amount.</p>
+      </div>
       <form th:action="@{/add-price-exception}" th:object="${exceptionsForm}" method="post">
         <div class="govuk-error-summary mv3" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
              data-module="govuk-error-summary" th:if="${flashError == 'add-price-exception-error'}">

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingControllerTest.kt
@@ -588,7 +588,7 @@ class MaintainSupplierPricingControllerTest(@Autowired private val wac: WebAppli
   }
 
   @Test
-  internal fun `cannot add an the same price for a  price exception`() {
+  internal fun `cannot add an exception for the same price`() {
     mockSession.addSupplierAndContractualYear(Supplier.SERCO, currentContractualYearDate)
 
     whenever(


### PR DESCRIPTION
**Changes:**

Small change to prevent adding price exceptions with the same price as the actual price (as this does not make sense). This is enforced at the Domain level so needs to be enforced here otherwise it will not be handled gracefully.