### PR TITLE
P4-3404 temporary version overrides for 3rd party libraries with logging CVE warnings.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,13 @@ dependencyCheck {
 // added specifically due to thymeleaf@3.0.12.RELEASE and CVE-2021-43466 - remove when update included in spring-boot
 ext["thymeleaf.version"] = "3.0.13.RELEASE"
 
+// added specifically due to org.apache.logging.log4j and CVE-2021-44832, CVE-2021-45105, CVE-2021-42550 - remove when update included in spring boot gradle plugin
+ext["log4j2.version"] = "2.17.1"
+
 dependencies {
+  implementation("ch.qos.logback:logback-classic:1.2.10") // resolves CVE-2021-42550, remove when update included in spring boot gradle plugin
+  implementation("ch.qos.logback:logback-core:1.2.10") // resolves CVE-2021-42550 remove when update included in spring boot gradle plugin
+
   implementation("com.beust:klaxon:5.5")
   implementation("com.amazonaws:aws-java-sdk-s3:1.12.129")
   implementation("io.sentry:sentry-spring-boot-starter:5.5.0")


### PR DESCRIPTION
**Temporary overrides for the following security warnings:**

`log4j-api-2.16.0.jar (pkg:maven/org.apache.logging.log4j/log4j-api@2.16.0, cpe:2.3:a:apache:log4j:2.16.0:*:*:*:*:*:*:*) : CVE-2021-44832, CVE-2021-45105
log4j-to-slf4j-2.16.0.jar (pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.16.0, cpe:2.3:a:apache:log4j:2.16.0:*:*:*:*:*:*:*) : CVE-2021-44832, CVE-2021-45105
logback-classic-1.2.6.jar (pkg:maven/ch.qos.logback/logback-classic@1.2.6, cpe:2.3:a:qos:logback:1.2.6:*:*:*:*:*:*:*) : CVE-2021-42550
logback-core-1.2.6.jar (pkg:maven/ch.qos.logback/logback-core@1.2.6, cpe:2.3:a:qos:logback:1.2.6:*:*:*:*:*:*:*) : CVE-2021-42550
`