### PR TITLE
P4-3738 this is a short term fix to resolved the health check endpoints of the service, calls are being redirected to the choose supplier URL

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/filters/ChooseSupplierFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/filters/ChooseSupplierFilter.kt
@@ -16,6 +16,10 @@ private val log = loggerFor<ChooseSupplierFilter>()
 class ChooseSupplierFilter : OncePerRequestFilter() {
 
   private val allowedLinks = arrayOf(
+    "/health",
+    "/health/liveness",
+    "/health/readiness",
+    "/info",
     CHOOSE_SUPPLIER_URL,
     "$CHOOSE_SUPPLIER_URL/geoamey",
     "$CHOOSE_SUPPLIER_URL/serco",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/filters/ChooseSupplierFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/filters/ChooseSupplierFilterTest.kt
@@ -51,6 +51,10 @@ internal class ChooseSupplierFilterTest {
       "image.png",
       "icon.ico",
       "javascript.js",
+      "/health",
+      "/health/liveness",
+      "/health/readiness",
+      "/info",
     ]
   )
   internal fun `filter does not redirect to choose supplier when no supplier selected for excluded URIs`(uri: String) {


### PR DESCRIPTION
I noticed when looking at the logs calls to the health endpoints are being redirected to the choose supplier URL.  I think primarily this has not been noticed as we don't have any type of pingdom set up for the service.