### PR TITLE
P4-3393 pull in latest DPS gradle spring boot plugin to suppress Log4j CVE.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.14"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.15"
   kotlin("plugin.spring") version "1.5.31"
   kotlin("plugin.jpa") version "1.5.31"
   kotlin("plugin.allopen") version "1.5.31"


### PR DESCRIPTION
The change comes on the back of the Verracode pipeline issue the day before.  The OWASP job is also now failing for the same thing.

Moving to the next version or the DPS Gradle spring boot plugin should resolve this.  I have run the check locally before after pulling in this version and it gives the all clear.