### PR TITLE
P4-3223 remove/hide 'add price' link on 'journeys for review' page ...

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlController.kt
@@ -20,6 +20,7 @@ import org.springframework.web.servlet.view.RedirectView
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.controller.constraints.ValidMonthYear
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.move.MoveType
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.EffectiveYear
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.JourneyService
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.MoveService
@@ -39,7 +40,8 @@ data class MonthsWidget(val currentMonth: LocalDate, val nextMonth: LocalDate, v
 class HtmlController(
   @Autowired val moveService: MoveService,
   @Autowired val journeyService: JourneyService,
-  @Autowired val timeSource: TimeSource
+  @Autowired val timeSource: TimeSource,
+  @Autowired val actualEffectiveYear: EffectiveYear
 ) {
 
   private val logger = LoggerFactory.getLogger(javaClass)
@@ -146,6 +148,7 @@ class HtmlController(
     model.apply {
       addAttribute("journeysSummary", journeyService.journeysSummary(supplier, startOfMonth))
       addAttribute("journeys", journeyService.distinctJourneysExcludingPriced(supplier, startOfMonth))
+      addAttribute("canAddPrice", actualEffectiveYear.canAddOrUpdatePrices(model.getSelectedEffectiveYear()))
     }
 
     return "journeys"

--- a/src/main/resources/templates/journeys.html
+++ b/src/main/resources/templates/journeys.html
@@ -104,9 +104,10 @@
                         </div>
                         <div sec:authorize="hasRole('ROLE_PECS_MAINTAIN_PRICE')">
                             <span th:unless="${journey.fromSiteName == null || journey.toSiteName == null}">
-                                <a th:href="@{'/add-price/' + ${journey.fromNomisAgencyId} + '-' + ${journey.toNomisAgencyId}}"
+                                <a th:if="${canAddPrice}" th:href="@{'/add-price/' + ${journey.fromNomisAgencyId} + '-' + ${journey.toNomisAgencyId}}"
                                    class="ma0 govuk-link">Add price</a>
                             </span>
+                          <span th:unless="${canAddPrice}" th:inline="text">Not priced</span>
                         </div>
                     </td>
                 </tr>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ManageLocationsAndPricesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/ManageLocationsAndPricesTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.MapLocation
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.SearchLocations
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.SelectMonthYear
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.Pages.UpdatePrice
+import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.UpdatePricePage
 import uk.gov.justice.digital.hmpps.pecs.jpc.integration.pages.previousMonth
 import java.time.LocalDate
 import java.time.Year
@@ -113,9 +114,9 @@ internal class ManageLocationsAndPricesTest : IntegrationTest() {
 
     isAtPage(Dashboard).navigateToJourneysForReview()
 
-    isAtPage(JourneysForReview).addPriceForJourney("PRISON1", "PRISON2")
-
-    isAtPage(Dashboard)
+    isAtPage(JourneysForReview)
+      .isRowPresent<JourneysForReviewPage>("PRISON ONE", "PR", "PRISON TWO", "PR", 1, "Not priced")
+      .assertTextIsNotPresent<JourneysForReviewPage>("Add price")
   }
 
   @Test
@@ -144,8 +145,8 @@ internal class ManageLocationsAndPricesTest : IntegrationTest() {
 
     isAtPage(UpdatePrice)
       .isAtPricePageForJourney("PRISON1", "POLICE1")
-      .assertTextIsNotPresent("Update price")
-      .assertTextIsNotPresent("Price exceptions")
+      .assertTextIsNotPresent<UpdatePricePage>("Update price")
+      .assertTextIsNotPresent<UpdatePricePage>("Price exceptions")
       .assertTextIsPresent("Price history")
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/MovePriceExceptionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/MovePriceExceptionTest.kt
@@ -57,9 +57,9 @@ internal class MovePriceExceptionTest : IntegrationTest() {
 
     isAtPage(UpdatePrice)
       .isAtPricePageForJourney("PRISON1", "POLICE1")
-      .assertTextIsNotPresent("Existing price exceptions")
+      .assertTextIsNotPresent<UpdatePricePage>("Existing price exceptions")
       .showPriceExceptionsTab()
-      .assertTextIsNotPresent("Existing price exceptions")
+      .assertTextIsNotPresent<UpdatePricePage>("Existing price exceptions")
       .addPriceException(date.month, Money.valueOf(3000.00))
 
     goToPage(Dashboard)
@@ -106,7 +106,7 @@ internal class MovePriceExceptionTest : IntegrationTest() {
       .isRowPresent<UpdatePricePage>("August", "£3000.00")
       .showPriceExceptionsTab()
       .removePriceException(date.month)
-      .assertTextIsNotPresent("Existing price exceptions")
+      .assertTextIsNotPresent<UpdatePricePage>("Existing price exceptions")
 
     goToPage(Dashboard)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/ApplicationPage.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/ApplicationPage.kt
@@ -32,6 +32,12 @@ abstract class ApplicationPage : FluentPage() {
     find(By.xpath("//p[normalize-space(text())='$text']")).firstOrNull().let { assertThat(it).isNotNull }
   }
 
+  internal inline fun <reified T : ApplicationPage> assertTextIsNotPresent(text: String): T {
+    assertThat(super.pageSource()).doesNotContainIgnoringCase(text)
+
+    return this as T
+  }
+
   inline fun <reified T : ApplicationPage> isRowPresent(value: Any, vararg values: Any): T {
     val query = values.joinToString(" ") { "and contains(., '$it')" }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/UpdatePricePage.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/UpdatePricePage.kt
@@ -41,12 +41,6 @@ class UpdatePricePage : ApplicationPage() {
     submit.click()
   }
 
-  fun assertTextIsNotPresent(text: String): UpdatePricePage {
-    assertThat(super.pageSource()).doesNotContainIgnoringCase(text)
-
-    return this
-  }
-
   fun assertTextIsPresent(text: String): UpdatePricePage {
     assertThat(super.pageSource()).containsIgnoringCase(text)
 


### PR DESCRIPTION
**Changes:**

Remove/hide 'add price' link on 'journeys for review' page to stop navigation to the 'add price' page when outside of the price change window. Instead of showing the 'add price' link will just display 'Not priced'.

![image](https://user-images.githubusercontent.com/60104344/137747093-0054067a-8904-47d6-bdf3-053b16f47a73.png)