### PR TITLE
MAPB-450: fix oauth2 login configuration

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/security/SecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/security/SecurityConfiguration.kt
@@ -86,7 +86,7 @@ class SecurityConfiguration<S : Session> {
       it.accessDeniedHandler(accessDeniedHandler())
     }
     .oauth2Login {
-      it.userInfoEndpoint { oAuth2UserService() }.failureUrl(ssoLogoutUri()).successHandler(logInHandler())
+      it.userInfoEndpoint { userInfoConfig -> userInfoConfig.userService(oAuth2UserService()) }.failureUrl(ssoLogoutUri()).successHandler(logInHandler())
     }
     .logout {
       it.logoutSuccessHandler(logOutHandler())


### PR DESCRIPTION
**Fix: Users being signed out after login in dev**
**Symptom:** 
After successfully authenticating at the HMPPS Auth server, users were immediately redirected to https://sign-in-dev.hmpps.service.justice.gov.uk/auth/sign-in?signout instead of landing in the app.

**Root cause:** 
The Spring Boot 4.0 / Spring Security 7.0 upgrade (via HMPPS Gradle plugin 10.x) removed the automatic detection of OAuth2UserService beans from the application context.

The existing code in SecurityConfiguration.kt was:
it.userInfoEndpoint { oAuth2UserService() }

This lambda calls oAuth2UserService() but discards the result — the UserInfoEndpointConfig was never actually configured with our custom service. This was accidentally working in Spring Security 6.x because it would fall back to scanning the application context for a single OAuth2UserService<OAuth2UserRequest, OAuth2User> bean. Spring Security 7.0 removed this fallback behaviour.

Without the custom service, Spring fell back to DefaultOAuth2UserService which:

Calls the /users/me endpoint to get user attributes
Derives authorities from OAuth2 scopes only (i.e. SCOPE_read)
Never sets ROLE_PECS_JPC on the user

Every authenticated user hit the accessDeniedHandler → redirect to auth sign-out