### PR TITLE
P4-3265 including year a long side the month for price exceptions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/EffectiveYear.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/EffectiveYear.kt
@@ -7,7 +7,7 @@ import java.time.LocalDate
 /**
  * The effective year represents the start year’s pricing that should be applied. An effective year starts at the
  * beginning of September and runs to the end of August the following year. For example, the 1st Sept 2020 to 31st Aug
- * 2021 would be be 2020.
+ * 2021 would be 2020.
  */
 @Component
 class EffectiveYear(private val timeSource: TimeSource) {
@@ -23,4 +23,10 @@ fun nextEffectiveYearForDate(date: LocalDate) = effectiveYearForDate(date) + 1
 /**
  * Starts from 9-12 then 1-8 representing September to August the following year.
  */
-fun effectiveMonthsOrdered() = listOf(9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8)
+fun ordinalMonthsAndYearForSeptemberToAugust(startingYear: Int) = listOf(9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8).map {
+  if (it >= 9) {
+    it to startingYear
+  } else {
+    it to startingYear + 1
+  }
+}

--- a/src/main/resources/templates/update-price.html
+++ b/src/main/resources/templates/update-price.html
@@ -94,12 +94,14 @@
                 <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                   <th scope="col" class="govuk-table__header">Month</th>
+                  <th scope="col" class="govuk-table__header">Year</th>
                   <th scope="col" class="govuk-table__header">Price</th>
                 </tr>
                 </thead>
                 <tbody class="govuk-table__body">
                 <tr class="govuk-table__row" th:each="exception: ${existingExceptions}">
-                  <td class="govuk-table__cell" scope="row" th:inline="text" th:text="${exception.text}"></td>
+                  <td class="govuk-table__cell" scope="row" th:inline="text" th:text="${exception.month}"></td>
+                  <td class="govuk-table__cell" scope="row" th:inline="text" th:text="${exception.year}"></td>
                   <td class="govuk-table__cell" scope="row" th:inline="text" th:text="${'£' + exception.amount}"></td>
                 </tr>
                 </tbody>
@@ -137,13 +139,15 @@
             <thead class="govuk-table__head">
             <tr class="govuk-table__row">
               <th scope="col" class="govuk-table__header">Month</th>
+              <th scope="col" class="govuk-table__header">Year</th>
               <th scope="col" class="govuk-table__header">Price</th>
               <th scope="col" class="govuk-table__header"></th>
             </tr>
             </thead>
             <tbody class="govuk-table__body">
             <tr class="govuk-table__row" th:each="exception: ${existingExceptions}">
-              <td class="govuk-table__cell vam" scope="row" th:inline="text" th:text="${exception.text}"></td>
+              <td class="govuk-table__cell vam" scope="row" th:inline="text" th:text="${exception.month}"></td>
+              <td class="govuk-table__cell vam" scope="row" th:inline="text" th:text="${exception.year}"></td>
               <td class="govuk-table__cell vam" scope="row" th:inline="text" th:text="${'£' + exception.amount}"></td>
               <td class="govuk-table__cell" scope="row" th:inline="text">
                 <form th:action="@{/remove-price-exception}" method="post">
@@ -185,10 +189,10 @@
             <div class="govuk-form-group">
               <select class="govuk-select" id="exception-month" th:field="*{exceptionMonth}">
                 <option
-                  th:each="month : *{months}"
-                  th:disabled="${month.disabled}"
-                  th:value="${month.value}"
-                  th:text="${month.text}">
+                  th:each="exception : *{months}"
+                  th:disabled="${exception.alreadySelected}"
+                  th:value="${exception.value}"
+                  th:text="${exception.month} + ' ' + ${exception.year}">
                 </option>
               </select>
             </div>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingControllerTest.kt
@@ -339,8 +339,8 @@ class MaintainSupplierPricingControllerTest(@Autowired private val wac: WebAppli
           )
         }
       }
-      .andExpect { model { attribute("existingExceptions", listOf(PriceExceptionMonth(Month.JULY, true, Money(100)))) } }
-      .andExpect { model { attribute("exceptionsForm", PriceExceptionForm("$fromAgencyId-$toAgencyId", mapOf(7 to Money(100)), exceptionPrice = "0.00")) } }
+      .andExpect { model { attribute("existingExceptions", listOf(PriceExceptionMonth(Month.JULY, true, currentContractualEffectiveYear + 1, Money(100)))) } }
+      .andExpect { model { attribute("exceptionsForm", PriceExceptionForm("$fromAgencyId-$toAgencyId", mapOf(7 to Money(100)), effectiveYear = currentContractualEffectiveYear, exceptionPrice = "0.00")) } }
       .andExpect { view { name("update-price") } }
       .andExpect { status { isOk() } }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/EffectiveYearTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/EffectiveYearTest.kt
@@ -60,6 +60,46 @@ internal class EffectiveYearTest {
     assertThat(EffectiveYear { september(2020) }.canAddOrUpdatePrices(2018)).isFalse
   }
 
+  @Test
+  fun `ordinal month and years are correct for effective year 2020`() {
+    assertThat(ordinalMonthsAndYearForSeptemberToAugust(2020)).isEqualTo(
+      listOf(
+        9 to 2020,
+        10 to 2020,
+        11 to 2020,
+        12 to 2020,
+        1 to 2021,
+        2 to 2021,
+        3 to 2021,
+        4 to 2021,
+        5 to 2021,
+        6 to 2021,
+        7 to 2021,
+        8 to 2021,
+      )
+    )
+  }
+
+  @Test
+  fun `ordinal month and years are correct for effective year 2021`() {
+    assertThat(ordinalMonthsAndYearForSeptemberToAugust(2021)).isEqualTo(
+      listOf(
+        9 to 2021,
+        10 to 2021,
+        11 to 2021,
+        12 to 2021,
+        1 to 2022,
+        2 to 2022,
+        3 to 2022,
+        4 to 2022,
+        5 to 2022,
+        6 to 2022,
+        7 to 2022,
+        8 to 2022,
+      )
+    )
+  }
+
   private fun september(year: Int) = LocalDateTime.of(year, 9, 1, 0, 0)
 
   private fun august(year: Int) = LocalDateTime.of(year, 8, 31, 0, 0)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/MovePriceExceptionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/MovePriceExceptionTest.kt
@@ -62,6 +62,10 @@ internal class MovePriceExceptionTest : IntegrationTest() {
       .assertTextIsNotPresent<UpdatePricePage>("Existing price exceptions")
       .addPriceException(date.month, Money.valueOf(3000.00))
 
+    isAtPage(UpdatePrice)
+      .assertTextIsPresent("Existing price exceptions")
+      .isRowPresent<UpdatePricePage>("August", year.value, "£3000.00")
+
     goToPage(Dashboard)
 
     isAtPage(Dashboard)
@@ -103,7 +107,7 @@ internal class MovePriceExceptionTest : IntegrationTest() {
     isAtPage(UpdatePrice)
       .isAtPricePageForJourney("PRISON1", "POLICE1")
       .assertTextIsPresent("Existing price exceptions")
-      .isRowPresent<UpdatePricePage>("August", "£3000.00")
+      .isRowPresent<UpdatePricePage>("August", year.value, "£3000.00")
       .showPriceExceptionsTab()
       .removePriceException(date.month)
       .assertTextIsNotPresent<UpdatePricePage>("Existing price exceptions")


### PR DESCRIPTION
**Changes:**

Including year a long side the month for price exceptions due to the fact an effective starts mid year and goes into next.

![image](https://user-images.githubusercontent.com/60104344/138102668-8635fe7d-2338-4cdf-b735-949044c330ad.png)

![image](https://user-images.githubusercontent.com/60104344/138102741-4a0439e9-8027-42dd-9df9-bea9aeb63f26.png)
