### PR TITLE
P4 3476 improve memory consumption usage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.0.2"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.0.3"
   kotlin("plugin.spring") version "1.6.10"
   kotlin("plugin.jpa") version "1.6.10"
   kotlin("plugin.allopen") version "1.6.10"
@@ -11,16 +11,13 @@ allOpen {
   annotation("javax.persistence.MappedSuperclass")
 }
 
-// Temporary override of version 9.0.56 for OWASP CVE's CVE-2022-23181, CVE-2022-23181 (this will come via the hmpps.gradle-spring-boot plugin eventually)
-ext["tomcat.version"] = "9.0.58"
-
 dependencyCheck {
   suppressionFiles.add("calculate-journey-variable-payments-suppressions.xml")
 }
 
 dependencies {
   implementation("com.beust:klaxon:5.5")
-  implementation("com.amazonaws:aws-java-sdk-s3:1.12.151")
+  implementation("com.amazonaws:aws-java-sdk-s3:1.12.154")
   implementation("io.sentry:sentry-spring-boot-starter:5.6.1")
   implementation("net.javacrumbs.shedlock:shedlock-spring:4.33.0")
   implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.33.0")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/move/PersistenceResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/move/PersistenceResult.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.domain.move
+
+/**
+ * Simple DTO to capture the numbers persisted (if any) and the number of errors (if any).
+ */
+data class PersistenceResult(val persisted: Int = 0, val errors: Int = 0) {
+  /**
+   * Will be zero if nothing processed.
+   */
+  fun processed() = persisted + errors
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/move/PersonPersister.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/move/PersonPersister.kt
@@ -15,50 +15,48 @@ class PersonPersister(
   /**
    * Returns the total number of successfully persisted people.
    */
-  fun persistPeople(people: List<Person>): Int {
+  fun persistPeople(people: Sequence<Person>): PersistenceResult {
     var saveCounter = 0
     var errorCounter = 0
 
     @Transactional
     fun persistPerson(person: Person) = personRepository.saveAndFlush(person)
 
-    logger.info("Persisting ${people.size} people")
     people.forEach { person ->
       Result.runCatching { persistPerson(person) }.onSuccess {
         saveCounter++
-        if (saveCounter % 500 == 0) logger.info("Persisted $saveCounter people out of ${people.size}.")
+        if (saveCounter % 500 == 0) logger.info("Persisted $saveCounter people...")
       }.onFailure {
         errorCounter++
         logger.warn("Error persisting person ${person.personId} - ${it.message}")
       }
     }
 
-    logger.info("Persisted $saveCounter people out of ${people.size}, $errorCounter errors occurred.")
+    logger.info("Persisted $saveCounter people, $errorCounter errors occurred.")
 
-    return saveCounter
+    return PersistenceResult(saveCounter, errorCounter)
   }
 
-  /**
-   * Returns the total number of successfully persisted profiles.
-   */
-  fun persistProfiles(profiles: List<Profile>): Int {
-    logger.info("Persisting ${profiles.size} profiles")
+  fun persistProfiles(profiles: Sequence<Profile>): PersistenceResult {
+    logger.info("Persisting profiles")
+
     var saveCounter = 0
     var errorCounter = 0
+
     profiles.forEach { profile ->
       Result.runCatching {
         profileRepository.saveAndFlush(profile)
       }.onSuccess {
         saveCounter++
-        if (saveCounter % 500 == 0) logger.info("Persisted $saveCounter profiles out of ${profiles.size}.")
+        if (saveCounter % 500 == 0) logger.info("Persisted $saveCounter profiles...")
       }.onFailure {
         errorCounter++
         logger.warn("Error persisting profile ${profile.profileId} - ${it.message}")
       }
     }
 
-    logger.info("Persisted $saveCounter profiles out of ${profiles.size}, $errorCounter errors occurred.")
+    logger.info("Persisted $saveCounter profiles, $errorCounter errors occurred.")
 
-    return saveCounter
+    return PersistenceResult(saveCounter, errorCounter)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportService.kt
@@ -81,32 +81,30 @@ class ImportService(
     logger.info("Importing people for date: $date.")
 
     import { reportImporter.importPeopleOn(date) }?.let {
-      val people = it.toList()
-      personPersister.persistPeople(people).let { persisted ->
-        auditService.create(AuditableEvent.importReportEvent("people", date, people.size, persisted))
+      personPersister.persistPeople(it).let { result ->
+        auditService.create(AuditableEvent.importReportEvent("people", date, result.processed(), result.persisted))
 
         raiseMonitoringAlertIf(
-          people.isNotEmpty() && people.size > persisted,
-          "people: persisted $persisted out of ${people.size} for reporting feed date $date."
+          result.errors > 0,
+          "people: persisted ${result.persisted} and ${result.errors} errors for reporting feed date $date."
         )
 
-        raiseMonitoringAlertIf(people.isEmpty(), "There were no people to persist for reporting feed date $date.")
+        raiseMonitoringAlertIf(result.processed() == 0, "There were no people to persist for reporting feed date $date.")
       }
     }
 
     logger.info("Importing profiles for date: $date.")
 
     import { reportImporter.importProfilesOn(date) }?.let {
-      val profiles = it.toList()
-      personPersister.persistProfiles(profiles).let { persisted ->
-        auditService.create(AuditableEvent.importReportEvent("profiles", date, profiles.size, persisted))
+      personPersister.persistProfiles(it).let { result ->
+        auditService.create(AuditableEvent.importReportEvent("profiles", date, result.processed(), result.persisted))
 
         raiseMonitoringAlertIf(
-          profiles.isNotEmpty() && profiles.size > persisted,
-          "profiles: persisted $persisted out of ${profiles.size} for reporting feed date $date."
+          result.errors > 0,
+          "profiles: persisted ${result.persisted} and ${result.errors} errors for reporting feed date $date."
         )
 
-        raiseMonitoringAlertIf(profiles.isEmpty(), "There were no profiles to persist for reporting feed date $date.")
+        raiseMonitoringAlertIf(result.processed() == 0, "There were no profiles to persist for reporting feed date $date.")
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/spreadsheet/inbound/report/ReportImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/spreadsheet/inbound/report/ReportImporter.kt
@@ -20,8 +20,11 @@ open class ReportImporter(
 
   private fun importMovesJourneysEvents(from: LocalDate, to: LocalDate): Collection<Move> {
     val movesContent = getContents("moves", from, to)
+
     val journeysContent = getContents("journeys", from, to)
+
     val eventsContent = getContents("events", from, to)
+
     return ReportParser.parseMovesJourneysEvents(
       moveFiles = movesContent,
       journeyFiles = journeysContent,
@@ -33,6 +36,7 @@ open class ReportImporter(
 
   private fun importPeople(from: LocalDate, to: LocalDate): Sequence<Person> {
     val peopleContent = getContents("people", from, to)
+
     return ReportParser.parseAsPerson(peopleFiles = peopleContent)
   }
 
@@ -40,6 +44,7 @@ open class ReportImporter(
 
   private fun importProfiles(from: LocalDate, to: LocalDate): Sequence<Profile> {
     val profilesContent = getContents("profiles", from, to)
+
     return ReportParser.parseAsProfile(profileFiles = profilesContent)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/spreadsheet/inbound/report/ReportParser.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/spreadsheet/inbound/report/ReportParser.kt
@@ -21,7 +21,7 @@ object ReportParser {
    */
   fun <T> read(files: List<String>, f: (j: String) -> T?): Sequence<T> {
     return files.asSequence().flatMap {
-      it.split("\n").filter { it.isNotEmpty() }.map { json ->
+      it.splitToSequence("\n").filter { it.isNotEmpty() }.map { json ->
         try {
           f(json)
         } catch (e: Exception) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/move/PersonPersisterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/move/PersonPersisterTest.kt
@@ -45,7 +45,7 @@ internal class PersonPersisterTest(
   @Test
   fun `Persist PII data`() {
     val reportPerson = reportPersonFactory()
-    PersonPersister(personRepository, profileRepository).persistPeople(listOf(reportPerson))
+    PersonPersister(personRepository, profileRepository).persistPeople(sequenceOf(reportPerson))
 
     entityManager.flush()
 
@@ -115,7 +115,7 @@ internal class PersonPersisterTest(
         entities(2) { reportPersonFactory().copy(personId = "invalid") } +
           entities(4) { id -> reportPersonFactory().copy(personId = id) }
       )
-    ).isEqualTo(4)
+    ).isEqualTo(PersistenceResult(persisted = 4, errors = 2))
 
     verify(personRepositorySpy, times(6)).saveAndFlush(any())
   }
@@ -176,11 +176,11 @@ internal class PersonPersisterTest(
         entities(2) { profileFactory().copy(profileId = "invalid", personId = "invalid") } +
           entities(4) { id -> profileFactory().copy(profileId = id, personId = id) }
       )
-    ).isEqualTo(4)
+    ).isEqualTo(PersistenceResult(persisted = 4, errors = 2))
 
     verify(profileRepositorySpy, times(6)).saveAndFlush(any())
   }
 
-  fun <T> entities(numberOf: Int, f: (id: String) -> T): List<T> =
-    MutableList(numberOf) { index -> f(index.toString()) }
+  fun <T> entities(numberOf: Int, f: (id: String) -> T): Sequence<T> =
+    MutableList(numberOf) { index -> f(index.toString()) }.asSequence()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/ImportServiceIntegrationTest.kt
@@ -45,7 +45,7 @@ class ImportServiceIntegrationTest(
   fun `given some report files contain errors the import should still complete successfully and not fail`() {
     importService.importReportsOn(LocalDate.of(2020, 12, 1))
 
-    verify(monitoringService).capture("people: persisted 3 out of 4 for reporting feed date 2020-12-01.")
+    verify(monitoringService).capture("people: persisted 3 and 1 errors for reporting feed date 2020-12-01.")
     verifyNoMoreInteractions(monitoringService)
   }
 


### PR DESCRIPTION
This changes the importing process for both people and profiles to be sequence (stream) based to help with memory consumption when we have large volumes of data.

This does not get round the fact due to ongoing backfill we have some very large files being processed e.g. 195MB for a profiles file (of which was about 54k individual profiles).