### PR TITLE
P4 3281 single sign on and off

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/JpcApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/JpcApplication.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 class JpcApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/InterceptorsConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/InterceptorsConfiguration.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.config
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import uk.gov.justice.digital.hmpps.pecs.jpc.interceptors.SessionCookieInterceptor
+import uk.gov.justice.digital.hmpps.pecs.jpc.interceptors.SessionCookieProperties
+
+@Configuration
+class InterceptorsConfiguration : WebMvcConfigurer {
+
+  @Autowired
+  private lateinit var sessionCookieProperties: SessionCookieProperties
+
+  override fun addInterceptors(registry: InterceptorRegistry) {
+    registry.addInterceptor(SessionCookieInterceptor(sessionCookieProperties))
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/interceptors/SessionCookieInterceptor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/interceptors/SessionCookieInterceptor.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.interceptors
+
+import org.springframework.web.servlet.HandlerInterceptor
+import org.springframework.web.servlet.ModelAndView
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+private const val SPRING_SESSION_COOKIE = "SESSION"
+private const val ANY_PATH_STARTING_AT_ROOT = "/"
+
+/**
+ * Intercepts the session cookie to help with cookie attribute management/lifecycle.
+ */
+class SessionCookieInterceptor(private val properties: SessionCookieProperties) : HandlerInterceptor {
+
+  override fun postHandle(
+    request: HttpServletRequest,
+    response: HttpServletResponse,
+    handler: Any,
+    modelAndView: ModelAndView?
+  ) {
+    request.cookies?.firstOrNull { it.name == SPRING_SESSION_COOKIE }?.apply {
+      this.maxAge = properties.maxAge.toSeconds().toInt()
+      this.path = ANY_PATH_STARTING_AT_ROOT
+      this.secure = request.isSecure
+      this.isHttpOnly = properties.httpOnly
+    }?.also { response.addCookie(it) }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/interceptors/SessionCookieProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/interceptors/SessionCookieProperties.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.interceptors
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+import java.time.Duration
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "server.servlet.session.cookie")
+data class SessionCookieProperties(val maxAge: Duration, val httpOnly: Boolean)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,7 @@ spring:
     store-type: jdbc
     jdbc:
       initialize-schema: never
+    timeout: 20M
   shell:
     interactive:
       enabled: false
@@ -64,6 +65,8 @@ server:
     session:
       cookie:
         secure: true
+        max-age: 20M
+        http-only: true
     context-path: /
   forward-headers-strategy: native
   tomcat:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/interceptors/SessionCookieInterceptorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/interceptors/SessionCookieInterceptorTest.kt
@@ -1,0 +1,68 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.interceptors
+
+import com.nhaarman.mockitokotlin2.mock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import java.time.Duration
+import javax.servlet.http.Cookie
+
+class SessionCookieInterceptorTest {
+
+  private val sessionCookie: Cookie = Cookie("SESSION", "")
+
+  private val nonSessionCookie: Cookie = Cookie("OTHER", "")
+
+  private val response = MockHttpServletResponse()
+
+  @Test
+  fun `insecure session cookie values are set when intercepted`() {
+    val inSecureRequest = requestWith(sessionCookie).apply { isSecure = false }
+
+    SessionCookieInterceptor(SessionCookieProperties(Duration.ofMinutes(1), true)).postHandle(
+      inSecureRequest,
+      response,
+      mock(),
+      mock()
+    )
+
+    assertThat(response.cookies).contains(sessionCookie)
+    assertThat(sessionCookie.path).isEqualTo("/")
+    assertThat(sessionCookie.secure).isFalse
+    assertThat(sessionCookie.isHttpOnly).isTrue
+    assertThat(sessionCookie.maxAge).isEqualTo(60)
+  }
+
+  @Test
+  fun `secure session cookie values are set when intercepted`() {
+    val secureRequest = requestWith(sessionCookie).apply { isSecure = true }
+
+    SessionCookieInterceptor(SessionCookieProperties(Duration.ofMinutes(2), false)).postHandle(
+      secureRequest,
+      response,
+      mock(),
+      mock()
+    )
+
+    assertThat(response.cookies).contains(sessionCookie)
+    assertThat(sessionCookie.path).isEqualTo("/")
+    assertThat(sessionCookie.secure).isTrue
+    assertThat(sessionCookie.isHttpOnly).isFalse
+    assertThat(sessionCookie.maxAge).isEqualTo(120)
+  }
+
+  @Test
+  fun `non-session cookie is not intercepted`() {
+    SessionCookieInterceptor(SessionCookieProperties(Duration.ofMinutes(1), true)).postHandle(
+      requestWith(
+        nonSessionCookie
+      ),
+      response, mock(), mock()
+    )
+
+    assertThat(response.cookies).doesNotContain(nonSessionCookie)
+  }
+
+  private fun requestWith(cookie: Cookie) = MockHttpServletRequest().apply { setCookies(cookie) }
+}


### PR DESCRIPTION
**Changes:**

This is the first change of two related to SSO.  This particular change improves the cookie security.

In particular the key changes being setting the http-only attribute and max-age of the cookie.