### PR TITLE
Update to latest version of DPS gradle spring boot and aws-java-sdk-s3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.3.2"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.3.3"
   kotlin("plugin.spring") version "1.6.21"
   kotlin("plugin.jpa") version "1.6.21"
   kotlin("plugin.allopen") version "1.6.21"
@@ -17,7 +17,7 @@ dependencyCheck {
 
 dependencies {
   implementation("com.beust:klaxon:5.6")
-  implementation("com.amazonaws:aws-java-sdk-s3:1.12.252")
+  implementation("com.amazonaws:aws-java-sdk-s3:1.12.266")
   implementation("io.sentry:sentry-spring-boot-starter:6.1.4")
   implementation("net.javacrumbs.shedlock:shedlock-spring:4.37.0")
   implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.37.0")


### PR DESCRIPTION
After running `./gradlew dependencyCheckAnalyze` to see a report of the OWASP security check, it was failing and produced an error around `aws-java-sdk-s3-1.12.252.jar (pkg:maven/com.amazonaws/aws-java-sdk-s3@1.12.252) : CVE-2022-31159` so I upgraded this version from `1.12.252 ` to `1.12.266` to silence the error. In addition I upgraded DPS gradle spring boot from `4.3.2` to `4.3.3`


The steps used for this ticket:

```
// This will report if the OWASP security check is failing (which it should be)
$ ./gradlew dependencyCheckAnalyze

// This will give you some of idea of what 3rd party libraries can be updated
$ ./gradlew dependencyUpdates

// This should be run after updating 3rd party libraries to see if security warnings go away.
$ ./gradlew dependencyCheckAnalyze

// This will run the unit tests.
$ ./gradlew clean build
```