### PR TITLE
P4-3865 fixing issue where audit events were not being created as part of the bulk price upload process.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/Price.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/domain/price/Price.kt
@@ -41,11 +41,11 @@ data class Price(
   @Enumerated(EnumType.STRING)
   val supplier: Supplier,
 
-  @ManyToOne(fetch = FetchType.LAZY)
+  @ManyToOne
   @JoinColumn(name = "from_location_id")
   val fromLocation: Location,
 
-  @ManyToOne(fetch = FetchType.LAZY)
+  @ManyToOne
   @JoinColumn(name = "to_location_id")
   val toLocation: Location,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/pricing/PriceImporter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/pricing/PriceImporter.kt
@@ -41,7 +41,7 @@ class PriceImporter(
     PricesSpreadsheet(
       XSSFWorkbook(prices),
       supplier,
-      locationRepository.findAll().toList(),
+      locationRepository.findAll(),
       priceRepo,
       effectiveYear
     ).use { import(it) }

--- a/src/main/resources/db/migration/dml/V1_21__backfill_price_audit_events.sql
+++ b/src/main/resources/db/migration/dml/V1_21__backfill_price_audit_events.sql
@@ -1,0 +1,18 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+insert into audit_events
+select uuid_generate_v4() event_id,
+       p.added_at created_at,
+       'JOURNEY_PRICE' event_type,
+       '{"supplier" : "' || p.supplier || '", "from_nomis_id" : "'|| lf.nomis_agency_id ||'", "to_nomis_id" : "'|| lt.nomis_agency_id ||'", "effective_year" : '|| p.effective_year ||', "new_price" : '|| cast(p.price_in_pence / 100.0 as decimal(15,2)) ||'}' metadata,
+       '_TERMINAL_' username,
+       p.supplier || '-' || lf.nomis_agency_id || '-' || lt.nomis_agency_id metadata_key
+  from prices p
+       left join locations lf on p.from_location_id = lf.location_id
+       left join locations lt on p.to_location_id = lt.location_id
+ where not exists (select 1
+                     from audit_events ae
+                    where jsonb_extract_path_text(ae.metadata::jsonb, 'supplier') = p.supplier
+                      and jsonb_extract_path_text(ae.metadata::jsonb, 'from_nomis_id') = lf.nomis_agency_id
+                      and jsonb_extract_path_text(ae.metadata::jsonb, 'to_nomis_id') = lt.nomis_agency_id
+                      and ae.event_type = 'JOURNEY_PRICE');

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/pricing/ImportPricesServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/service/pricing/ImportPricesServiceIntegrationTest.kt
@@ -1,0 +1,99 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.service.pricing
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.pecs.jpc.TestConfig
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.auditing.AuditEventRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.auditing.AuditEventType
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.location.Location
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.location.LocationRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.location.LocationType
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Money
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.PriceRepository
+import uk.gov.justice.digital.hmpps.pecs.jpc.domain.price.Supplier
+
+/**
+ * This test imports the Serco prices spreadsheet from the test resources folder which in turn is referenced in the TestConfig class.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ActiveProfiles("test")
+@ContextConfiguration(classes = [TestConfig::class])
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ImportPricesServiceIntegrationTest(
+  @Autowired private val locationRepository: LocationRepository,
+  @Autowired private val priceRepository: PriceRepository,
+  @Autowired private val auditEventRepository: AuditEventRepository,
+  @Autowired private val service: ImportPricesService,
+) {
+
+  private val prison = Location(
+    LocationType.PR,
+    "PRISON",
+    "HMP FRED"
+  )
+
+  private val court = Location(
+    LocationType.CC,
+    "COURT",
+    "FREDS COUNTY COURT"
+  )
+
+  @BeforeAll
+  fun `set up locations needed for journey price import`() {
+    locationRepository.saveAll(mutableListOf(prison, court))
+  }
+
+  @AfterEach
+  fun `clean up`() {
+    priceRepository.deleteAll()
+    auditEventRepository.deleteAll()
+  }
+
+  @Test
+  fun `Serco court to prison journey price imported and audit trail is created`() {
+    assertJourneyPriceImported(Supplier.SERCO, 2021, Expected("COURT", "PRISON", Money(600)))
+  }
+
+  @Test
+  fun `GEOAmey prison to court journey price imported and audit trail is created`() {
+    assertJourneyPriceImported(Supplier.GEOAMEY, 2020, Expected("PRISON", "COURT", Money(4300)))
+  }
+
+  private fun assertJourneyPriceImported(supplier: Supplier, year: Int, expected: Expected) {
+    assertThat(priceRepository.findAll()).isEmpty()
+    assertThat(auditEventRepository.findAll()).isEmpty()
+
+    service.importPricesFor(supplier, year)
+
+    val journeyPrices = priceRepository.findAll()
+
+    assertThat(journeyPrices).hasSize(1)
+
+    with(journeyPrices.first()) {
+      assertThat(supplier).isEqualTo(supplier)
+      assertThat(priceInPence).isEqualTo(expected.price.pence)
+      assertThat(effectiveYear).isEqualTo(year)
+      assertThat(fromLocation.nomisAgencyId).isEqualTo(expected.fromAgency)
+      assertThat(toLocation.nomisAgencyId).isEqualTo(expected.toAgency)
+    }
+
+    val auditEvents = auditEventRepository.findAll()
+
+    assertThat(auditEvents).hasSize(1)
+
+    with(auditEvents.first()) {
+      assertThat(eventType).isEqualTo(AuditEventType.JOURNEY_PRICE)
+      assertThat(metadataKey).isEqualTo("$supplier-${expected.fromAgency}-${expected.toAgency}")
+      assertThat(metadata).isEqualTo("""{"supplier" : "$supplier", "from_nomis_id" : "${expected.fromAgency}", "to_nomis_id" : "${expected.toAgency}", "effective_year" : $year, "new_price" : "${expected.price}", "exception_month" : null, "exception_deleted" : null}""")
+    }
+  }
+
+  private data class Expected(val fromAgency: String, val toAgency: String, val price: Money)
+}


### PR DESCRIPTION
Changes to fix an issue whereby audit records were not being created due to the lazy load of locations on price entities causing a runtime error.