### PR TITLE
P4-3722 resolves an issue where by was not starting at the correct date when resuming from a failed report ingress.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/tasks/ImportReportsDataTask.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/tasks/ImportReportsDataTask.kt
@@ -18,10 +18,10 @@ class ImportReportsDataTask(
   override fun performTask() {
     timeSource.yesterday().run {
       if (backDateEnabled) {
-        val importDate = service.dateOfLastImport()?.plusDays(1) ?: this
+        val startDate = service.dateOfLastImport() ?: this
 
-        if (importDate.isBefore(this)) {
-          backdateReportsFrom(importDate)
+        if (startDate.isBefore(this)) {
+          backdateReportsFrom(startDate)
 
           return
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/tasks/ImportReportsDataTaskTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/tasks/ImportReportsDataTaskTest.kt
@@ -6,6 +6,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.MonitoringService
@@ -28,8 +29,10 @@ class ImportReportsDataTaskTest {
     ImportReportsDataTask(true, importReportsService, timeSource, monitoringService).execute()
 
     verify(importReportsService).dateOfLastImport()
+    verify(importReportsService).importAllReportsOn(LocalDate.of(2022, 6, 12))
     verify(importReportsService).importAllReportsOn(LocalDate.of(2022, 6, 13))
     verify(importReportsService).importAllReportsOn(LocalDate.of(2022, 6, 14))
+    verifyNoMoreInteractions(importReportsService)
     verifyNoInteractions(monitoringService)
   }
 


### PR DESCRIPTION
Testing in development highlighted a gap in the auto recovery from a failed ingress. Missing import on date 2022-06-18.

![image](https://user-images.githubusercontent.com/60104344/174803292-a8f072df-3ce0-467b-a0f3-a2f5b0af17d9.png)

