### PR TITLE
P4-3281 changing how secure attibute is set. Did not work as expexcted when tested over HTTPS connection.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/interceptors/SessionCookieInterceptor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/interceptors/SessionCookieInterceptor.kt
@@ -22,7 +22,7 @@ class SessionCookieInterceptor(private val properties: SessionCookieProperties) 
     request.cookies?.firstOrNull { it.name == SPRING_SESSION_COOKIE }?.apply {
       this.maxAge = properties.maxAge.toSeconds().toInt()
       this.path = ANY_PATH_STARTING_AT_ROOT
-      this.secure = request.isSecure
+      this.secure = properties.secure
       this.isHttpOnly = properties.httpOnly
     }?.also { response.addCookie(it) }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/interceptors/SessionCookieProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/interceptors/SessionCookieProperties.kt
@@ -6,4 +6,4 @@ import java.time.Duration
 
 @ConstructorBinding
 @ConfigurationProperties(prefix = "server.servlet.session.cookie")
-data class SessionCookieProperties(val maxAge: Duration, val httpOnly: Boolean)
+data class SessionCookieProperties(val maxAge: Duration, val httpOnly: Boolean, val secure: Boolean)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/HtmlControllerTest.kt
@@ -56,7 +56,7 @@ class HtmlControllerTest(@Autowired private val wac: WebApplicationContext) {
   }
 
   @Test
-  internal fun `session cookie attributes are applied when present on a secure request`() {
+  internal fun `session cookie attributes are applied when present on an request`() {
     whenever(moveService.moveTypeSummaries(any(), any())).thenReturn(MoveTypeSummaries(0, listOf()))
 
     with(sessionCookie) {
@@ -68,38 +68,12 @@ class HtmlControllerTest(@Autowired private val wac: WebApplicationContext) {
 
     mockMvc.get("/dashboard") {
       session = mockSession.apply { setAttribute("date", LocalDate.now()) }
-      secure = true
       cookie(sessionCookie)
     }
 
     with(sessionCookie) {
       assertThat(path).isEqualTo("/") // applied in interceptor
-      assertThat(secure).isTrue // taken from request and applied in interceptor
-      assertThat(isHttpOnly).isTrue // taken from properties file and applied in interceptor
-      assertThat(maxAge).isEqualTo(Duration.ofMinutes(20).seconds.toInt()) // taken from properties file and applied in interceptor
-    }
-  }
-
-  @Test
-  internal fun `session cookie attributes are applied when present on an insecure request`() {
-    whenever(moveService.moveTypeSummaries(any(), any())).thenReturn(MoveTypeSummaries(0, listOf()))
-
-    with(sessionCookie) {
-      path = null
-      secure = false
-      isHttpOnly = false
-      maxAge = -1
-    }
-
-    mockMvc.get("/dashboard") {
-      session = mockSession.apply { setAttribute("date", LocalDate.now()) }
-      secure = false
-      cookie(sessionCookie)
-    }
-
-    with(sessionCookie) {
-      assertThat(path).isEqualTo("/") // applied in interceptor
-      assertThat(secure).isFalse // taken from request and applied in interceptor
+      assertThat(secure).isTrue // taken from properties file and applied in interceptor
       assertThat(isHttpOnly).isTrue // taken from properties file and applied in interceptor
       assertThat(maxAge).isEqualTo(Duration.ofMinutes(20).seconds.toInt()) // taken from properties file and applied in interceptor
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/interceptors/SessionCookieInterceptorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/interceptors/SessionCookieInterceptorTest.kt
@@ -18,9 +18,9 @@ class SessionCookieInterceptorTest {
 
   @Test
   fun `insecure session cookie values are set when intercepted`() {
-    val inSecureRequest = requestWith(sessionCookie).apply { isSecure = false }
+    val inSecureRequest = requestWith(sessionCookie)
 
-    SessionCookieInterceptor(SessionCookieProperties(Duration.ofMinutes(1), true)).postHandle(
+    SessionCookieInterceptor(SessionCookieProperties(Duration.ofMinutes(1), httpOnly = true, secure = false)).postHandle(
       inSecureRequest,
       response,
       mock(),
@@ -36,9 +36,9 @@ class SessionCookieInterceptorTest {
 
   @Test
   fun `secure session cookie values are set when intercepted`() {
-    val secureRequest = requestWith(sessionCookie).apply { isSecure = true }
+    val secureRequest = requestWith(sessionCookie)
 
-    SessionCookieInterceptor(SessionCookieProperties(Duration.ofMinutes(2), false)).postHandle(
+    SessionCookieInterceptor(SessionCookieProperties(Duration.ofMinutes(2), httpOnly = false, secure = true)).postHandle(
       secureRequest,
       response,
       mock(),
@@ -54,7 +54,7 @@ class SessionCookieInterceptorTest {
 
   @Test
   fun `non-session cookie is not intercepted`() {
-    SessionCookieInterceptor(SessionCookieProperties(Duration.ofMinutes(1), true)).postHandle(
+    SessionCookieInterceptor(SessionCookieProperties(Duration.ofMinutes(1), httpOnly = true, secure = true)).postHandle(
       requestWith(
         nonSessionCookie
       ),


### PR DESCRIPTION
**Changes:**

Tweaking how cookie 'secure' attribute is being set.  Did not work as expected even though documentation suggested otherwise.

![image](https://user-images.githubusercontent.com/60104344/140507356-7a180576-5dbc-4a24-98af-74a0ee443c30.png)
