### PR TITLE
P4-3579 set the OWASP cache to be inline with changes to the shared HMPPS Circle CI orb.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,7 @@ workflows:
           slack_channel: pecs-dev
           context:
             - hmpps-common-vars
+          cache_key: "v2_0"
       - hmpps/trivy_latest_scan:
           slack_channel: pecs-dev
           context:


### PR DESCRIPTION
Chore:

 Set the OWASP cache to be inline with changes to the shared HMPPS Circle CI orb.  This should resolve the following:

![image](https://user-images.githubusercontent.com/60104344/159659507-54d15e5f-1769-404a-87f5-f960a065e7c8.png)
