### PR TITLE
P4-3392 migration to correct old price adjustment audit records.

### DIFF
--- a/src/main/resources/db/migration/dml/V1_15__add_quotes_to_multiplier_value_for_audit_events.sql
+++ b/src/main/resources/db/migration/dml/V1_15__add_quotes_to_multiplier_value_for_audit_events.sql
@@ -1,0 +1,4 @@
+update audit_events
+set metadata = replace(replace(metadata, '"multiplier" : ', '"multiplier" : "'), ', "details"', '", "details"')
+where event_type = 'JOURNEY_PRICE_BULK_ADJUSTMENT'
+  and metadata not like '%"multiplier" : "%';


### PR DESCRIPTION
So testing on DEV highlighted an issue that I was not able to easily recreate as integration tests start with a clean audit history for bulk price adjustments.

The application was not able to go to the price adjustment screen as it was not able to de-serialise old audit records for bulk price adjustments. A runtime error was occurring.

![image](https://user-images.githubusercontent.com/60104344/146540158-c09e8ecc-2703-4240-9c65-e5f44928f60a.png)

This change adds quotes around any existing multiplier values to support the change to BigDecimal.

**So this:**

`{"supplier" : "SERCO", "effective_year" : 2021, "multiplier" : 1.5, "details" : "some notes"}`

**Would be updated to this:**

`{"supplier" : "SERCO", "effective_year" : 2021, "multiplier" : "1.5", "details" : "zzz"}`

**Upon navigating to the appropriate page the user should see something like the following:**

![image](https://user-images.githubusercontent.com/60104344/146540345-16437150-ceb2-4566-b09e-f36374eaf6dd.png)
