### PR TITLE
P4-3764 initial commit to add the daily imports runner and associated profile which will be used by the k8 job.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/CommandRunner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/CommandRunner.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.cli
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.boot.autoconfigure.condition.ConditionalOnNotWebApplication
+import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Supplier
 import uk.gov.justice.digital.hmpps.pecs.jpc.util.loggerFor
@@ -15,6 +16,7 @@ import java.time.LocalDate
 private val logger = loggerFor<CommandRunner>()
 
 @ConditionalOnNotWebApplication
+@Profile("!daily-reports")
 @Component
 class CommandRunner(
   private val bulkPriceImportCommand: BulkPriceImportCommand,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/DailyReportsImporterRunner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/DailyReportsImporterRunner.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.cli
+
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.boot.autoconfigure.condition.ConditionalOnNotWebApplication
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.reports.ImportReportsService
+
+@ConditionalOnNotWebApplication
+@Component
+@Profile("daily-reports")
+class DailyReportsImporterRunner(
+  private val service: ImportReportsService,
+  private val timeSource: TimeSource,
+) : ApplicationRunner {
+
+  override fun run(arguments: ApplicationArguments) {
+    timeSource.yesterday().run {
+      service.importAllReportsOn(this)
+    }
+  }
+}

--- a/src/main/resources/application-daily-reports.yml
+++ b/src/main/resources/application-daily-reports.yml
@@ -1,0 +1,3 @@
+spring:
+  main:
+    web-application-type: none


### PR DESCRIPTION
Prep work to for the upcoming k8 job so can run the daily reports import upon starting the container based application which will get pulled down as part of the job.

Essentially what we are going to end up with is this in the job:

`java -jar app.jar --spring.profiles.active=daily-reports`