### PR TITLE
P4-3764 disable application task for testing of k8 replacemet task/job in preprod and add support for back dating reports.

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -31,7 +31,7 @@ env:
   HMPPS_AUTH_BASE_URI: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
   HMPPS_AUTH_REDIRECT_BASE_URI: "https://calculate-journey-variable-payments-preprod.apps.live-1.cloud-platform.service.justice.gov.uk"
   CRON_AUTOMATIC_LOCATION_MAPPING: "0 30 3 * * ?"
-  CRON_IMPORT_REPORTS: "0 30 5 * * ?"
+  CRON_IMPORT_REPORTS: "-"
   CRON_BACKFILL_REPORTS: "-"
   CRON_REPROCESS_EXISTING_MOVES: "-"
   SENTRY_ENVIRONMENT: preprod

--- a/k8_jobs/import-reports.yaml
+++ b/k8_jobs/import-reports.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: calculate-journey-variable-payments-placeholder
 spec:
   concurrencyPolicy: Forbid
-  schedule: "0 9 * * *" # daily at 9:00 am
+  schedule: "3 6 * * *" # daily at 6:30 am UTC
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 2
   jobTemplate:
@@ -127,7 +127,7 @@ spec:
                 - name: FEATURE_FLAG_INCLUDE_RECONCILIATION_MOVES
                   value: "false"
                 - name: IMPORT_REPORTS_BACKDATE_ENABLED
-                  value: "false"
+                  value: "true"
                 - name: IMPORT_FILES_PRICES_GEO
                   value: "we_dont_care"
                 - name: IMPORT_FILES_PRICES_SERCO

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/DailyReportsImporterRunner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/DailyReportsImporterRunner.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.cli
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.boot.autoconfigure.condition.ConditionalOnNotWebApplication
@@ -7,6 +8,7 @@ import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
 import uk.gov.justice.digital.hmpps.pecs.jpc.service.reports.ImportReportsService
+import java.time.LocalDate
 
 /**
  * When the application is started in non-web mode and the 'daily-reports' profile is used this runner will execute and
@@ -16,13 +18,28 @@ import uk.gov.justice.digital.hmpps.pecs.jpc.service.reports.ImportReportsServic
 @Component
 @Profile("daily-reports")
 class DailyReportsImporterRunner(
+  @Value("\${IMPORT_REPORTS_BACKDATE_ENABLED}") private val backDateEnabled: Boolean = false,
   private val service: ImportReportsService,
   private val timeSource: TimeSource,
 ) : ApplicationRunner {
 
   override fun run(arguments: ApplicationArguments) {
     timeSource.yesterday().run {
+      if (backDateEnabled) {
+        val startDate = service.dateOfLastImport() ?: this
+
+        if (startDate.isBefore(this)) {
+          backdateReportsFrom(startDate)
+
+          return
+        }
+      }
+
       service.importAllReportsOn(this)
     }
+  }
+
+  private fun backdateReportsFrom(from: LocalDate) {
+    from.datesUntil(timeSource.date()).forEach { service.importAllReportsOn(it) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/DailyReportsImporterRunnerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/cli/DailyReportsImporterRunnerTest.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.cli
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import org.springframework.boot.ApplicationArguments
+import uk.gov.justice.digital.hmpps.pecs.jpc.config.TimeSource
+import uk.gov.justice.digital.hmpps.pecs.jpc.service.reports.ImportReportsService
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class DailyReportsImporterRunnerTest {
+
+  private val importReportsService: ImportReportsService = mock()
+  private val timeSource: TimeSource = TimeSource { LocalDateTime.of(2022, 6, 15, 0, 0) }
+  private val arguments: ApplicationArguments = mock()
+
+  @Test
+  fun `move data is backdated when backdating enabled`() {
+    whenever(importReportsService.dateOfLastImport()).thenReturn(LocalDate.of(2022, 6, 12))
+
+    DailyReportsImporterRunner(true, importReportsService, timeSource).run(arguments)
+
+    verify(importReportsService).dateOfLastImport()
+    verify(importReportsService).importAllReportsOn(LocalDate.of(2022, 6, 12))
+    verify(importReportsService).importAllReportsOn(LocalDate.of(2022, 6, 13))
+    verify(importReportsService).importAllReportsOn(LocalDate.of(2022, 6, 14))
+    verifyNoMoreInteractions(importReportsService)
+  }
+
+  @Test
+  fun `move data is imported for yesterday only when backdating is disabled`() {
+    DailyReportsImporterRunner(false, importReportsService, timeSource).run(arguments)
+
+    verify(importReportsService, never()).dateOfLastImport()
+    verify(importReportsService).importAllReportsOn(timeSource.yesterday())
+  }
+}


### PR DESCRIPTION
The daily importer has been updated to support back filling should the need arise.

This change also now disables the old way the import is run on preprod as the intent is to now move to the k8 cron job instead.