### PR TITLE
Stop using host Docker network mode

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-APP_DB_URL="jdbc:postgresql://127.0.0.1:5433/jpc?reWriteBatchedInserts=true&user=jpc&password=letmein"
+APP_DB_URL="jdbc:postgresql://localhost:5433/jpc?reWriteBatchedInserts=true&user=jpc&password=letmein"
 AWS_ACCESS_KEY_ID=foo
 AWS_SECRET_ACCESS_KEY=bar
 AWS_DEFAULT_REGION=eu-west-2

--- a/docker-compose-cjvp.yml
+++ b/docker-compose-cjvp.yml
@@ -17,4 +17,3 @@ services:
     environment:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=dev
-    network_mode: host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       POSTGRES_USER: jpc
       POSTGRES_PASSWORD: letmein
     command: -p 5433
-    network_mode: host
 
   localstack:
     image: localstack/localstack:0.11.5
@@ -30,7 +29,6 @@ services:
       - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
       - $PWD/localstack:/docker-entrypoint-initaws.d
-    network_mode: host
 
   hmpps-auth:
     image: quay.io/hmpps/hmpps-auth:latest
@@ -42,7 +40,6 @@ services:
     environment:
       - SERVER_PORT=9090
       - SPRING_PROFILES_ACTIVE=dev
-    network_mode: host
 
   hmpps-book-secure-move-api:
     image: rodolpheche/wiremock:latest
@@ -52,4 +49,3 @@ services:
     volumes:
       - $PWD/wiremock-docker:/home/wiremock
     command: --verbose --global-response-templating --port=8081
-    network_mode: host

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,7 +8,7 @@ spring:
     enabled: true
     locations: classpath:/db/migration
 
-APP_DB_URL: "jdbc:postgresql://127.0.0.1:5433/jpc?reWriteBatchedInserts=true&user=jpc&password=letmein"
+APP_DB_URL: "jdbc:postgresql://localhost:5433/jpc?reWriteBatchedInserts=true&user=jpc&password=letmein"
 AWS_ACCESS_KEY_ID: foo
 AWS_SECRET_ACCESS_KEY: bar
 AWS_DEFAULT_REGION: eu-west-2


### PR DESCRIPTION
As far as I can tell this mode isn't necessary as we already expose the ports of the dependant services. Without it, I've got the service running locally and the integration tests passing.