### PR TITLE
MAPB-450: add flush mode to session management

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,7 @@ spring:
     store-type: jdbc
     jdbc:
       initialize-schema: never
+      flush-mode: immediate
     timeout: 20M
   security:
     oauth2:


### PR DESCRIPTION
Logging showed an authorization_request_not_found

Likely cause
This is a Spring Session JDBC flush timing race condition. Here's exactly what happens:
CJVP stores the OAuth2 authorization request (state) in session 9CC8DA15
CJVP sends Set-Cookie: SESSION=9CC8DA15 + redirect to auth before the SessionRepositoryFilter has committed session 9CC8DA15 to JDBC (default FlushMode.ON_SAVE saves after the response is sent)

The browser follows the redirect to auth immediately
Auth quickly redirects back to CJVP with SESSION=9CC8DA15 in the cookie
CJVP's Spring Session tries to load 9CC8DA15 from JDBC — but the write from step 2 hasn't completed yet → creates a brand new empty session

No authorization request in the session → authorization_request_not_found → sign-out

The fix is flush-mode: immediate — this forces the session to be written to JDBC as soon as attributes are set, before the redirect response is sent, eliminating the race: