### PR TITLE
P4-3561 this changes the historic move processing service to include moves that have not been assigned a move type. They were previously ignored.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/moves/MoveService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/moves/MoveService.kt
@@ -35,7 +35,7 @@ class MoveService(
   }
 
   fun moves(supplier: Supplier, startDate: LocalDate) =
-    moveQueryRepository.movesInDateRange(supplier, startDate, endOfMonth(startDate))
+    moveQueryRepository.movesWithMoveTypeInDateRange(supplier, startDate, endOfMonth(startDate))
 
   fun findMoveByReferenceAndSupplier(ref: String, supplier: Supplier) =
     // At time of writing the need for filtering null moves types is a result of poor supplier data.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/move/MoveQueryRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/move/MoveQueryRepositoryTest.kt
@@ -67,6 +67,7 @@ internal class MoveQueryRepositoryTest {
   private val standardMoveGeoamey = standardMoveSerco.copy(moveId = "M2", supplier = Supplier.GEOAMEY)
   private val journeyModelGeoamey =
     journeyModel1Serco.copy(journeyId = "J3", supplier = Supplier.GEOAMEY, moveId = standardMoveGeoamey.moveId)
+  private val moveWithoutMoveTypeGeoamey = standardMoveSerco.copy(moveId = "M3", supplier = Supplier.GEOAMEY, moveType = null)
 
   @BeforeEach
   fun beforeEach() {
@@ -103,6 +104,7 @@ internal class MoveQueryRepositoryTest {
 
     moveRepository.save(standardMoveGeoamey)
     journeyRepository.save(journeyModelGeoamey)
+    moveRepository.save(moveWithoutMoveTypeGeoamey)
 
     entityManager.flush()
   }
@@ -244,7 +246,7 @@ internal class MoveQueryRepositoryTest {
   }
 
   @Test
-  fun `GEOAMey moves count`() {
+  fun `GEOAmey moves count`() {
     assertThat(
       moveQueryRepository.moveCountInDateRange(
         Supplier.GEOAMEY,
@@ -252,5 +254,33 @@ internal class MoveQueryRepositoryTest {
         defaultMoveDate10Sep2020
       )
     ).isEqualTo(1)
+  }
+
+  @Test
+  fun `GEOAmey has one standard move for moves with a move type`() {
+    val moves = moveQueryRepository.movesWithMoveTypeInDateRange(
+      Supplier.GEOAMEY,
+      defaultMoveDate10Sep2020,
+      defaultMoveDate10Sep2020,
+    )
+
+    assertThat(moves).hasSize(6)
+    assertThat(moves[MoveType.STANDARD]).hasSize(1)
+    assertThat(moves[MoveType.CANCELLED]).isEmpty()
+    assertThat(moves[MoveType.REDIRECTION]).isEmpty()
+    assertThat(moves[MoveType.LOCKOUT]).isEmpty()
+    assertThat(moves[MoveType.LONG_HAUL]).isEmpty()
+    assertThat(moves[MoveType.MULTI]).isEmpty()
+  }
+
+  @Test
+  fun `All GEOAMey moves found, with or without a move type assigned`() {
+    assertThat(
+      moveQueryRepository.allMovesInDateRange(
+        Supplier.GEOAMEY,
+        defaultMoveDate10Sep2020,
+        defaultMoveDate10Sep2020,
+      )
+    ).hasSize(2)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/moves/HistoricMovesProcessingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/moves/HistoricMovesProcessingServiceTest.kt
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.move.Move
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.move.MovePersister
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.move.MoveQueryRepository
-import uk.gov.justice.digital.hmpps.pecs.jpc.domain.move.MoveType
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.util.DateRange
 import java.time.LocalDateTime
@@ -55,13 +54,11 @@ class HistoricMovesProcessingServiceTest {
   fun `given a valid date range when process historic moves is called the expected invocations are made`() {
     val dateRange = DateRange(timeSource.yesterday(), timeSource.yesterday())
 
-    whenever(moveQueryRepository.movesInDateRange(Supplier.SERCO, dateRange.start, dateRange.endInclusive)).thenReturn(
-      mapOf(MoveType.STANDARD to listOf(move))
-    )
+    whenever(moveQueryRepository.allMovesInDateRange(Supplier.SERCO, dateRange.start, dateRange.endInclusive)).thenReturn(listOf(move))
 
     service.process(DateRange(dateRange.start, dateRange.endInclusive), Supplier.SERCO)
 
-    verify(moveQueryRepository).movesInDateRange(Supplier.SERCO, dateRange.start, dateRange.endInclusive)
+    verify(moveQueryRepository).allMovesInDateRange(Supplier.SERCO, dateRange.start, dateRange.endInclusive)
     verify(movePersister).persist(listOf(move))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/reports/ImportServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/reports/ImportServiceIntegrationTest.kt
@@ -102,8 +102,7 @@ class ImportServiceIntegrationTest(
       Supplier.GEOAMEY
     )
 
-    // Note out of the 9 moves one is never assigned a move type hence. The processor ignores these moves, so there are 8 and not 9 in this case.
-    assertThat(processedMoveCount).isEqualTo(8)
+    assertThat(processedMoveCount).isEqualTo(9)
 
     // Check moves have not changed
     assertThat(importedDecemberMoves.map { it.first }).hasSameElementsAs(createdMoves)


### PR DESCRIPTION
Whilst carrying out move corrections on the preprod and production environments I realised moves without move types were not being included when they should have been.

The historic move processing service has now been changed to now include all moves with and without a move type.