### PR TITLE
P4-3558 removing journey lockout event which is no longer used by Basm.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/event/Event.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/event/Event.kt
@@ -167,7 +167,6 @@ enum class EventType(val value: String) {
   MOVE_REDIRECT("MoveRedirect"),
   JOURNEY_START("JourneyStart"),
   JOURNEY_COMPLETE("JourneyComplete"),
-  JOURNEY_LOCKOUT("JourneyLockout"),
   JOURNEY_LODGING("JourneyLodging"),
   JOURNEY_CANCEL("JourneyCancel"),
   UNKNOWN("Unknown"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/move/MovePersister.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/move/MovePersister.kt
@@ -171,7 +171,6 @@ class MovePersister(
 
 private val noteworthyEvents = listOf(
   EventType.MOVE_REDIRECT,
-  EventType.JOURNEY_LOCKOUT,
   EventType.MOVE_LOCKOUT,
   EventType.JOURNEY_CANCEL,
   EventType.MOVE_LODGING_START,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/reports/MoveFilterer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/reports/MoveFilterer.kt
@@ -69,7 +69,7 @@ object MoveFilterer {
         move.hasAllOf(EventType.JOURNEY_LODGING) ||
           move.hasAllOf(EventType.MOVE_LODGING_START, EventType.MOVE_LODGING_END)
         ) &&
-      move.hasNoneOf(EventType.MOVE_REDIRECT, EventType.MOVE_LOCKOUT, EventType.JOURNEY_LOCKOUT) &&
+      move.hasNoneOf(EventType.MOVE_REDIRECT, EventType.MOVE_LOCKOUT) &&
       with(move.journeys.map { it }) {
         count { it.stateIsAnyOf(JourneyState.completed) && it.billable } == 2
       }
@@ -80,7 +80,7 @@ object MoveFilterer {
    */
   fun isLockoutMove(move: Move) =
     move.isCompleted() &&
-      move.hasAnyOf(EventType.MOVE_LOCKOUT, EventType.JOURNEY_LOCKOUT) &&
+      move.hasAnyOf(EventType.MOVE_LOCKOUT) &&
       move.hasNoneOf(EventType.MOVE_REDIRECT) &&
       with(move.journeys) {
         count { it.stateIsAnyOf(JourneyState.completed) && it.billable } in 2..3
@@ -108,7 +108,6 @@ object MoveFilterer {
         EventType.MOVE_LODGING_START,
         EventType.MOVE_LODGING_END,
         EventType.MOVE_LOCKOUT,
-        EventType.JOURNEY_LOCKOUT
       ) &&
       when (val moveStartDate = move.mayBeMoveStartDate()) {
         null -> {

--- a/src/main/resources/templates/fragments/event-type.html
+++ b/src/main/resources/templates/fragments/event-type.html
@@ -9,7 +9,6 @@
     <span th:case="'MoveRedirect'">Redirected</span>
     <span th:case="'JourneyStart'">Journey started</span>
     <span th:case="'JourneyComplete'">Journey completed</span>
-    <span th:case="'JourneyLockout'">Journey lockout</span>
     <span th:case="'JourneyLodging'">Journey lodging</span>
     <span th:case="'JourneyCancel'">Journey cancelled</span>
     <span th:case="'Unknown'">No events listed</span>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/reports/MoveFiltererTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/reports/MoveFiltererTest.kt
@@ -197,32 +197,11 @@ internal class MoveFiltererTest {
     journeys = listOf(reportJourneyFactory(journeyId = "J1M1", billable = true, toLocation = "DOES_NOT_MATCH_MOVE"))
   )
 
-  private val completedLockoutJourneyLockoutEvent = reportMoveFactory(
-    moveId = "M8",
-    events = listOf(
-      moveEventFactory(type = EventType.MOVE_START.value, moveId = "M8", occurredAt = from.atStartOfDay()),
-      moveEventFactory(
-        type = EventType.MOVE_COMPLETE.value,
-        moveId = "M8",
-        occurredAt = from.atStartOfDay().plusHours(4)
-      )
-    ),
-    journeys = listOf(
-      reportJourneyFactory(
-        journeyId = "J1M8",
-        moveId = "M8",
-        billable = true,
-        events = listOf(journeyEventFactory(journeyId = "J1M8", type = "JourneyLockout"))
-      ),
-      reportJourneyFactory(journeyId = "J2M8", moveId = "M8", billable = true)
-    )
-  )
-
   private val completedLockoutMoveLockoutEvent = reportMoveFactory(
     moveId = "M8b",
     events = listOf(
       moveEventFactory(type = EventType.MOVE_START.value, moveId = "M8b", occurredAt = from.atStartOfDay()),
-      moveEventFactory(type = "MoveLockout", moveId = "M8b"),
+      moveEventFactory(type = EventType.MOVE_LOCKOUT.value, moveId = "M8b"),
       moveEventFactory(
         type = EventType.MOVE_COMPLETE.value,
         moveId = "M8b",
@@ -276,7 +255,6 @@ internal class MoveFiltererTest {
 
   @Test
   fun `is lockout move`() {
-    assertThat(MoveFilterer.isLockoutMove(completedLockoutJourneyLockoutEvent)).isTrue
     assertThat(MoveFilterer.isLockoutMove(completedLockoutMoveLockoutEvent)).isTrue
     assertThat(MoveFilterer.isLockoutMove(standard)).isFalse
   }


### PR DESCRIPTION
This removes all references to the JourneyLockout event which has been deprecated in the Basm API.

This is a safe removal as there are no such events recorded at the time of raising the PR.