### PR TITLE
P4-3435 fixing issue parsing historic audit events for price changes.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/util/json/BigDecimalParser.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/util/json/BigDecimalParser.kt
@@ -11,7 +11,8 @@ val bigDecimalConverter = object : Converter {
 
   override fun canConvert(cls: Class<*>) = cls == BigDecimal::class.java
 
-  override fun fromJson(jv: JsonValue) = BigDecimal(jv.string)
+  override fun fromJson(jv: JsonValue) =
+    Result.runCatching { BigDecimal(jv.string) }.getOrElse { jv.double!!.toBigDecimal() }
 
   override fun toJson(value: Any) =
     """"$value""""

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/auditing/PriceMetadataTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/auditing/PriceMetadataTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Money
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Price
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Supplier
 import java.math.BigDecimal
+import java.time.LocalDateTime
 import java.time.Month
 
 internal class PriceMetadataTest {
@@ -107,5 +108,27 @@ internal class PriceMetadataTest {
     assertThat(metadata.isUpdate()).isFalse
     assertThat(metadata.isAdjustment()).isFalse
     assertThat(metadata.isRemoveException()).isTrue
+  }
+
+  @Test
+  fun `can map audit event with unquoted new price`() {
+    val auditEvent = AuditEvent(
+      AuditEventType.JOURNEY_PRICE, LocalDateTime.now(),
+      "some user",
+      "{\"supplier\" : \"SERCO\", \"from_nomis_id\" : \"SNAACC\", \"to_nomis_id\" : \"PVI\", \"effective_year\" : 2020, \"new_price\" : 5000.01}"
+    )
+
+    assertThat(PriceMetadata.map(auditEvent)).isEqualTo(PriceMetadata(Supplier.SERCO, "SNAACC", "PVI", 2020, BigDecimal("5000.01")))
+  }
+
+  @Test
+  fun `can map new audit event with quoted new price`() {
+    val auditEvent = AuditEvent(
+      AuditEventType.JOURNEY_PRICE, LocalDateTime.now(),
+      "some user",
+      "{\"supplier\" : \"SERCO\", \"from_nomis_id\" : \"SNAACC\", \"to_nomis_id\" : \"PVI\", \"effective_year\" : 2020, \"new_price\" : \"5000.01\"}"
+    )
+
+    assertThat(PriceMetadata.map(auditEvent)).isEqualTo(PriceMetadata(Supplier.SERCO, "SNAACC", "PVI", 2020, BigDecimal("5000.01")))
   }
 }


### PR DESCRIPTION
I identified a problem when trying to make a change to a price whereby if there was an historic audit record for the chosen price it can cause a runtime exception.

This is down for a format change.  It was stored as a double but now as a string.

This change adds support for both the old and new format change.