### PR TITLE
P4-3476 split import of people and profiles out from moves to help reduce memory consumption when high volumes of reporting data.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/TaskScheduler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/TaskScheduler.kt
@@ -6,31 +6,34 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.pecs.jpc.tasks.BackfillReportsTask
 import uk.gov.justice.digital.hmpps.pecs.jpc.tasks.PreviousDaysLocationMappingTask
-import uk.gov.justice.digital.hmpps.pecs.jpc.tasks.PreviousDaysReportsTask
+import uk.gov.justice.digital.hmpps.pecs.jpc.tasks.PreviousDaysMovesTask
+import uk.gov.justice.digital.hmpps.pecs.jpc.tasks.PreviousDaysPeopleAndProfilesTask
 
 @ConditionalOnWebApplication
 @Component
 class TaskScheduler(
-  val previousDaysReportsTask: PreviousDaysReportsTask,
-  val previousDaysLocationMappingTask: PreviousDaysLocationMappingTask,
-  val backfillReportsTask: BackfillReportsTask
+  val previousDaysMoves: PreviousDaysMovesTask,
+  val previousDaysPeopleAndProfiles: PreviousDaysPeopleAndProfilesTask,
+  val previousDaysLocationMapping: PreviousDaysLocationMappingTask,
+  val backfillReports: BackfillReportsTask
 ) {
 
   @Scheduled(cron = "\${CRON_IMPORT_REPORTS}")
   @SchedulerLock(name = "importReports")
   fun previousDaysReportsTask() {
-    previousDaysReportsTask.execute()
+    previousDaysMoves.execute()
+    previousDaysPeopleAndProfiles.execute()
   }
 
   @Scheduled(cron = "\${CRON_AUTOMATIC_LOCATION_MAPPING}")
   @SchedulerLock(name = "automaticLocationMapping")
   fun automaticLocationMapping() {
-    previousDaysLocationMappingTask.execute()
+    previousDaysLocationMapping.execute()
   }
 
   @Scheduled(cron = "\${CRON_BACKFILL_REPORTS}")
   @SchedulerLock(name = "backfillReports")
   fun backfillReports() {
-    backfillReportsTask.execute()
+    backfillReports.execute()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
@@ -43,6 +43,10 @@ class ImportService(
     importPeopleProfilesOn(date)
   }
 
+  fun importMoves(date: LocalDate) {
+    importMovesJourneysEventsOn(date)
+  }
+
   private fun importMovesJourneysEventsOn(date: LocalDate) {
     logger.info("Importing moves, journeys and events for date: $date.")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/tasks/PreviousDaysLocationMappingTask.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/tasks/PreviousDaysLocationMappingTask.kt
@@ -7,8 +7,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.service.MonitoringService
 import uk.gov.justice.digital.hmpps.pecs.jpc.util.loggerFor
 
 /**
- * This task is designed in such a way it will always attempt to map new locations added to BaSM for the previous day.
- * This is based on the current date - 1 day at time of execution.
+ * This task maps new locations added to BaSM for the previous day to that of the date of execution.
  */
 private val logger = loggerFor<PreviousDaysLocationMappingTask>()
 
@@ -17,13 +16,15 @@ class PreviousDaysLocationMappingTask(
   private val service: AutomaticLocationMappingService,
   private val timeSource: TimeSource,
   monitoringService: MonitoringService
-) : Task("Previous Days Locations", monitoringService) {
+) : Task("Previous days locations", monitoringService) {
 
   override fun performTask() {
-    val yesterday = timeSource.date().minusDays(1)
+    timeSource.yesterday().run {
+      logger.info("Mapping previous days locations added to BaSM (if any): $this.")
 
-    logger.info("Mapping previous days locations added to BaSM (if any): $yesterday.")
+      service.mapIfNotPresentLocationsCreatedOn(this)
 
-    service.mapIfNotPresentLocationsCreatedOn(yesterday)
+      logger.info("Finished mapping previous days locations added to BaSM (if any): $this.")
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/tasks/PreviousDaysMovesTask.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/tasks/PreviousDaysMovesTask.kt
@@ -7,23 +7,24 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.service.MonitoringService
 import uk.gov.justice.digital.hmpps.pecs.jpc.util.loggerFor
 
 /**
- * This task is designed in such a way it will always import reporting data for the previous day. This is based on the
- * current date - 1 day at time of execution.
+ * This task imports moves for the previous day to that of the date of execution.
  */
-private val logger = loggerFor<PreviousDaysReportsTask>()
+private val logger = loggerFor<PreviousDaysMovesTask>()
 
 @Component
-class PreviousDaysReportsTask(
+class PreviousDaysMovesTask(
   private val service: ImportService,
   private val timeSource: TimeSource,
   monitoringService: MonitoringService
-) : Task("Previous Days Reports", monitoringService) {
+) : Task("Previous days moves", monitoringService) {
 
   override fun performTask() {
-    val yesterday = timeSource.date().minusDays(1)
+    timeSource.yesterday().run {
+      logger.info("Importing previous days moves for date $this.")
 
-    logger.info("Importing previous days reporting data: $yesterday.")
+      service.importMoves(this)
 
-    service.importReportsOn(yesterday)
+      logger.info("Finished importing previous days moves for date $this.")
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/tasks/PreviousDaysPeopleAndProfilesTask.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/tasks/PreviousDaysPeopleAndProfilesTask.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.tasks
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportService
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.MonitoringService
+import uk.gov.justice.digital.hmpps.pecs.jpc.util.loggerFor
+
+private val logger = loggerFor<PreviousDaysPeopleAndProfilesTask>()
+
+/**
+ * This task imports people and profiles for the previous day to that of the date of execution.
+ */
+@Component
+class PreviousDaysPeopleAndProfilesTask(
+  val importService: ImportService,
+  val timeSource: TimeSource,
+  monitoringService: MonitoringService
+) : Task("Previous days people and profiles", monitoringService) {
+
+  override fun performTask() {
+    timeSource.yesterday().run {
+      logger.info("Importing people and profiles for date $this.")
+
+      importService.importPeopleProfiles(this)
+
+      logger.info("Finished importing people and profiles for date $this.")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceTest.kt
@@ -159,6 +159,13 @@ internal class ImportServiceTest {
   }
 
   @Test
+  fun `given an import date of yesterday ensure only one call is made when importing moves`() {
+    importService.importMoves(timeSourceWithFixedDate.yesterday())
+
+    verify(reportImporter).importMovesJourneysEventsOn(timeSourceWithFixedDate.yesterday())
+  }
+
+  @Test
   fun `given an import date of yesterday ensure only one call is made when importing people and profiles`() {
     importService.importPeopleProfiles(timeSourceWithFixedDate.yesterday())
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/tasks/BackfillReportsTaskTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/tasks/BackfillReportsTaskTest.kt
@@ -15,7 +15,7 @@ internal class BackfillReportsTaskTest {
 
   private val importService: ImportService = mock()
 
-  private val timeSource: TimeSource = TimeSource { LocalDate.now().atStartOfDay() }
+  private val timeSource: TimeSource = TimeSource { LocalDate.of(2022, 2, 7).atStartOfDay() }
 
   private val monitoringService: MonitoringService = mock()
 
@@ -27,7 +27,7 @@ internal class BackfillReportsTaskTest {
 
     task.execute()
 
-    verify(importService).importReportsOn(DateRange(LocalDate.of(2020, 9, 1), timeSource.date().minusDays(1)))
+    verify(importService).importReportsOn(DateRange(LocalDate.of(2020, 9, 1), LocalDate.of(2022, 2, 6)))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/tasks/PreviousDaysMovesTaskTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/tasks/PreviousDaysMovesTaskTest.kt
@@ -6,25 +6,25 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
-import uk.gov.justice.digital.hmpps.pecs.jpc.service.AutomaticLocationMappingService
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportService
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.MonitoringService
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-internal class PreviousDaysLocationMappingTaskTest {
+internal class PreviousDaysMovesTaskTest {
 
-  private val mappingService: AutomaticLocationMappingService = mock()
+  private val importService: ImportService = mock()
   private val monitoringService: MonitoringService = mock()
   private val timeSource: TimeSource = TimeSource { LocalDateTime.of(2020, 11, 30, 12, 0) }
-  private val task = PreviousDaysLocationMappingTask(mappingService, timeSource, monitoringService)
+  private val task = PreviousDaysMovesTask(importService, timeSource, monitoringService)
 
   @Test
-  internal fun `locations mapping invoked with previous days date`() {
+  internal fun `move data import invoked with previous days date`() {
     LockAssert.TestHelper.makeAllAssertsPass(true)
 
     task.execute()
 
-    verify(mappingService).mapIfNotPresentLocationsCreatedOn(LocalDate.of(2020, 11, 29))
+    verify(importService).importMoves(LocalDate.of(2020, 11, 29))
     verifyNoInteractions(monitoringService)
   }
 
@@ -34,7 +34,7 @@ internal class PreviousDaysLocationMappingTaskTest {
 
     task.execute()
 
-    verifyNoInteractions(mappingService)
-    verify(monitoringService).capture("Unable to lock task 'Previous days locations' for execution")
+    verifyNoInteractions(importService)
+    verify(monitoringService).capture("Unable to lock task 'Previous days moves' for execution")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/tasks/PreviousDaysPeopleAndProfilesTaskTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/tasks/PreviousDaysPeopleAndProfilesTaskTest.kt
@@ -8,22 +8,23 @@ import org.mockito.kotlin.verifyNoInteractions
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.ImportService
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.MonitoringService
+import java.time.LocalDate
 import java.time.LocalDateTime
 
-internal class PreviousDaysReportsTaskTest {
+internal class PreviousDaysPeopleAndProfilesTaskTest {
 
   private val importService: ImportService = mock()
   private val monitoringService: MonitoringService = mock()
   private val timeSource: TimeSource = TimeSource { LocalDateTime.of(2020, 11, 30, 12, 0) }
-  private val task = PreviousDaysReportsTask(importService, timeSource, monitoringService)
+  private val task = PreviousDaysPeopleAndProfilesTask(importService, timeSource, monitoringService)
 
   @Test
-  internal fun `reports data import invoked with previous days date`() {
+  internal fun `people and profile data import invoked with previous days date`() {
     LockAssert.TestHelper.makeAllAssertsPass(true)
 
     task.execute()
 
-    verify(importService).importReportsOn(timeSource.date().minusDays(1))
+    verify(importService).importPeopleProfiles(LocalDate.of(2020, 11, 29))
     verifyNoInteractions(monitoringService)
   }
 
@@ -34,6 +35,6 @@ internal class PreviousDaysReportsTaskTest {
     task.execute()
 
     verifyNoInteractions(importService)
-    verify(monitoringService).capture("Unable to lock task 'Previous Days Reports' for execution")
+    verify(monitoringService).capture("Unable to lock task 'Previous days people and profiles' for execution")
   }
 }


### PR DESCRIPTION
The change splits out the import of people and profiles to run separately from that of moves in an effort to reduce memory consumption when there is a large volume of reporting data.

There is also a small amount of refactoring around the existing tasks to tidy them up a bit.