### PR TITLE
P4-3476 adding command so can backfill people and profiles independantly of moves.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ java -Xmx1024m -jar app.jar --spring.main.web-application-type=none --report-imp
 
 java -Xmx1024m -jar app.jar --spring.main.web-application-type=none --process-historic-moves --supplier=SERCO --from=YYYY-MM-DD --to=YYYY-MM-DD
 ```
+```
+# Backfill people and profiles. This will backfill from the date specified to the current day - 1
+
+java -Xmx1024m -jar app.jar --spring.main.web-application-type=none --import-people-profiles --from=YYYY-MM-DD
+```
 
 Typing help in the shell will also list the available commands.  TAB autocomplete is also available.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/CommandRunner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/CommandRunner.kt
@@ -34,6 +34,9 @@ class CommandRunner(
         arguments.getDate("from"),
         arguments.getDate("to")
       )
+      arguments.contains("import-people-profiles") -> reportImportCommand.importPeopleAndProfiles(
+        arguments.getDate("from")
+      )
       arguments.contains("process-historic-moves") -> historicMovesCommand.process(
         arguments.getDate("from"),
         arguments.getDate("to"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/HistoricMovesCommand.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/HistoricMovesCommand.kt
@@ -7,6 +7,9 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.service.HistoricMovesProcessingServ
 import uk.gov.justice.digital.hmpps.pecs.jpc.util.DateRange
 import java.time.LocalDate
 
+/**
+ * This command does not pull in any (new) data. It goes through the existing move data within the service.
+ */
 @ConditionalOnNotWebApplication
 @Component
 class HistoricMovesCommand(private val historicMovesProcessingService: HistoricMovesProcessingService) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/ReportImportCommand.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/ReportImportCommand.kt
@@ -26,4 +26,19 @@ class ReportImportCommand(private val importService: ImportService) {
 
     logger.info("Finished import of reports from $from to $to.")
   }
+
+  /**
+   * This will import all people and profiles from the date specified to the current date - 1.
+   */
+  fun importPeopleAndProfiles(from: LocalDate) {
+    logger.info("Starting backfill of people and profiles.")
+
+    Result.runCatching {
+      importService.importPeopleProfiles(from)
+    }.onFailure {
+      logger.error("An error occurred during import people and profiles", it)
+    }
+
+    logger.info("Finished backfill of people and profiles.")
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.domain.move.PersonPersister
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.spreadsheet.inbound.price.PriceImporter
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.spreadsheet.inbound.report.ReportImporter
+import uk.gov.justice.digital.hmpps.pecs.jpc.util.DateRange
 import uk.gov.justice.digital.hmpps.pecs.jpc.util.loggerFor
 import java.time.Duration
 import java.time.LocalDate
@@ -56,6 +57,18 @@ class ImportService(
         )
 
         raiseMonitoringAlertIf(moves.isEmpty(), "There were no moves to persist for reporting feed date $date.")
+      }
+    }
+  }
+
+  /**
+   * This will import all people and profiles starting from the date supplied upto the current date minus one day. This
+   * is needed to ensure the data is as up-to-date as possible.
+   */
+  fun importPeopleProfiles(from: LocalDate) {
+    DateRange(from, timeSource.yesterday()).run {
+      for (i in 0..ChronoUnit.DAYS.between(this.start, this.endInclusive)) {
+        importPeopleProfilesOn(this.start.plusDays(i))
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/CommandRunnerPeopleAndProfilesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/CommandRunnerPeopleAndProfilesTest.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.cli
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
+import java.time.LocalDate
+
+@SpringBootTest(args = ["--import-people-profiles", "--from=2022-01-13"], webEnvironment = WebEnvironment.NONE)
+@ActiveProfiles("test")
+@ContextConfiguration(classes = [TestConfig::class])
+class CommandRunnerPeopleAndProfilesTest {
+
+  @MockBean
+  private lateinit var historicMovesCommand: HistoricMovesCommand
+
+  @MockBean
+  private lateinit var bulkPriceImportCommand: BulkPriceImportCommand
+
+  @MockBean
+  private lateinit var reportImportCommand: ReportImportCommand
+
+  @Test
+  fun `people and profiles command is invoked for date 2022-01-13`() {
+    verify(reportImportCommand).importPeopleAndProfiles(LocalDate.of(2022, 1, 13))
+
+    verifyNoInteractions(bulkPriceImportCommand)
+    verifyNoInteractions(historicMovesCommand)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/ReportImportCommandTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/ReportImportCommandTest.kt
@@ -21,4 +21,11 @@ internal class ReportImportCommandTest {
 
     verify(importService).importReportsOn(DateRange(date, date.plusDays(1)))
   }
+
+  @Test
+  internal fun `given a date in the past the import people and profiles is called with the correct date`() {
+    commands.importPeopleAndProfiles(date)
+
+    verify(importService).importPeopleProfiles(date)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.service
 
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
@@ -155,5 +156,34 @@ internal class ImportServiceTest {
     verify(reportImporter).importMovesJourneysEventsOn(timeSourceWithFixedDate.date().plusDays(1))
     verify(reportImporter).importPeopleOn(timeSourceWithFixedDate.date().plusDays(1))
     verify(reportImporter).importProfilesOn(timeSourceWithFixedDate.date().plusDays(1))
+  }
+
+  @Test
+  fun `given an import date of yesterday ensure only one call is made when importing people and profiles`() {
+    importService.importPeopleProfiles(timeSourceWithFixedDate.yesterday())
+
+    verify(reportImporter).importPeopleOn(timeSourceWithFixedDate.yesterday())
+    verify(reportImporter).importProfilesOn(timeSourceWithFixedDate.yesterday())
+  }
+
+  @Test
+  fun `given an import date of two days ago ensure two calls are made when importing people and profiles`() {
+    importService.importPeopleProfiles(timeSourceWithFixedDate.yesterday().minusDays(1))
+
+    verify(reportImporter).importPeopleOn(timeSourceWithFixedDate.yesterday().minusDays(1))
+    verify(reportImporter).importPeopleOn(timeSourceWithFixedDate.yesterday())
+    verify(reportImporter).importProfilesOn(timeSourceWithFixedDate.yesterday().minusDays(1))
+    verify(reportImporter).importProfilesOn(timeSourceWithFixedDate.yesterday())
+  }
+
+  @Test
+  fun `given an import date of current or future date an exception is thrown when importing people and profiles`() {
+    assertThatThrownBy {
+      importService.importPeopleProfiles(timeSourceWithFixedDate.date())
+    }.isInstanceOf(RuntimeException::class.java)
+
+    assertThatThrownBy {
+      importService.importPeopleProfiles(timeSourceWithFixedDate.date().plusDays(1))
+    }.isInstanceOf(RuntimeException::class.java)
   }
 }


### PR DESCRIPTION
This adds a new backfill command for people and profiles only.  This can be done independently of moves.

This does not answer the question over why we are missing people/profiles.  Either way we need this to resolve the historic moves that are missing them.