### PR TITLE
MAPB-450: fix oauth2 login configuration

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/security/SecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/security/SecurityConfiguration.kt
@@ -11,8 +11,12 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter
+import org.springframework.security.oauth2.core.endpoint.PkceParameterNames
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.security.oauth2.jwt.JwtDecoder
@@ -47,6 +51,9 @@ class SecurityConfiguration<S : Session> {
 
   @Autowired
   private lateinit var auditService: AuditService
+
+  @Autowired
+  private lateinit var clientRegistrationRepository: ClientRegistrationRepository
 
   @Bean
   fun jdbcHttpSessionCustomizer(): PostgreSqlJdbcHttpSessionCustomizer = PostgreSqlJdbcHttpSessionCustomizer()
@@ -86,7 +93,24 @@ class SecurityConfiguration<S : Session> {
       it.accessDeniedHandler(accessDeniedHandler())
     }
     .oauth2Login {
-      it.userInfoEndpoint { userInfoConfig -> userInfoConfig.userService(oAuth2UserService()) }.failureUrl(ssoLogoutUri()).successHandler(logInHandler())
+      it.authorizationEndpoint { authEndpoint ->
+        authEndpoint.authorizationRequestResolver(
+          DefaultOAuth2AuthorizationRequestResolver(
+            clientRegistrationRepository,
+            OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI,
+          ).also { resolver ->
+            resolver.setAuthorizationRequestCustomizer { builder ->
+              builder
+                .additionalParameters { params ->
+                  params.remove(PkceParameterNames.CODE_CHALLENGE)
+                  params.remove(PkceParameterNames.CODE_CHALLENGE_METHOD)
+                }
+                .attributes { attrs -> attrs.remove(PkceParameterNames.CODE_VERIFIER) }
+            }
+          },
+        )
+      }
+        .userInfoEndpoint { oAuth2UserService() }.failureUrl(ssoLogoutUri()).successHandler(logInHandler())
     }
     .logout {
       it.logoutSuccessHandler(logOutHandler())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,6 @@
 spring:
   application:
     name: calculate-journey-variable-payments
-  autoconfigure:
-    exclude:
-      - uk.gov.justice.hmpps.kotlin.auth.HmppsResourceServerConfiguration
   jpa:
     show-sql: true
     generate-ddl: false


### PR DESCRIPTION
**Summary**
The Spring Boot upgrade (HMPPS Gradle plugin 8.x → 10.x) brought in Spring Boot 4.0 / Spring Security 7.0, which introduced two breaking changes to the OAuth2 login flow:
 
**Breaking change 1:** 
PKCE now always enabled (root cause of sign-out)
Spring Security 7.0 unconditionally adds PKCE (code_challenge / code_verifier) to all authorization_code flows. HMPPS Auth rejects confidential clients using PKCE with invalid_client, causing the login to fail and redirect to sign-out.
**Fix:** 
Custom DefaultOAuth2AuthorizationRequestResolver in SecurityConfiguration.kt that strips the PKCE parameters from the authorization request after SS7 adds them.
 
**Breaking change 2:** 
autoconfigure: exclude (red herring, reverted)
An earlier attempt incorrectly excluded HmppsResourceServerConfiguration. This wasn't the root cause and has been removed.