### PR TITLE
P4-3223 changed point at which price lock down message is displayed.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ApplicationInformationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ApplicationInformationController.kt
@@ -3,28 +3,32 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.controller
 import com.fasterxml.jackson.annotation.JsonInclude
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
+import org.springframework.ui.ModelMap
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.bind.annotation.SessionAttributes
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.EffectiveYear
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.AnnualPriceAdjustmentsService
 
 @RestController
 @RequestMapping(name = "Supplier information", path = ["/app"], produces = [MediaType.APPLICATION_JSON_VALUE])
-@SessionAttributes(SUPPLIER_ATTRIBUTE)
-class ApplicationInformationController(val annualPriceAdjustmentsService: AnnualPriceAdjustmentsService) {
+@SessionAttributes(DATE_ATTRIBUTE, SUPPLIER_ATTRIBUTE)
+class ApplicationInformationController(val annualPriceAdjustmentsService: AnnualPriceAdjustmentsService, val effectiveYear: EffectiveYear) {
   private val logger = LoggerFactory.getLogger(javaClass)
 
   @GetMapping(path = ["/info"])
-  fun info(@ModelAttribute(name = SUPPLIER_ATTRIBUTE) supplier: Supplier): ApplicationInformation {
+  fun info(@ModelAttribute(name = SUPPLIER_ATTRIBUTE) supplier: Supplier, model: ModelMap): ApplicationInformation {
     logger.info("getting info for $supplier")
 
     return ApplicationInformation(
       when {
         annualPriceAdjustmentsService.adjustmentInProgressFor(supplier) ->
           "A bulk price adjustment is currently in progress. Any further price changes will be prevented until the adjustment is complete."
+        !effectiveYear.canAddOrUpdatePrices(model.getSelectedEffectiveYear()) ->
+          "Prices for the selected catalogue year ${model.getSelectedYearStart().month()} ${model.getSelectedYearStart().year()} to ${model.getSelectedYearEnd().month()} ${model.getSelectedYearEnd().year()} can no longer be changed."
         else -> null
       }
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingController.kt
@@ -121,12 +121,6 @@ class MaintainSupplierPricingController(
       return "add-price"
     }
 
-    redirectAttributes.addFlashAttribute("flashMessage", "information")
-    redirectAttributes.addFlashAttribute(
-      "flashAttrMessage",
-      "Prices for the selected price catalogue ${model.getSelectedYearStart().month()} ${model.getSelectedYearStart().year()} to ${model.getSelectedYearEnd().month()} ${model.getSelectedYearEnd().year()} can no longer be changed."
-    )
-
     return RedirectView(HtmlController.DASHBOARD_URL)
   }
 

--- a/src/main/resources/templates/fragments/flash-messages.html
+++ b/src/main/resources/templates/fragments/flash-messages.html
@@ -56,14 +56,6 @@
               Price exception for [[${flashAttrExceptionMonth}]] removed for journey from [[${flashAttrLocationFrom}]] to [[${flashAttrLocationTo}]]
             </p>
           </div>
-          <div th:case="'information'">
-            <p class="govuk-heading-m govuk-!-font-weight-bold ma0">
-              Important
-            </p>
-            <p class="govuk-body ma0" id="app-message__heading" th:inline="text">
-              [[${flashAttrMessage}]]
-            </p>
-          </div>
           <div th:case="*"></div>
         </div>
         <a th:href="${dismissFallback}" class="govuk-link" onclick="event.preventDefault();this.parentElement.remove()">Dismiss</a>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ApplicationInformationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ApplicationInformationControllerTest.kt
@@ -76,7 +76,7 @@ class ApplicationInformationControllerTest(@Autowired private val wac: WebApplic
   }
 
   @Test
-  internal fun `application info message is not present when outside allowed price change window`() {
+  internal fun `application info message is present when outside allowed price change window`() {
     whenever(annualPriceAdjustmentsService.adjustmentInProgressFor(defaultSupplierSerco)).thenReturn(false)
     whenever(effectiveYear.canAddOrUpdatePrices(any())).thenReturn(false)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingControllerTest.kt
@@ -188,8 +188,6 @@ class MaintainSupplierPricingControllerTest(@Autowired private val wac: WebAppli
     whenever(actualEffectiveYear.canAddOrUpdatePrices(any())).thenReturn(false)
 
     mockMvc.get("/add-price/$fromAgencyId-$toAgencyId") { session = mockSession }
-      .andExpect { flash { attribute("flashMessage", "information") } }
-      .andExpect { flash { attribute("flashAttrMessage", "Prices for the selected price catalogue September $currentContractualEffectiveYear to August ${currentContractualEffectiveYear + 1} can no longer be changed.") } }
       .andExpect { redirectedUrl("/dashboard") }
   }
 


### PR DESCRIPTION
**Changes:**

The point at which price lock down message is displayed has been changed. Now displayed as soon at you go to the dashboard (and stays there) so clearer to end user.

![image](https://user-images.githubusercontent.com/60104344/137718713-c0e25040-214b-4fdc-a4c8-14d58d1e9bb2.png)
