### PR TITLE
P4-3764 only audit reports import if move, people and profiles imported without error. This indicates a successful import.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/auditing/AuditableEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/auditing/AuditableEvent.kt
@@ -151,15 +151,25 @@ data class AuditableEvent(
     private fun authentication() = SecurityContextHolder.getContext().authentication
       ?: throw RuntimeException("Attempted to create audit event $AuditEventType.LOCATION without a user")
 
-    fun importReportEvent(type: String, reportDate: LocalDate, processed: Int, saved: Int) =
+    fun importReportsEvent(
+      reportDate: LocalDate,
+      moves_processed: Int,
+      moves_saved: Int,
+      people_processed: Int,
+      people_saved: Int,
+      profiles_processed: Int,
+      profiles_saved: Int,
+    ) =
       createEvent(
         type = AuditEventType.REPORTING_DATA_IMPORT,
         metadata = mapOf(
-          "type" to type,
           "report_date" to reportDate.toString(),
-          "processed" to processed,
-          "saved" to saved
-
+          "moves_processed" to moves_processed,
+          "moves_saved" to moves_saved,
+          "people_processed" to people_processed,
+          "people_saved" to people_saved,
+          "profiles_processed" to profiles_processed,
+          "profiles_saved" to profiles_saved,
         ),
         allowNoUser = true
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AuditServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/AuditServiceTest.kt
@@ -342,12 +342,30 @@ internal class AuditServiceTest {
 
   @Test
   internal fun `create import reports audit event`() {
-    service.create(AuditableEvent.importReportEvent("moves", LocalDate.of(2021, 2, 22), 20, 10))
+    service.create(
+      AuditableEvent.importReportsEvent(
+        LocalDate.of(2021, 2, 22),
+        20,
+        10,
+        people_processed = 5,
+        people_saved = 5,
+        profiles_processed = 5,
+        profiles_saved = 4
+      )
+    )
 
     verifyEvent(
       AuditEventType.REPORTING_DATA_IMPORT,
       "_TERMINAL_",
-      mapOf("type" to "moves", "report_date" to "2021-02-22", "processed" to 20, "saved" to 10)
+      mapOf(
+        "report_date" to "2021-02-22",
+        "moves_processed" to 20,
+        "moves_saved" to 10,
+        "people_processed" to 5,
+        "people_saved" to 5,
+        "profiles_processed" to 5,
+        "profiles_saved" to 4
+      )
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/reports/ImportReportServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/reports/ImportReportServiceTest.kt
@@ -66,9 +66,17 @@ internal class ImportReportServiceTest {
 
     service.importAllReportsOn(timeSourceWithFixedDate.yesterday())
 
-    verify(auditService).create(AuditableEvent.importReportEvent("moves", timeSourceWithFixedDate.yesterday(), 1, 1))
-    verify(auditService).create(AuditableEvent.importReportEvent("people", timeSourceWithFixedDate.yesterday(), 1, 1))
-    verify(auditService).create(AuditableEvent.importReportEvent("profiles", timeSourceWithFixedDate.yesterday(), 1, 1))
+    verify(auditService).create(
+      AuditableEvent.importReportsEvent(
+        timeSourceWithFixedDate.yesterday(),
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      )
+    )
     verifyNoInteractions(monitoringService)
   }
 


### PR DESCRIPTION
This should help resolve a self repair issue whereby an import didn't work fully e.g. it only imported moves and people and not profiles. Previously the service regarded this as successful due to audit records existing for the moves and people imported. Now only one audit event for an import will only be created if all 3 are successfully imported so any attempts for the service to self repair will work from the date of the last successful audit entry.