### PR TITLE
P4-3559 tweak to queries as the date restriction needs have changed due to have month and year as columns on the moves tables.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/journey/JourneyQueryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/journey/JourneyQueryRepository.kt
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.location.LocationType
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Supplier
 import java.sql.ResultSet
-import java.sql.Timestamp
 import java.time.LocalDate
 
 /**
@@ -106,7 +105,7 @@ class JourneyQueryRepository(@Autowired val jdbcTemplate: JdbcTemplate) {
                      left join PRICE_EXCEPTIONS pe on p.price_id = pe.price_id and pe.month = ?
                      where m.move_type is not null and m.supplier = ? 
                         and m.move_month = ? and m.move_year = ?
-                        and m.drop_off_or_cancelled >= ? and m.drop_off_or_cancelled < ?
+                        and m.drop_off_or_cancelled is not null
             GROUP BY j.from_nomis_agency_id, j.to_nomis_agency_id, jfl.site_name, jtl.site_name, jfl.location_type, jtl.location_type, COALESCE(pe.price_in_pence, p.price_in_pence)
             $havingOnlyUnpriced
             ORDER BY null_locations_and_prices_sum desc, volume desc
@@ -119,9 +118,7 @@ class JourneyQueryRepository(@Autowired val jdbcTemplate: JdbcTemplate) {
       startDate.possiblePriceExceptionMonth(),
       supplier.name,
       startDate.month.value,
-      startDate.year,
-      Timestamp.valueOf(startDate.atStartOfDay()),
-      Timestamp.valueOf(endDateInclusive.plusDays(1).atStartOfDay())
+      startDate.year
     )
   }
 
@@ -158,8 +155,7 @@ class JourneyQueryRepository(@Autowired val jdbcTemplate: JdbcTemplate) {
              left join LOCATIONS jtl on j.to_nomis_agency_id = jtl.nomis_agency_id 
              left join PRICES p on jfl.location_id = p.from_location_id and jtl.location_id = p.to_location_id and j.effective_year = p.effective_year and p.supplier = ?
              left join PRICE_EXCEPTIONS pe on p.price_id = pe.price_id and pe.month = ?
-             where m.move_type is not null and m.supplier = ? and m.move_month = ? and m.move_year = ? and m.drop_off_or_cancelled >= ?  
-             and m.drop_off_or_cancelled < ?
+             where m.move_type is not null and m.supplier = ? and m.move_month = ? and m.move_year = ? and m.drop_off_or_cancelled is not null
              GROUP BY journey) as js
       """.trimIndent()
 
@@ -170,9 +166,7 @@ class JourneyQueryRepository(@Autowired val jdbcTemplate: JdbcTemplate) {
       startDate.possiblePriceExceptionMonth(),
       supplier.name,
       startDate.month.value,
-      startDate.year,
-      Timestamp.valueOf(startDate.atStartOfDay()),
-      Timestamp.valueOf(endDateInclusive.plusDays(1).atStartOfDay())
+      startDate.year
     )[0]
   }
 }


### PR DESCRIPTION
So on comparing results with changes deployed to preprod versus what was in production I noticed a couple of multi type moves were not displaying as expected for Feb 2022 and Mar 2022.

Ultimately this is a result of poor seed data, either way it should still show up in the multi moves so they can at least be investigated and ideally resolved the by the suppliers.

With the two additional fields now present on the moves table (month and year) we only need to check for the presence of an end date and not if it is in range, the month and year fields service this purpose.