### PR TITLE
P4 3334 price adjustment increase decimal points

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.12"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.13"
   kotlin("plugin.spring") version "1.5.31"
   kotlin("plugin.jpa") version "1.5.31"
   kotlin("plugin.allopen") version "1.5.31"
@@ -17,53 +17,22 @@ dependencyCheck {
 
 dependencies {
   implementation("com.beust:klaxon:5.5")
-  implementation("com.amazonaws:aws-java-sdk-s3:1.12.99")
-  implementation("io.sentry:sentry-spring-boot-starter:5.3.0")
+  implementation("com.amazonaws:aws-java-sdk-s3:1.12.112")
+  implementation("io.sentry:sentry-spring-boot-starter:5.4.0")
   implementation("net.javacrumbs.shedlock:shedlock-spring:4.29.0")
   implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.29.0")
   implementation("nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:3.0.0")
-  implementation("org.apache.poi:poi-ooxml:5.0.0")
-
-  constraints {
-    implementation("org.apache.xmlgraphics:batik-all:1.14") {
-      because("previous transitive version 1.13 pulled from Apache POI 5.0.0 has CVE")
-    }
-    implementation("org.apache.pdfbox:pdfbox:2.0.24") {
-      because("previous transitive version 2.0.23 pulled from Apache POI 5.0.0 has CVE")
-    }
-    implementation("org.apache.commons:commons-compress:1.21") {
-      because("previous transitive version 1.20 pulled from Apache POI 5.0.0 has CVE")
-    }
-    implementation("org.apache.santuario:xmlsec:2.2.3") {
-      because("previous transitive version 2.2.1 pulled from Apache POI 5.0.0 has CVE")
-    }
-  }
-
-  implementation("org.flywaydb:flyway-core:8.0.2")
+  implementation("org.apache.poi:poi-ooxml:5.1.0")
+  implementation("org.flywaydb:flyway-core:8.0.4")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
-  implementation("org.springframework.session:spring-session-jdbc:2.5.3")
+  implementation("org.springframework.session:spring-session-jdbc:2.6.0")
   implementation("org.springframework.shell:spring-shell-starter:2.0.1.RELEASE")
   implementation("org.thymeleaf.extras:thymeleaf-extras-springsecurity5:3.0.4.RELEASE")
   implementation(kotlin("script-runtime"))
-
-  constraints {
-    implementation("org.apache.xmlgraphics:batik-all:1.14") {
-      because("previous transitive version 1.13 pulled from Apache POI 5.0.0 has CVE")
-    }
-    implementation("org.apache.pdfbox:pdfbox:2.0.24") {
-      because("previous transitive version 2.0.23 pulled from Apache POI 5.0.0 has CVE")
-    }
-    implementation("org.apache.commons:commons-compress:1.21") {
-      because("previous transitive version 1.20 pulled from Apache POI 5.0.0 has CVE")
-    }
-    implementation("org.apache.santuario:xmlsec:2.2.3") {
-      because("previous transitive version 2.2.1 pulled from Apache POI 5.0.0 has CVE")
-    }
-  }
 
   testImplementation("com.github.tomakehurst:wiremock-standalone:2.27.2")
   testImplementation("org.fluentlenium:fluentlenium-junit-jupiter:4.8.0")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/AnnualPriceAdjustmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/AnnualPriceAdjustmentsController.kt
@@ -52,7 +52,7 @@ class AnnualPriceAdjustmentsController(
 
     model.apply {
       addContractStartAndEndDates()
-      addAttribute("form", AnnualPriceAdjustmentForm("0.0000"))
+      addAttribute("form", AnnualPriceAdjustmentForm("0.0"))
       addAttribute("history", priceAdjustmentHistoryFor(supplier))
     }
 
@@ -100,7 +100,7 @@ class AnnualPriceAdjustmentsController(
       .sortedByDescending { lh -> lh.datetime }
 
   data class AnnualPriceAdjustmentForm(
-    @get: Pattern(regexp = "^[0-9](\\.[0-9]{0,4})?\$", message = "Invalid rate")
+    @get: Pattern(regexp = "^[0-9](\\.[0-9]{0,15})?\$", message = "Invalid rate")
     val rate: String?,
 
     @get: NotBlank(message = "Enter details upto 255 characters")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/spreadsheet/outbound/PriceSheet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/spreadsheet/outbound/PriceSheet.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.service.spreadsheet.outbound
 
-import org.apache.pdfbox.util.Hex
+import org.apache.commons.codec.binary.Hex
 import org.apache.poi.ss.usermodel.BuiltinFormats
 import org.apache.poi.ss.usermodel.CellStyle
 import org.apache.poi.ss.usermodel.FillPatternType

--- a/src/main/resources/templates/annual-price-adjustment.html
+++ b/src/main/resources/templates/annual-price-adjustment.html
@@ -43,10 +43,10 @@
               <div id="rate-hint" class="govuk-hint">Example 1.5</div>
               <p th:if="${#fields.hasErrors('rate')}" class="govuk-error-message">
                 <span class="govuk-visually-hidden">Error:</span>
-                Enter a valid price adjustment greater than zero in the correct format ###.###
+                Enter a valid price adjustment greater than zero in the correct format #.###############
               </p>
               <div class="govuk-input__wrapper">
-                <input class="govuk-input govuk-input--width-5" id="rate" name="rate" type="text"
+                <input class="govuk-input govuk-input--width-10" id="rate" name="rate" type="text"
                        aria-describedby="rate-hint" th:field="*{rate}"
                        th:classappend="${#fields.hasErrors('rate')} ? 'govuk-input--error'">
               </div>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/AnnualPriceAdjustmentsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/AnnualPriceAdjustmentsControllerTest.kt
@@ -80,7 +80,7 @@ class AnnualPriceAdjustmentsControllerTest(@Autowired private val wac: WebApplic
         model {
           attribute(
             "form",
-            AnnualPriceAdjustmentsController.AnnualPriceAdjustmentForm("0.0000")
+            AnnualPriceAdjustmentsController.AnnualPriceAdjustmentForm("0.0")
           )
         }
       }
@@ -124,10 +124,10 @@ class AnnualPriceAdjustmentsControllerTest(@Autowired private val wac: WebApplic
   }
 
   @Test
-  fun `fails upon submission of an rate with more than 4 decimal places`() {
+  fun `fails upon submission of an rate with more than 15 decimal places`() {
     mockMvc.post("/annual-price-adjustment") {
       session = mockSession
-      param("rate", "1.12345")
+      param("rate", "1.12345678901234501")
       param("details", "some details")
     }
       .andExpect { model { attributeHasFieldErrorCode("form", "rate", "Pattern") } }
@@ -205,16 +205,16 @@ class AnnualPriceAdjustmentsControllerTest(@Autowired private val wac: WebApplic
 
   @Test
   fun `annual price adjustment with valid rate and details containing allowed characters are applied for supplier`() {
-    setOf("special characters @#$%%^&*()_", "special characters `~{}[]:;',./?", "inflation rate of 1.1234").forEach { allowedCharacters ->
+    setOf("special characters @#$%%^&*()_", "special characters `~{}[]:;',./?", "inflation rate of 1.123456789012345").forEach { allowedCharacters ->
       mockMvc.post("/annual-price-adjustment") {
         session = mockSession
-        param("rate", "1.1234")
+        param("rate", "1.123456789012345")
         param("details", allowedCharacters)
       }
         .andExpect { redirectedUrl("/manage-journey-price-catalogue") }
         .andExpect { status { is3xxRedirection() } }
 
-      verify(adjustmentsService).adjust(eq(Supplier.SERCO), eq(effectiveYearForDate(effectiveDate)), eq(1.1234), anyOrNull(), eq(allowedCharacters))
+      verify(adjustmentsService).adjust(eq(Supplier.SERCO), eq(effectiveYearForDate(effectiveDate)), eq(1.123456789012345), anyOrNull(), eq(allowedCharacters))
       verify(adjustmentsService, never()).adjustmentsHistoryFor(any())
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/AnnualBulkPriceAdjustmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/AnnualBulkPriceAdjustmentTest.kt
@@ -16,8 +16,10 @@ internal class AnnualBulkPriceAdjustmentTest : IntegrationTest() {
 
     isAtPage(ManageJourneyPriceCatalogue).navigateToApplyBulkPriceAdjustment()
 
-    isAtPage(AnnualPriceAdjustment).applyAdjustment(1.6, "Indexation rate of 1.6.")
+    isAtPage(AnnualPriceAdjustment).applyAdjustment(1.123456789012345, "Indexation rate of 1.123456789012345.")
 
-    isAtPage(ManageJourneyPriceCatalogue)
+    isAtPage(ManageJourneyPriceCatalogue).navigateToApplyBulkPriceAdjustment()
+
+    isAtPage(AnnualPriceAdjustment).showPriceAdjustmentHistoryTab().isPriceHistoryRowPresent(1.123456789012345, "Indexation rate of 1.123456789012345.")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/AnnualPriceAdjustmentPage.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/integration/pages/AnnualPriceAdjustmentPage.kt
@@ -32,7 +32,7 @@ class AnnualPriceAdjustmentPage : ApplicationPage() {
     return this
   }
 
-  fun isPriceHistoryRowPresent(rate: Double) {
-    isRowPresent<AnnualPriceAdjustmentPage>("Prices adjusted by blended rate of $rate")
+  fun isPriceHistoryRowPresent(rate: Double, notes: String) {
+    isRowPresent<AnnualPriceAdjustmentPage>("Prices adjusted by blended rate of $rate", notes)
   }
 }


### PR DESCRIPTION
**Changes:**

- Housekeeping to bump 3rd party dependencies.  This has helped clean up 3rd party CVE transitive dependency overrides.
- Bumping the number of allowed decimals from 4 to 15 for annual price adjustments.  It turns out this level of accuracy is required. 

Whilst there is no financial impact to the change itself, there is a financial impact to the Supplier, as they will not be fairly compensated for the journeys they complete as Indexation would not have been properly applied to the journeys.

![image](https://user-images.githubusercontent.com/60104344/142382871-13844222-aa53-40c5-96fe-5192f04dbc4c.png)
