### PR TITLE
P4-3299 updating 3rd party dependencies and correcting hardcoding of month in date dependent integration test.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.10"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.12"
   kotlin("plugin.spring") version "1.5.31"
   kotlin("plugin.jpa") version "1.5.31"
   kotlin("plugin.allopen") version "1.5.31"
@@ -17,17 +17,12 @@ dependencyCheck {
 
 dependencies {
   implementation("com.beust:klaxon:5.5")
-  implementation("com.amazonaws:aws-java-sdk-s3:1.12.87")
-  implementation("io.sentry:sentry-spring-boot-starter:5.2.2")
-  implementation("net.javacrumbs.shedlock:shedlock-spring:4.28.0")
-  implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.28.0")
+  implementation("com.amazonaws:aws-java-sdk-s3:1.12.99")
+  implementation("io.sentry:sentry-spring-boot-starter:5.3.0")
+  implementation("net.javacrumbs.shedlock:shedlock-spring:4.29.0")
+  implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.29.0")
   implementation("nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:3.0.0")
   implementation("org.apache.poi:poi-ooxml:5.0.0")
-
-  // These can be removed when (and only when) the dependencies have been updated in Spring 2.5.6. 9.0.53 has CVE's.
-  // There are still being overridden if add to the constraints below.
-  implementation("org.apache.tomcat.embed:tomcat-embed-core:9.0.54")
-  implementation("org.apache.tomcat.embed:tomcat-embed-websocket:9.0.54")
 
   constraints {
     implementation("org.apache.xmlgraphics:batik-all:1.14") {
@@ -44,13 +39,13 @@ dependencies {
     }
   }
 
-  implementation("org.flywaydb:flyway-core:8.0.1")
+  implementation("org.flywaydb:flyway-core:8.0.2")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
-  implementation("org.springframework.session:spring-session-jdbc:2.5.2")
+  implementation("org.springframework.session:spring-session-jdbc:2.5.3")
   implementation("org.springframework.shell:spring-shell-starter:2.0.1.RELEASE")
   implementation("org.thymeleaf.extras:thymeleaf-extras-springsecurity5:3.0.4.RELEASE")
   implementation(kotlin("script-runtime"))
@@ -81,7 +76,7 @@ dependencies {
   testImplementation("com.squareup.okhttp3:okhttp:4.9.2")
 
   runtimeOnly("com.h2database:h2")
-  runtimeOnly("org.postgresql:postgresql:42.2.24")
+  runtimeOnly("org.postgresql:postgresql:42.3.1")
 }
 
 tasks {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ControllerExtensionFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/ControllerExtensionFunctions.kt
@@ -52,3 +52,5 @@ internal fun ModelMap.removeAnyPreviousSearchHistory() {
   this.addAttribute(PICK_UP_ATTRIBUTE, "")
   this.addAttribute(DROP_OFF_ATTRIBUTE, "")
 }
+
+internal fun String.titleCased() = this.lowercase().replaceFirstChar { it.titlecaseChar() }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/MaintainSupplierPricingController.kt
@@ -93,7 +93,7 @@ class MaintainSupplierPricingController(
   data class PriceExceptionMonth(val value: String, val month: String, val alreadySelected: Boolean, val year: Int, val amount: Money?) {
     constructor(month: Month, alreadySelected: Boolean, year: Int, amount: Money?) : this(
       month.name,
-      month.name.lowercase().replaceFirstChar { it.titlecaseChar() },
+      month.name.titleCased(),
       alreadySelected,
       year,
       amount

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/MovePriceExceptionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/MovePriceExceptionTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
+import uk.gov.justice.digital.hmpps.pecs.jpc.controller.titleCased
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.move.MoveType.STANDARD
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Money
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Supplier
@@ -29,6 +30,8 @@ internal class MovePriceExceptionTest : IntegrationTest() {
 
   private val date = currentDate.minusMonths(2)
 
+  private val month = date.month
+
   private val year = Year.of(date.year)
 
   @Test
@@ -42,7 +45,7 @@ internal class MovePriceExceptionTest : IntegrationTest() {
 
     isAtPage(Dashboard).navigateToSelectMonthPage()
 
-    isAtPage(SelectMonthYear).navigateToDashboardFor(date.month, year)
+    isAtPage(SelectMonthYear).navigateToDashboardFor(month, year)
 
     isAtPage(Dashboard).navigateToManageJourneyPrice()
 
@@ -64,7 +67,7 @@ internal class MovePriceExceptionTest : IntegrationTest() {
 
     isAtPage(UpdatePrice)
       .assertTextIsPresent("Existing price exceptions")
-      .isRowPresent<UpdatePricePage>("August", year.value, "£3000.00")
+      .isRowPresent<UpdatePricePage>(month.name.titleCased(), year.value, "£3000.00")
 
     goToPage(Dashboard)
 
@@ -91,7 +94,7 @@ internal class MovePriceExceptionTest : IntegrationTest() {
 
     isAtPage(Dashboard).navigateToSelectMonthPage()
 
-    isAtPage(SelectMonthYear).navigateToDashboardFor(date.month, year)
+    isAtPage(SelectMonthYear).navigateToDashboardFor(month, year)
 
     isAtPage(Dashboard).navigateToManageJourneyPrice()
 
@@ -107,7 +110,7 @@ internal class MovePriceExceptionTest : IntegrationTest() {
     isAtPage(UpdatePrice)
       .isAtPricePageForJourney("PRISON1", "POLICE1")
       .assertTextIsPresent("Existing price exceptions")
-      .isRowPresent<UpdatePricePage>("August", year.value, "£3000.00")
+      .isRowPresent<UpdatePricePage>(month.name.titleCased(), year.value, "£3000.00")
       .showPriceExceptionsTab()
       .removePriceException(date.month)
       .assertTextIsNotPresent<UpdatePricePage>("Existing price exceptions")


### PR DESCRIPTION
**Changes:**

This now uses the latest version of Spring boot (which in turn resolves a CVE) which is pulled in via the hmpps.gradle-spring-boot plugin.

It also fixes an issue with a date dependent integration test.