### PR TITLE
P4 3209 price exceptions tab feature v2

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingController.kt
@@ -191,6 +191,7 @@ class MaintainSupplierPricingController(
       addAttribute("cancelLink", getJourneySearchResultsUrl())
       addAttribute("existingExceptions", existingExceptions(price.exceptions))
       addAttribute("exceptionsForm", PriceExceptionForm(moveId, price.exceptions))
+      addContractStartAndEndDates()
     }
 
     return "update-price"
@@ -219,6 +220,7 @@ class MaintainSupplierPricingController(
         addAttribute("history", priceHistoryForMove(supplier, fromAgencyId, toAgencyId))
         addAttribute("existingExceptions", existingExceptions(existingPrice.exceptions))
         addAttribute("exceptionsForm", PriceExceptionForm(form.moveId, existingPrice.exceptions))
+        addContractStartAndEndDates()
       }
 
       return "update-price"
@@ -287,6 +289,7 @@ class MaintainSupplierPricingController(
         addAttribute("cancelLink", getJourneySearchResultsUrl())
         addAttribute("history", priceHistoryForMove(supplier, fromAgencyId, toAgencyId))
         addAttribute("exceptionsForm", PriceExceptionForm(form.moveId, existingPrice.exceptions))
+        addContractStartAndEndDates()
       }
 
       redirectAttributes.showErrorOnRedirect("add-price-exception-error")
@@ -310,7 +313,7 @@ class MaintainSupplierPricingController(
       addFlashAttribute("flashAttrLocationTo", existingPrice.toAgency)
     }
 
-    return RedirectView(model.getJourneySearchResultsUrl())
+    return RedirectView("$UPDATE_PRICE/${form.moveId}#price-exceptions")
   }
 
   private fun RedirectAttributes.showErrorOnRedirect(attribute: String) = this.addFlashAttribute("flashError", attribute)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingController.kt
@@ -151,14 +151,18 @@ class MaintainSupplierPricingController(
       effectiveYear
     )
 
-    redirectAttributes.apply {
+    redirectAttributes.showPriceCreatedMessageOnRedirect(form)
+
+    return RedirectView(HtmlController.JOURNEYS_URL)
+  }
+
+  private fun RedirectAttributes.showPriceCreatedMessageOnRedirect(form: PriceForm) {
+    this.apply {
       addFlashAttribute("flashMessage", "price-created")
       addFlashAttribute("flashAttrLocationFrom", form.from)
       addFlashAttribute("flashAttrLocationTo", form.to)
       addFlashAttribute("flashAttrPrice", form.price)
     }
-
-    return RedirectView(HtmlController.JOURNEYS_URL)
   }
 
   @GetMapping("$UPDATE_PRICE/{moveId}")
@@ -230,14 +234,18 @@ class MaintainSupplierPricingController(
       )
     }
 
-    redirectAttributes.apply {
+    redirectAttributes.showPriceUpdatedMessageOnRedirect(form)
+
+    return RedirectView(model.getJourneySearchResultsUrl())
+  }
+
+  private fun RedirectAttributes.showPriceUpdatedMessageOnRedirect(form: PriceForm) {
+    this.apply {
       addFlashAttribute("flashMessage", "price-updated")
       addFlashAttribute("flashAttrLocationFrom", form.from)
       addFlashAttribute("flashAttrLocationTo", form.to)
       addFlashAttribute("flashAttrPrice", form.price)
     }
-
-    return RedirectView(model.getJourneySearchResultsUrl())
   }
 
   private fun existingExceptions(existingExceptions: Map<Int, Money>) =
@@ -281,7 +289,7 @@ class MaintainSupplierPricingController(
         addAttribute("exceptionsForm", PriceExceptionForm(form.moveId, existingPrice.exceptions))
       }
 
-      redirectAttributes.addFlashErrorOnRedirect("add-price-exception-error")
+      redirectAttributes.showErrorOnRedirect("add-price-exception-error")
 
       return RedirectView("$UPDATE_PRICE/${form.moveId}#price-exceptions")
     }
@@ -305,7 +313,7 @@ class MaintainSupplierPricingController(
     return RedirectView(model.getJourneySearchResultsUrl())
   }
 
-  private fun RedirectAttributes.addFlashErrorOnRedirect(attribute: String) = this.addFlashAttribute("flashError", attribute)
+  private fun RedirectAttributes.showErrorOnRedirect(attribute: String) = this.addFlashAttribute("flashError", attribute)
 
   private fun getWarningTexts(supplier: Supplier, selectedEffectiveYear: Int, from: String, to: String): List<Warning> {
     if (selectedEffectiveYear >= actualEffectiveYear.current())

--- a/src/main/resources/templates/fragments/contractual-year.html
+++ b/src/main/resources/templates/fragments/contractual-year.html
@@ -1,5 +1,5 @@
 <div th:fragment="contractualYear" class="mv4">
-  <h1 class="govuk-heading-xl mv2" th:inline="text">
+  <h1 class="govuk-heading-l mv2" th:inline="text">
     Manage Journey Price Catalogue [[${contractualYearStart}]] to [[${contractualYearEnd}]]
   </h1>
 </div>

--- a/src/main/resources/templates/fragments/flash-messages.html
+++ b/src/main/resources/templates/fragments/flash-messages.html
@@ -45,7 +45,7 @@
                 Price exception added
               </p>
               <p class="govuk-body ma0" id="app-message__heading" th:inline="text">
-                Journey from [[${flashAttrLocationFrom}]] to [[${flashAttrLocationTo}]] for [[${flashAttrExceptionMonth}]] priced at £[[${flashAttrExceptionPrice}]]
+                Price exception of £[[${flashAttrExceptionPrice}]] for [[${flashAttrExceptionMonth}]] 2020 added for journey from [[${flashAttrLocationFrom}]] to [[${flashAttrLocationTo}]]
               </p>
             </div>
             <div th:case="*"></div>

--- a/src/main/resources/templates/update-price.html
+++ b/src/main/resources/templates/update-price.html
@@ -10,6 +10,9 @@
 <body>
 
 <div class="govuk-width-container" layout:fragment="content">
+  <div th:replace="fragments/flash-messages.html :: flash-messages(dismissFallback='/manage-journey-price-catalogue')"></div>
+
+  <div th:insert="fragments/contractual-year.html :: contractualYear"></div>
 
   <a th:href="${cancelLink}" class="govuk-back-link">Back</a>
 
@@ -86,7 +89,7 @@
               </div>
             </li>
             <li class="mv3" th:if="${priceExceptionFeatureEnabled && existingExceptions.size > 0}">
-              <label class="govuk-label govuk-body govuk-!-font-weight-bold">Price exceptions</label>
+              <label class="govuk-label govuk-body govuk-!-font-weight-bold">Existing price exceptions</label>
               <table class="govuk-table">
                 <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
@@ -126,8 +129,26 @@
     <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="price-exceptions" th:if="${priceExceptionFeatureEnabled}">
       <div>
         <h2 class="govuk-heading-l">Price exceptions</h2>
-        <p class="govuk-heading-s govuk-body govuk-!-font-weight-regular">Add an agreed price exception more or less to that of the yearly amount.</p>
       </div>
+      <ol class="list pl0">
+        <li class="mv3" th:if="${priceExceptionFeatureEnabled && existingExceptions.size > 0}">
+          <label class="govuk-label govuk-body govuk-!-font-weight-bold">Existing price exceptions</label>
+          <table class="govuk-table">
+            <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">Month</th>
+              <th scope="col" class="govuk-table__header">Price</th>
+            </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+            <tr class="govuk-table__row" th:each="exception: ${existingExceptions}">
+              <td class="govuk-table__cell" scope="row" th:inline="text" th:text="${exception.text}"></td>
+              <td class="govuk-table__cell" scope="row" th:inline="text" th:text="${'£' + exception.amount}"></td>
+            </tr>
+            </tbody>
+          </table>
+        </li>
+      </ol>
       <form th:action="@{/add-price-exception}" th:object="${exceptionsForm}" method="post">
         <div class="govuk-error-summary mv3" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
              data-module="govuk-error-summary" th:if="${flashError == 'add-price-exception-error'}">
@@ -147,6 +168,8 @@
         <input type="hidden" th:field="*{moveId}" class="dn"/>
         <ol class="list pl0">
           <li class="mv1">
+            <label class="govuk-label govuk-body govuk-!-font-weight-bold">Add price exception</label>
+            <p class="govuk-heading-s govuk-body govuk-!-font-weight-regular">Add an agreed price exception more or less to that of the yearly amount.</p>
             <label class="govuk-label govuk-body govuk-!-font-weight-bold"
                    for="exception-month">
               Month
@@ -180,23 +203,6 @@
                      aria-describedby="price-hint" th:field="*{exceptionPrice}"
                      th:classappend="${flashError == 'add-price-exception-error'} ? 'govuk-input--error'">
             </div>
-          </li>
-          <li class="mv3" th:if="${priceExceptionFeatureEnabled && existingExceptions.size > 0}">
-            <label class="govuk-label govuk-body govuk-!-font-weight-bold">Price exceptions</label>
-            <table class="govuk-table">
-              <thead class="govuk-table__head">
-              <tr class="govuk-table__row">
-                <th scope="col" class="govuk-table__header">Month</th>
-                <th scope="col" class="govuk-table__header">Price</th>
-              </tr>
-              </thead>
-              <tbody class="govuk-table__body">
-              <tr class="govuk-table__row" th:each="exception: ${existingExceptions}">
-                <td class="govuk-table__cell" scope="row" th:inline="text" th:text="${exception.text}"></td>
-                <td class="govuk-table__cell" scope="row" th:inline="text" th:text="${'£' + exception.amount}"></td>
-              </tr>
-              </tbody>
-            </table>
           </li>
         </ol>
         <div class="flex items-center">

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingControllerTest.kt
@@ -471,8 +471,8 @@ class MaintainSupplierPricingControllerTest(@Autowired private val wac: WebAppli
 
   @Test
   internal fun `can add a price exception`() {
-
     mockSession.addSupplierAndContractualYear(SERCO, currentContractualDate)
+
     whenever(
       service.maybePrice(
         SERCO,
@@ -493,7 +493,7 @@ class MaintainSupplierPricingControllerTest(@Autowired private val wac: WebAppli
       .andExpect { flash { attribute("flashAttrExceptionMonth", "SEPTEMBER") } }
       .andExpect { flash { attribute("flashAttrLocationFrom", "a") } }
       .andExpect { flash { attribute("flashAttrLocationTo", "b") } }
-      .andExpect { redirectedUrl("/journeys-results") }
+      .andExpect { redirectedUrl("/update-price/AAAAAA-BBBBBB#price-exceptions") }
       .andExpect { status { is3xxRedirection() } }
 
     verify(service).addPriceException(SERCO, fromAgencyId, toAgencyId, currentContractualEffectiveYear, Month.SEPTEMBER, Money.valueOf(50.00))


### PR DESCRIPTION
**Changes:**

- Tweaks to the layout and navigation around addition of price exceptions.
- Resized heading for contractual year, overly large and causing it to wrap.
- Heading for contractual year also included in the update price page to aid the user.

On the update price tab now says existing price exceptions:

![image](https://user-images.githubusercontent.com/60104344/135612533-5830afd8-ede6-4482-916a-68dc6aaa1ac8.png)

On the price exceptions tab, move existing exceptions to top:

![image](https://user-images.githubusercontent.com/60104344/135612926-460ffc9a-a0ec-4383-9eb7-9459d95c216f.png)

![image](https://user-images.githubusercontent.com/60104344/135612633-d900b9a4-961c-4db6-8621-5dad9df3aa2b.png)

When you add an exception it stays on the tab instead of navigation to another page.
