### PR TITLE
MAPB-450: fix auth conflict by excluding HMppsResourceServerConfiguration

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: calculate-journey-variable-payments
+  autoconfigure:
+    exclude:
+      - uk.gov.justice.hmpps.kotlin.auth.HmppsResourceServerConfiguration
   jpa:
     show-sql: true
     generate-ddl: false


### PR DESCRIPTION
**Root Cause**

The Spring Boot upgrade (commit 8f2385c0) added hmpps-kotlin-spring-boot-starter:2.5.0 as a dependency. This library auto-configures HmppsResourceServerConfiguration, which:
Has @EnableWebSecurity + @EnableMethodSecurity — registering a second, conflicting security setup
Creates a hmppsSecurityFilterChain configured as a stateless JWT resource server (Bearer token based, SessionCreationPolicy.STATELESS)
Creates a JwtDecoder bean using the jwk-set-uri

This hmppsSecurityFilterChain conflicts directly with CJVP's own session-based OAuth2 browser login security chain. With the HMPPS resource server chain active:
The OAuth2 code callback (/login/oauth2/code/hmpps) gets intercepted by the stateless chain before the app's own chain can handle it
OR the authenticated session is rejected because the HMPPS chain expects a Bearer token, not a session cookie
Either way, the login flow fails and the user gets redirected to ssoLogoutUri() → https://sign-in-dev.hmpps.service.justice.gov.uk/auth/sign-out → which redirects to sign-in?signout.

**Fix**

Added uk.gov.justice.hmpps.kotlin.auth.HmppsResourceServerConfiguration to Spring Boot's autoconfigure.exclude list in application.yml. This is the correct approach because:
CJVP is a UI service (browser-based OAuth2 login + session cookies), not an API service (JWT Bearer tokens + stateless)
The HMPPS starter is still needed for health check utilities (HealthPingCheck, healthWebClient), and those are in separate auto-configuration classes that are NOT excluded
The app's own SecurityConfiguration handles all security correctly