### PR TITLE
Assign PECS Developers as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ministryofjustice/book-a-secure-move
+* @ministryofjustice/pecs-developers


### PR DESCRIPTION
This team contains only developers and means we'll automatically be asked to review any PRs.