### PR TITLE
MAPB-450: add EnableJdbcHttpSession

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/security/SecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/config/security/SecurityConfiguration.kt
@@ -23,9 +23,11 @@ import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.JwtDecoders
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.session.FlushMode
 import org.springframework.session.Session
 import org.springframework.session.config.SessionRepositoryCustomizer
 import org.springframework.session.jdbc.JdbcIndexedSessionRepository
+import org.springframework.session.jdbc.config.annotation.web.http.EnableJdbcHttpSession
 import org.thymeleaf.extras.springsecurity6.dialect.SpringSecurityDialect
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.auditing.LogInAuditHandler
 import uk.gov.justice.digital.hmpps.pecs.jpc.domain.auditing.LogOutAuditHandler
@@ -38,6 +40,7 @@ private val logger = loggerFor<SecurityConfiguration<*>>()
  * All OAuth2 and user session management is configured here.
  */
 @EnableWebSecurity
+@EnableJdbcHttpSession(maxInactiveIntervalInSeconds = 1200) // 20 minutes — Spring Boot 4.0 removed Spring Session auto-configuration
 @ConditionalOnWebApplication
 @EnableMethodSecurity
 @Configuration
@@ -60,6 +63,7 @@ class SecurityConfiguration<S : Session> {
 
   class PostgreSqlJdbcHttpSessionCustomizer : SessionRepositoryCustomizer<JdbcIndexedSessionRepository> {
     override fun customize(sessionRepository: JdbcIndexedSessionRepository) {
+      sessionRepository.setFlushMode(FlushMode.IMMEDIATE)
       sessionRepository.setCreateSessionAttributeQuery(CREATE_SESSION_ATTRIBUTE_QUERY)
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,12 +22,6 @@ spring:
       connection-timeout: 1000
       validation-timeout: 500
 
-  session:
-    store-type: jdbc
-    jdbc:
-      initialize-schema: never
-      flush-mode: immediate
-    timeout: 20M
   security:
     oauth2:
       resourceserver:


### PR DESCRIPTION
I've scaled the last one in dev to one pod and it works. So there is an issue with the session handling. USed co-pilot to investigate the issue. shown below

**Root cause found:** 
Spring Boot 4.0 removed Spring Session auto-configuration entirely
Spring Boot's spring-boot-autoconfigure-4.0.6.jar contains zero session-related classes. The spring.session.store-type: jdbc property that worked in Spring Boot 3.x is now completely ignored — there's no auto-configuration to read it. Sessions fell back to Tomcat's in-memory store. That's why spring_session has never had a single row — not today, not before the upgrade.

With 2 pods and no sticky sessions in the ingress, every time the OAuth2 callback hit a different pod than the one that stored the authorization request, the state was gone → authorization_request_not_found.

**What was changed**
SecurityConfiguration.kt — @EnableJdbcHttpSession(maxInactiveIntervalInSeconds = 1200) added:
This directly imports JdbcHttpSessionConfiguration, bypassing auto-configuration entirely
1200 seconds = 20 minutes, matching the previous spring.session.timeout: 20M
PostgreSqlJdbcHttpSessionCustomizer — FlushMode.IMMEDIATE added:
Sessions are now written to the DB the moment any attribute is set (including when the OAuth2 authorization request is stored), eliminating the write-before-redirect race condition
The existing PostgreSQL upsert query is still applied