### PR TITLE
P4-3394 fix CVE warnings for log4j, netty and h2 database.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.15"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.16"
   kotlin("plugin.spring") version "1.5.31"
   kotlin("plugin.jpa") version "1.5.31"
   kotlin("plugin.allopen") version "1.5.31"
@@ -46,8 +46,8 @@ dependencies {
   testImplementation("org.springframework.security:spring-security-test")
   testImplementation("com.squareup.okhttp3:mockwebserver:4.9.2")
   testImplementation("com.squareup.okhttp3:okhttp:4.9.2")
+  testImplementation("com.h2database:h2")
 
-  runtimeOnly("com.h2database:h2")
   runtimeOnly("org.postgresql:postgresql:42.3.1")
 }
 


### PR DESCRIPTION
Revolving the following security alerts for netty, log4j and h2 in-memory DB.

```
h2-1.4.200.jar (pkg:maven/com.h2database/h2@1.4.200, cpe:2.3:a:h2database:h2:1.4.200:*:*:*:*:*:*:*) : CVE-2021-23463
netty-buffer-4.1.69.Final.jar (pkg:maven/io.netty/netty-buffer@4.1.69.Final, cpe:2.3:a:netty:netty:4.1.69:*:*:*:*:*:*:*) : CVE-2021-43797
netty-codec-4.1.69.Final.jar (pkg:maven/io.netty/netty-codec@4.1.69.Final, cpe:2.3:a:netty:netty:4.1.69:*:*:*:*:*:*:*) : CVE-2021-43797
netty-codec-dns-4.1.69.Final.jar (pkg:maven/io.netty/netty-codec-dns@4.1.69.Final, cpe:2.3:a:netty:netty:4.1.69:*:*:*:*:*:*:*) : CVE-2021-43797
netty-codec-http-4.1.69.Final.jar (pkg:maven/io.netty/netty-codec-http@4.1.69.Final, cpe:2.3:a:netty:netty:4.1.69:*:*:*:*:*:*:*) : CVE-2021-43797
netty-codec-http2-4.1.69.Final.jar (pkg:maven/io.netty/netty-codec-http2@4.1.69.Final, cpe:2.3:a:netty:netty:4.1.69:*:*:*:*:*:*:*) : CVE-2021-43797
netty-codec-socks-4.1.69.Final.jar (pkg:maven/io.netty/netty-codec-socks@4.1.69.Final, cpe:2.3:a:netty:netty:4.1.69:*:*:*:*:*:*:*) : CVE-2021-43797
netty-common-4.1.69.Final.jar (pkg:maven/io.netty/netty-common@4.1.69.Final, cpe:2.3:a:netty:netty:4.1.69:*:*:*:*:*:*:*) : CVE-2021-43797
netty-handler-4.1.69.Final.jar (pkg:maven/io.netty/netty-handler@4.1.69.Final, cpe:2.3:a:netty:netty:4.1.69:*:*:*:*:*:*:*) : CVE-2021-43797
netty-handler-proxy-4.1.69.Final.jar (pkg:maven/io.netty/netty-handler-proxy@4.1.69.Final, cpe:2.3:a:netty:netty:4.1.69:*:*:*:*:*:*:*) : CVE-2021-43797
netty-resolver-4.1.69.Final.jar (pkg:maven/io.netty/netty-resolver@4.1.69.Final, cpe:2.3:a:netty:netty:4.1.69:*:*:*:*:*:*:*) : CVE-2021-43797
netty-resolver-dns-4.1.69.Final.jar (pkg:maven/io.netty/netty-resolver-dns@4.1.69.Final, cpe:2.3:a:netty:netty:4.1.69:*:*:*:*:*:*:*) : CVE-2021-43797
netty-resolver-dns-native-macos-4.1.69.Final-osx-x86_64.jar (pkg:maven/io.netty/netty-resolver-dns-native-macos@4.1.69.Final, cpe:2.3:a:netty:netty:4.1.69:*:*:*:*:*:*:*) : CVE-2021-43797
netty-transport-4.1.69.Final.jar (pkg:maven/io.netty/netty-transport@4.1.69.Final, cpe:2.3:a:netty:netty:4.1.69:*:*:*:*:*:*:*) : CVE-2021-43797
netty-transport-native-epoll-4.1.69.Final-linux-x86_64.jar (pkg:maven/io.netty/netty-transport-native-epoll@4.1.69.Final, cpe:2.3:a:netty:netty:4.1.69:*:*:*:*:*:*:*) : CVE-2021-43797
netty-transport-native-unix-common-4.1.69.Final.jar (pkg:maven/io.netty/netty-transport-native-unix-common@4.1.69.Final, cpe:2.3:a:netty:netty:4.1.69:*:*:*:*:*:*:*) : CVE-2021-43797
```
