### PR TITLE
P4 3564 breadcrumb trail bug

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.5-beta-3"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.5"
   kotlin("plugin.spring") version "1.6.21"
   kotlin("plugin.jpa") version "1.6.21"
   kotlin("plugin.allopen") version "1.6.21"
@@ -17,7 +17,7 @@ dependencyCheck {
 
 dependencies {
   implementation("com.beust:klaxon:5.6")
-  implementation("com.amazonaws:aws-java-sdk-s3:1.12.205")
+  implementation("com.amazonaws:aws-java-sdk-s3:1.12.207")
   implementation("io.sentry:sentry-spring-boot-starter:5.7.3")
   implementation("net.javacrumbs.shedlock:shedlock-spring:4.34.0")
   implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.34.0")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/SummaryPageController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/SummaryPageController.kt
@@ -245,7 +245,7 @@ class SummaryPageController(
 
     val maybeMove = moveService.findMoveByReferenceAndSupplier(moveRef, supplier)
     val uri =
-      maybeMove.orElse(null)?.let { "$MOVES_URL/${it.moveId}" } ?: "$FIND_MOVE_URL/?no-results-for=${form.reference}"
+      maybeMove?.let { "$MOVES_URL/${it.moveId}" } ?: "$FIND_MOVE_URL/?no-results-for=${form.reference}"
     return "redirect:$uri"
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/SummaryPageController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/SummaryPageController.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.service.moves.MoveService
 import uk.gov.justice.digital.hmpps.pecs.jpc.util.MonthYearParser
 import uk.gov.justice.digital.hmpps.pecs.jpc.util.loggerFor
 import java.time.LocalDate
+import java.time.LocalDateTime
 import javax.validation.Valid
 
 /**
@@ -93,7 +94,7 @@ class SummaryPageController(
   @RequestMapping("$MOVES_BY_TYPE_URL/{moveTypeString}")
   fun movesByType(
     @PathVariable moveTypeString: String,
-    @ModelAttribute(name = DATE_ATTRIBUTE) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startOfMonth: LocalDate,
+    @ModelAttribute(name = START_OF_MONTH_DATE_ATTRIBUTE) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startOfMonth: LocalDate,
     @ModelAttribute(name = SUPPLIER_ATTRIBUTE) supplier: Supplier,
     model: ModelMap
   ): String {
@@ -132,9 +133,13 @@ class SummaryPageController(
 
     return maybeMove?.let {
       model.addAttribute(MOVE_ATTRIBUTE, maybeMove)
+      model.addAttribute(START_OF_MONTH_DATE_ATTRIBUTE, it.pickUpDateTime?.atStartOfMonthForBreadcrumbTrail())
+
       ModelAndView("move")
     } ?: ModelAndView("error/404", HttpStatus.NOT_FOUND)
   }
+
+  private fun LocalDateTime.atStartOfMonthForBreadcrumbTrail() = this.toLocalDate()?.withDayOfMonth(1)
 
   @RequestMapping(JOURNEYS_URL)
   fun journeys(
@@ -244,8 +249,10 @@ class SummaryPageController(
     if (!moveRef.matches("[A-Za-z0-9]+".toRegex())) return "redirect:$FIND_MOVE_URL/?no-results-for=invalid-reference"
 
     val maybeMove = moveService.findMoveByReferenceAndSupplier(moveRef, supplier)
+
     val uri =
       maybeMove?.let { "$MOVES_URL/${it.moveId}" } ?: "$FIND_MOVE_URL/?no-results-for=${form.reference}"
+
     return "redirect:$uri"
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/move/MoveRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/move/MoveRepository.kt
@@ -2,11 +2,10 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.domain.move
 
 import org.springframework.data.jpa.repository.JpaRepository
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Supplier
-import java.util.Optional
 
 interface MoveRepository : JpaRepository<Move, String> {
 
   fun findAllByMoveIdIn(ids: List<String>): List<Move>
 
-  fun findByReferenceAndSupplier(ref: String, supplier: Supplier): Optional<Move>
+  fun findByReferenceAndSupplier(ref: String, supplier: Supplier): Move?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/moves/MoveService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/moves/MoveService.kt
@@ -38,8 +38,7 @@ class MoveService(
     moveQueryRepository.movesWithMoveTypeInDateRange(supplier, startDate, endOfMonth(startDate))
 
   fun findMoveByReferenceAndSupplier(ref: String, supplier: Supplier) =
-    // At time of writing the need for filtering null moves types is a result of poor supplier data.
-    moveRepository.findByReferenceAndSupplier(ref, supplier).filter { it.moveType != null }
+    moveRepository.findByReferenceAndSupplier(ref, supplier)?.takeIf { it.moveType != null }
 
   fun movesForMoveType(supplier: Supplier, moveType: MoveType, startDate: LocalDate) =
     moveQueryRepository.movesForMoveTypeInDateRange(supplier, moveType, startDate, endOfMonth(startDate))

--- a/src/main/resources/templates/move.html
+++ b/src/main/resources/templates/move.html
@@ -14,7 +14,7 @@
     <div class="govuk-breadcrumbs ">
         <ol class="govuk-breadcrumbs__list">
             <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-breadcrumbs__link" href="/dashboard" th:inline="text">[[${#temporals.monthName(startOfMonthDate)}]]
+                <a class="govuk-breadcrumbs__link" th:href="@{/dashboard(date=${#temporals.format(startOfMonthDate, 'yyyy-MM-dd')})}" th:inline="text">[[${#temporals.monthName(startOfMonthDate)}]]
                     [[${#temporals.format(startOfMonthDate, 'yyyy')}]]</a>
             </li>
             <li class="govuk-breadcrumbs__list-item">

--- a/src/main/resources/templates/moves-by-type.html
+++ b/src/main/resources/templates/moves-by-type.html
@@ -14,7 +14,7 @@
     <div class="govuk-breadcrumbs ">
         <ol class="govuk-breadcrumbs__list">
             <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-breadcrumbs__link" href="/dashboard" th:inline="text">[[${#temporals.monthName(startOfMonthDate)}]]
+                <a class="govuk-breadcrumbs__link" th:href="@{/dashboard(date=${#temporals.format(startOfMonthDate, 'yyyy-MM-dd')})}" th:inline="text">[[${#temporals.monthName(startOfMonthDate)}]]
                     [[${#temporals.format(startOfMonthDate, 'yyyy')}]] move summary</a>
             </li>
             <li class="govuk-breadcrumbs__list-item">

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/SummaryPageControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/controller/SummaryPageControllerTest.kt
@@ -30,7 +30,6 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.service.reports.defaultSupplierSerc
 import java.time.Duration
 import java.time.LocalDate
 import java.time.Month
-import java.util.Optional
 import javax.servlet.http.Cookie
 
 @SpringBootTest
@@ -138,7 +137,7 @@ class SummaryPageControllerTest(@Autowired private val wac: WebApplicationContex
   @Test
   internal fun `find a move by valid lowercase reference id with whitespace correctly redirects to move details page`() {
 
-    whenever(moveService.findMoveByReferenceAndSupplier("REF1", defaultSupplierSerco)).thenReturn(Optional.of(moveM1()))
+    whenever(moveService.findMoveByReferenceAndSupplier("REF1", defaultSupplierSerco)).thenReturn(moveM1())
 
     mockMvc.post("/find-move") {
       session = mockSession
@@ -153,7 +152,7 @@ class SummaryPageControllerTest(@Autowired private val wac: WebApplicationContex
   @Test
   internal fun `find a move by a non-existent reference id calls the move service then redirects to search form`() {
 
-    whenever(moveService.findMoveByReferenceAndSupplier("REF1", defaultSupplierSerco)).thenReturn(Optional.of(moveM1()))
+    whenever(moveService.findMoveByReferenceAndSupplier("REF1", defaultSupplierSerco)).thenReturn(moveM1())
 
     mockMvc.post("/find-move") {
       session = mockSession
@@ -168,7 +167,7 @@ class SummaryPageControllerTest(@Autowired private val wac: WebApplicationContex
   @Test
   internal fun `find a move by invalid reference id redirects to search form without calling the move service`() {
 
-    whenever(moveService.findMoveByReferenceAndSupplier("REF1", defaultSupplierSerco)).thenReturn(Optional.of(moveM1()))
+    whenever(moveService.findMoveByReferenceAndSupplier("REF1", defaultSupplierSerco)).thenReturn(moveM1())
 
     mockMvc.post("/find-move") {
       session = mockSession
@@ -183,7 +182,7 @@ class SummaryPageControllerTest(@Autowired private val wac: WebApplicationContex
   @Test
   internal fun `find a move by move not found redirects to search form without calling the move service`() {
 
-    whenever(moveService.findMoveByReferenceAndSupplier("REF1", defaultSupplierSerco)).thenReturn(Optional.empty())
+    whenever(moveService.findMoveByReferenceAndSupplier("REF1", defaultSupplierSerco)).thenReturn(null)
 
     mockMvc.post("/find-move") {
       session = mockSession

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/move/TestMoveFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/move/TestMoveFactory.kt
@@ -39,7 +39,8 @@ fun moveM1(
   toNomisAgencyId: String = "GNI",
   dropOffOrCancelledDateTime: LocalDateTime = defaultMoveDate10Sep2020.atStartOfDay().plusHours(10),
   person: Person? = personPE1(),
-  journeys: List<Journey> = listOf()
+  journeys: List<Journey> = listOf(),
+  moveDate: LocalDate = defaultMoveDate10Sep2020
 ) = Move(
   moveId = moveId,
   profileId = "PR1",
@@ -48,14 +49,14 @@ fun moveM1(
   moveType = MoveType.STANDARD,
   status = MoveStatus.completed,
   reference = "REF1",
-  moveDate = defaultMoveDate10Sep2020,
+  moveDate = moveDate,
   fromNomisAgencyId = fromNomisAgencyId,
   fromSiteName = "from",
   fromLocationType = LocationType.PR,
   toNomisAgencyId = toNomisAgencyId,
   toSiteName = "to",
   toLocationType = LocationType.PR,
-  pickUpDateTime = defaultMoveDate10Sep2020.atStartOfDay(),
+  pickUpDateTime = moveDate.atStartOfDay(),
   dropOffOrCancelledDateTime = dropOffOrCancelledDateTime,
   reportFromLocationType = "prison",
   reportToLocationType = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/moves/MoveServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/moves/MoveServiceTest.kt
@@ -15,7 +15,6 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.domain.move.journeyJ1
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.move.moveM1
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.reports.defaultSupplierSerco
 import java.time.Month
-import java.util.Optional
 
 internal class MoveServiceTest {
 
@@ -117,17 +116,17 @@ internal class MoveServiceTest {
   fun `find move by move reference`() {
     val move = moveM1()
 
-    whenever(moveRepository.findByReferenceAndSupplier("REF1", defaultSupplierSerco)).thenReturn(Optional.of(move))
+    whenever(moveRepository.findByReferenceAndSupplier("REF1", defaultSupplierSerco)).thenReturn(move)
 
-    assertThat(service.findMoveByReferenceAndSupplier("REF1", defaultSupplierSerco)).hasValue(move)
+    assertThat(service.findMoveByReferenceAndSupplier("REF1", defaultSupplierSerco)).isEqualTo(move)
   }
 
   @Test
   fun `find move by move reference not found when move has no move type`() {
     val move = moveM1().copy(moveType = null)
 
-    whenever(moveRepository.findByReferenceAndSupplier("REF1", defaultSupplierSerco)).thenReturn(Optional.of(move))
+    whenever(moveRepository.findByReferenceAndSupplier("REF1", defaultSupplierSerco)).thenReturn(move)
 
-    assertThat(service.findMoveByReferenceAndSupplier("REF1", defaultSupplierSerco)).isNotPresent
+    assertThat(service.findMoveByReferenceAndSupplier("REF1", defaultSupplierSerco)).isNull()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/reports/ImportServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/reports/ImportServiceIntegrationTest.kt
@@ -92,7 +92,7 @@ class ImportServiceIntegrationTest(
     assertThat(createdJourneys).hasSize(13)
 
     val importedDecemberMoves = geoMovesDec2020()
-      .map { moveRepository.findByReferenceAndSupplier(it.moveRef, it.supplier).orElseThrow() to it.moveType }.toList()
+      .map { moveRepository.findByReferenceAndSupplier(it.moveRef, it.supplier)!! to it.moveType }.toList()
 
     assertThat(importedDecemberMoves).hasSize(9)
     assertMovesHaveExpectedMoveTypeOrNull(importedDecemberMoves)


### PR DESCRIPTION
The main dashboard page provides the ability to search for moves by their reference number.

The breadcrumb trail was displaying incorrectly after searching for a move that was not in the same month as the currently chosen month on the dashboard view. It showed the month chosen on the dashboard and not that of the move.

Additional changes have also been made to the move type link in the breadcrumbs as this also would not have gone to the correct month/year.

**Breadcrumb trail before (notice the move start date is Dec 1st 2020 and not in April 2022):**

![image](https://user-images.githubusercontent.com/60104344/165726918-a605665f-0448-4ed5-a1b2-7a2faef4a327.png)

**Breadcrumb trail after:**

![image](https://user-images.githubusercontent.com/60104344/165727009-a0afb049-6c8d-4663-9d15-406e6a94061a.png)
